### PR TITLE
Update OverlayPlugin to support newer ffxiv plugin versions

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -246,7 +246,10 @@ namespace RainbowMage.OverlayPlugin
         {
             var repo = GetRepository();
             if (repo == null)
-                return Language.Unknown;
+            {
+                // Defaults to English
+                return Language.English;
+            }
             return repo.GetSelectedLanguageID();
         }
 

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVProcess.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVProcess.cs
@@ -133,6 +133,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
               job == EntityJob.CUL;
         }
 
+        static internal string ToProperCase(string name)
+        {
+            System.Globalization.CultureInfo cultureInfo = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Globalization.TextInfo textInfo = cultureInfo.TextInfo;
+            return textInfo.ToTitleCase(name);
+        }
+
         [Serializable]
         public class EntityData
         {

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVProcessCn.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVProcessCn.cs
@@ -180,10 +180,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors {
 
         // dump '\0' string terminators
         var memoryName = System.Text.Encoding.UTF8.GetString(mem.Name, EntityMemory.nameBytes).Split(new[] { '\0' }, 2)[0];
-        var capitalizedName = FFXIV_ACT_Plugin.Common.StringHelper.ToProperCase(memoryName);
 
         EntityData entity = new EntityData() {
-          name = capitalizedName,
+          name = memoryName,
           id = mem.id,
           type = mem.type,
           distance = mem.distance,

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVProcessIntl.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVProcessIntl.cs
@@ -178,10 +178,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors {
 
         // dump '\0' string terminators
         var memoryName = System.Text.Encoding.UTF8.GetString(mem.Name, EntityMemory.nameBytes).Split(new[] { '\0' }, 2)[0];
-        var capitalizedName = FFXIV_ACT_Plugin.Common.StringHelper.ToProperCase(memoryName);
 
         EntityData entity = new EntityData() {
-          name = capitalizedName,
+          name = memoryName,
           id = mem.id,
           type = mem.type,
           distance = mem.distance,

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVProcessKo.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVProcessKo.cs
@@ -167,10 +167,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
 
         // dump '\0' string terminators
         var memoryName = System.Text.Encoding.UTF8.GetString(mem.Name, EntityMemory.nameBytes).Split(new[] { '\0' }, 2)[0];
-        var capitalizedName = FFXIV_ACT_Plugin.Common.StringHelper.ToProperCase(memoryName);
 
         EntityData entity = new EntityData() {
-          name = capitalizedName,
+          name = memoryName,
           id = mem.id,
           type = mem.type,
           distance = mem.distance,


### PR DESCRIPTION
Remove Language.Unknown and calls to ToProperCase.

Additionally, stop proper casing 6.x versions as the ffxiv plugin has
stopped proper casing names there.  This caused problems in cactbot
where names no longer matched, so doing it here as well for consistency.

Split from ngld/OverlayPlugin#235 to make this easier to land.
This is a copy of ngld/OverlayPlugin#258 applied to this fork.