### PR TITLE
Cleanup some build warnings

### DIFF
--- a/DEPS.py
+++ b/DEPS.py
@@ -4,7 +4,7 @@
 
 deps = {
     'ACT': {
-        'url': 'https://github.com/EQAditu/AdvancedCombatTracker/releases/download/3.4.7.268/ACTv3.zip',
+        'url': 'https://github.com/EQAditu/AdvancedCombatTracker/releases/download/3.4.9.271/ACTv3.zip',
         'dest': 'Thirdparty/ACT',
         'strip': 0,
         'hash': ['sha256', 'adf13a38d0938ce90f8e674f8365b227d933b91636ddf72b26c85702f6e3b808'],

--- a/OverlayPlugin.Common/Registry.cs
+++ b/OverlayPlugin.Common/Registry.cs
@@ -10,7 +10,6 @@ namespace RainbowMage.OverlayPlugin
         private List<Type> _overlays;
         private List<IEventSource> _eventSources;
         private List<Type> _esQueue;
-        private bool _esReady = false;
         private List<IOverlayPreset> _overlayPresets;
 
         public IEnumerable<Type> Overlays => _overlays;
@@ -28,7 +27,6 @@ namespace RainbowMage.OverlayPlugin
             _overlays = new List<Type>();
             _eventSources = new List<IEventSource>();
             _esQueue = new List<Type>();
-            _esReady = false;
             _overlayPresets = new List<IOverlayPreset>();
         }
 

--- a/OverlayPlugin.Core/Controls/NewOverlayDialog.cs
+++ b/OverlayPlugin.Core/Controls/NewOverlayDialog.cs
@@ -268,9 +268,12 @@ namespace RainbowMage.OverlayPlugin
         public bool Locked { get; set; }
         public List<string> Supports { get; set; }
 
+        // Suppress CS0649 since this is modified on deserialization
+        #pragma warning disable 0649
         [JsonExtensionData]
         [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "JsonExtensionData modifies this variable")]
         private IDictionary<string, JToken> _others;
+        #pragma warning restore 0649
 
         [OnDeserialized]
         public void ParseOthers(StreamingContext ctx)

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -516,6 +516,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                             name = c.Name,
                             worldId = c.WorldID,
                             job = c.Job,
+                            level = c.Level,
                             inParty = GetPartyType(c) == 1 /* Party */,
                         });
                     }

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -38,7 +38,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Advanced Combat Tracker, Version=3.1.5.246, Culture=neutral, PublicKeyToken=a946b61e93d97868, processorArchitecture=x86">
+    <Reference Include="Advanced Combat Tracker, Version=3.4.9.271, Culture=neutral, PublicKeyToken=a946b61e93d97868, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Thirdparty\ACT\Advanced Combat Tracker.exe</HintPath>
       <Private>False</Private>

--- a/OverlayPlugin/OverlayPlugin.csproj
+++ b/OverlayPlugin/OverlayPlugin.csproj
@@ -52,7 +52,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Advanced Combat Tracker, Version=3.1.5.246, Culture=neutral, PublicKeyToken=a946b61e93d97868, processorArchitecture=x86">
+    <Reference Include="Advanced Combat Tracker, Version=3.4.9.271, Culture=neutral, PublicKeyToken=a946b61e93d97868, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Thirdparty\ACT\Advanced Combat Tracker.exe</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
Just some build warning cleanup.

There's a few other overall issues:

1. FFXIV plugin deprecation:
```
\OverlayPlugin\OverlayPlugin.Core\MemoryProcessors\FFXIVMemory.cs(75,28): warning CS0618: 'FFXIVRepository.GetCurrentFFXIVProcess()' is obsolete: 'Subscribe to the ProcessChanged event instead (See RegisterProcessChangedHandler())'
\OverlayPlugin\OverlayPlugin.Core\MemoryProcessors\FFXIVMemory.cs(63,13): warning CS0162: Unreachable code detected
\OverlayPlugin\OverlayPlugin.Core\EventSources\CactbotEventSource.cs(761,13): warning CS0618: 'Registry.RegisterOverlayPreset(IOverlayPreset)' is obsolete: 'Please call RegisterOverlayPreset2() on the Registry object instead.'
\OverlayPlugin\OverlayPlugin.Core\EventSources\CactbotEventSource.cs(773,13): warning CS0618: 'Registry.RegisterOverlayPreset(IOverlayPreset)' is obsolete: 'Please call RegisterOverlayPreset2() on the Registry object instead.'
\OverlayPlugin\OverlayPlugin.Core\OverlayZCorrector.cs(38,27): warning CS0618: 'FFXIVRepository.GetCurrentFFXIVProcess()' is obsolete: 'Subscribe to the ProcessChanged event instead (See RegisterProcessChangedHandler())'
```
2. Cactbot code pulled into OverlayPlugin:
```
\OverlayPlugin\OverlayPlugin.Core\PluginMain.cs(426,21): warning CS0219: The variable 'foundCactbot' is assigned but its value is never used
```
3. This unused event:
```
\OverlayPlugin\OverlayPlugin.Core\OverlayBase.cs(29,49): warning CS0067: The event 'OverlayBase<TConfig>.OnLog' is never used
```

Resolution for the above:

1. I'll make a separate PR for this
2. Not sure exactly how we should handle this. Remove the previous effort entirely?
3. I'm not sure if this event is actually unused, could use a second opinion on if it's safe to remove this (and also the event listener being added in `PluginMain.cs:351`)