### PR TITLE
Switch ACT Plugin Id to be 86 only

### DIFF
--- a/OverlayPlugin.Updater/Updater.cs
+++ b/OverlayPlugin.Updater/Updater.cs
@@ -336,7 +336,7 @@ namespace RainbowMage.OverlayPlugin.Updater
                 repo = "OverlayPlugin/OverlayPlugin",
                 downloadUrl = "https://github.com/{REPO}/releases/download/v{VERSION}/OverlayPlugin-{VERSION}.zip",
                 strippedDirs = 1,
-                actPluginId = checkPreRelease ? 86 : 77,
+                actPluginId = 86,
             };
 
             await RunAutoUpdater(options, manualCheck);


### PR DESCRIPTION
Previously, OverlayPlugin supported two plugin ids,
77 for normal releases and 86 for preleases, accessible
by double clicking on the update button.

This logic should probably be cleaned up and removed but
this is a minimal patch to allow for a broader OverlayPlugin
release with minimal risk.

EQAditu suggested after some testing that the new OverlayPlugin
should use a different id to avoid some error cases.

If OverlayPlugin wants to handle prereleases in the future,
we can add this back in.