### PR TITLE
Update .NET framework for AddonExample

### DIFF
--- a/AddonExample/AddonExample.csproj
+++ b/AddonExample/AddonExample.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AddonExample</RootNamespace>
     <AssemblyName>AddonExample</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
Without this, AddonExample throws errors when building.

This is split from ngld/OverlayPlugin#235 to make it easier to land.

This is ngld/OverlayPlugin#257 against this fork.