### PR TITLE
Update URL for Kagami

### DIFF
--- a/OverlayPlugin.Core/resources/presets.json
+++ b/OverlayPlugin.Core/resources/presets.json
@@ -67,7 +67,7 @@
   },
   "Kagami": {
     "type": "MiniParse",
-    "url": "https://ramram1048.github.io/kagami/",
+    "url": "https://sgosiaco.github.io/kagami/",
     "size": [800, 400],
     "supports": ["modern"]
   },


### PR DESCRIPTION
Recreating this PR for this fork per the message on discord
Original PR: https://github.com/ngld/OverlayPlugin/pull/266

Original Message:
The original URL was for a fork that has since been deleted. The fork is removed and the old URL now returns a 404 error.
The proposed URL is for another fork which has been maintained by @sgosiaco, and has been generally recommended in the ACT_FFXIV Discord.