### PR TITLE
Change updater to use zip file, only release zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         with:
           name: OverlayPlugin ${{ needs.validate_tag.outputs.version }}
           tag: v${{ needs.validate_tag.outputs.version }}
-          artifacts: out/OverlayPlugin-*.*
+          artifacts: out/OverlayPlugin-${{ needs.validate_tag.outputs.version }}.zip
           artifactContentType: application/zip
           draft: true
           generateReleaseNotes: true

--- a/OverlayPlugin.Updater/Updater.cs
+++ b/OverlayPlugin.Updater/Updater.cs
@@ -334,7 +334,8 @@ namespace RainbowMage.OverlayPlugin.Updater
                 currentVersion = Assembly.GetExecutingAssembly().GetName().Version,
                 checkInterval = TimeSpan.FromMinutes(5),
                 repo = "OverlayPlugin/OverlayPlugin",
-                downloadUrl = "https://github.com/{REPO}/releases/download/v{VERSION}/OverlayPlugin-{VERSION}.7z",
+                downloadUrl = "https://github.com/{REPO}/releases/download/v{VERSION}/OverlayPlugin-{VERSION}.zip",
+                strippedDirs = 1,
                 actPluginId = checkPreRelease ? 86 : 77,
             };
 


### PR DESCRIPTION
Currently, ACT get plugins uses the zip file (with 1 layer of folders)
and the OverlayPlugin updater uses the 7z file (with 0 extra layers).
ACT update is also very static, in that it always looks for the second
asset, which must be the zip file.  This is all a bit fragile.

To make this a little bit easier, change the updater to use the zip
file instead, and only release the zip file.  This requires stripping
an extra dir.  Verified by changing the version back in time and
using ngld/OverlayPlugin to update from the zip file properly.