### PR TITLE
Add proof of concept repo func to write log line

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -1,0 +1,185 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace RainbowMage.OverlayPlugin
+{
+    class FFXIVCustomLogLines
+    {
+        private ILogger logger;
+        private FFXIVRepository repository;
+        private Dictionary<uint, ILogLineRegistryEntry> registry = new Dictionary<uint, ILogLineRegistryEntry>();
+
+        private const uint registeredCustomLogLineID = 256;
+
+        public FFXIVCustomLogLines(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            repository = container.Resolve<FFXIVRepository>();
+            var main = container.Resolve<PluginMain>();
+
+            var pluginDirectory = main.PluginDirectory;
+
+            var reservedLogLinesPath = Path.Combine(pluginDirectory, "resources", "reserved_log_lines.json");
+
+            try
+            {
+                var jsonData = File.ReadAllText(reservedLogLinesPath);
+                var reservedData = JsonConvert.DeserializeObject<List<ConfigReservedLogLine>>(jsonData);
+                logger.Log(LogLevel.Warning, $"Parsing {reservedData.Count} reserved log line entries.");   
+                foreach (var reservedDataEntry in reservedData)
+                {
+                    if (reservedDataEntry.Source == null || reservedDataEntry.Version == null)
+                    {
+                        logger.Log(LogLevel.Warning, $"Reserved log line entry missing Source or Version.");
+                        continue;
+                    }
+                    if (reservedDataEntry.ID == null)
+                    {
+                        if (reservedDataEntry.StartID == null || reservedDataEntry.EndID == null)
+                        {
+                            logger.Log(LogLevel.Warning, $"Reserved log line entry missing StartID ({reservedDataEntry.StartID}) or EndID ({reservedDataEntry.EndID}).");
+                            continue;
+                        }
+                        for (uint ID = reservedDataEntry.StartID.Value; ID < reservedDataEntry.EndID.Value; ++ID)
+                        {
+                            if (registry.ContainsKey(ID))
+                            {
+                                logger.Log(LogLevel.Warning, $"Reserved log line entry already registered ({ID}).");
+                                continue;
+                            }
+                            var Source = reservedDataEntry.Source;
+                            var Version = reservedDataEntry.Version.Value;
+                            logger.Log(LogLevel.Debug, $"Reserving log line entry for ID {ID}, Source {Source}, Version {Version}.");
+                            registry[ID] = new LogLineRegistryEntry()
+                            {
+                                ID = ID,
+                                Source = Source,
+                                Version = Version,
+                            };
+                        }
+                    }
+                    else
+                    {
+                        var ID = reservedDataEntry.ID.Value;
+                        if (registry.ContainsKey(ID))
+                        {
+                            logger.Log(LogLevel.Warning, $"Reserved log line entry already registered ({ID}).");
+                            continue;
+                        }
+                        var Source = reservedDataEntry.Source;
+                        var Version = reservedDataEntry.Version.Value;
+                        logger.Log(LogLevel.Debug, $"Reserving log line entry for ID {ID}, Source {Source}, Version {Version}.");
+                        registry[ID] = new LogLineRegistryEntry()
+                        {
+                            ID = ID,
+                            Source = Source,
+                            Version = Version,
+                        };
+                    }
+                }
+            } catch(Exception ex)
+            {
+                logger.Log(LogLevel.Error, string.Format(Resources.ErrorCouldNotLoadReservedLogLines, ex));
+            }
+        }
+
+        public Func<string, bool> RegisterCustomLogLine(ILogLineRegistryEntry entry)
+        {
+            // Don't allow any attempt to write a custom log line with FFXIV_ACT_Plugin as the source.
+            // This prevents a downstream plugin from attempting to register e.g. `00` lines by just pretending to be FFXIV_ACT_Plugin.
+            if (entry.Source == "FFXIV_ACT_Plugin")
+            {
+                logger.Log(LogLevel.Warning, $"Attempted to register custom log line with reserved source.");
+                return null;
+            }
+            var ID = entry.ID;
+            if (registry.ContainsKey(ID))
+            {
+                // Allow re-registering the handler if the ID, Source, and Version match.
+                // Implicitly don't allow re-registering the same handler if the Version changes to prevent log file confusion.
+                if (!registry[ID].Equals(entry))
+                {
+                    logger.Log(LogLevel.Warning, $"Reserved log line entry already registered ({ID}).");
+                    return null;
+                }
+            }
+            else
+            {
+                // Write out that a new log line has been registered. Prevent newlines in the string input for sanity.
+                var Source = entry.Source.Replace("\r", "\\r").Replace("\n", "\\n");
+                repository.WriteLogLineImpl(registeredCustomLogLineID, $"{ID}|{Source}|{entry.Version}");
+            }
+            registry.Add(ID, entry);
+            return (line) => {
+                if (line.Contains("\r") || line.Contains("\n"))
+                {
+                    logger.Log(LogLevel.Warning, $"Attempted to write custom log line with CR or LF with ID of {ID}");
+                    return false;
+                }
+                repository.WriteLogLineImpl(ID, line);
+                return true;
+            };
+        }
+    }
+
+    interface ILogLineRegistryEntry
+    {
+        uint ID { get; }
+        string Source { get; }
+        uint Version { get; }
+    }
+
+    class LogLineRegistryEntry : ILogLineRegistryEntry
+    {
+        public uint ID { get; set; }
+        public string Source { get; set; }
+        public uint Version { get; set; }
+
+        public override string ToString()
+        {
+            return Source + "|" + ID;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            var otherEntry = (ILogLineRegistryEntry)obj;
+
+            return ID == otherEntry.ID && Source == otherEntry.Source && Version == otherEntry.Version;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            hash = hash * 31 + ID.GetHashCode();
+            hash = hash * 31 + Source.GetHashCode();
+            hash = hash * 31 + Version.GetHashCode();
+            return hash;
+        }
+    }
+
+    internal interface IConfigReservedLogLine
+    {
+        uint? ID { get; }
+        uint? StartID { get; }
+        uint? EndID { get; }
+        string Source { get; }
+        uint? Version { get; }
+    }
+
+    [JsonObject(NamingStrategyType = typeof(Newtonsoft.Json.Serialization.DefaultNamingStrategy))]
+    internal class ConfigReservedLogLine : IConfigReservedLogLine
+    {
+        public uint? ID { get; set; }
+        public uint? StartID { get; set; }
+        public uint? EndID { get; set; }
+        public string Source { get; set; }
+        public uint? Version { get; set; }
+    }
+}

--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -105,13 +105,10 @@ namespace RainbowMage.OverlayPlugin
                     return null;
                 }
             }
-            else
-            {
-                // Write out that a new log line has been registered. Prevent newlines in the string input for sanity.
-                var Source = entry.Source.Replace("\r", "\\r").Replace("\n", "\\n");
-                repository.WriteLogLineImpl(registeredCustomLogLineID, $"{ID}|{Source}|{entry.Version}");
-            }
-            registry.Add(ID, entry);
+            // Write out that a new log line has been registered. Prevent newlines in the string input for sanity.
+            var Source = entry.Source.Replace("\r", "\\r").Replace("\n", "\\n");
+            repository.WriteLogLineImpl(registeredCustomLogLineID, $"{ID}|{Source}|{entry.Version}");
+            registry[ID] = entry;
             return (line) => {
                 if (line.Contains("\r") || line.Contains("\n"))
                 {
@@ -139,7 +136,7 @@ namespace RainbowMage.OverlayPlugin
 
         public override string ToString()
         {
-            return Source + "|" + ID;
+            return Source + "|" + ID + "|" + Version;
         }
 
         public override bool Equals(object obj)

--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -42,16 +42,18 @@ namespace RainbowMage.OverlayPlugin
                             logger.Log(LogLevel.Warning, $"Reserved log line entry missing StartID ({reservedDataEntry.StartID}) or EndID ({reservedDataEntry.EndID}).");
                             continue;
                         }
-                        for (uint ID = reservedDataEntry.StartID.Value; ID < reservedDataEntry.EndID.Value; ++ID)
+                        var Source = reservedDataEntry.Source;
+                        var Version = reservedDataEntry.Version.Value;
+                        var StartID = reservedDataEntry.StartID.Value;
+                        var EndID = reservedDataEntry.EndID.Value;
+                        logger.Log(LogLevel.Debug, $"Reserving log line entries {StartID}-{EndID} for Source {Source}, Version {Version}.");
+                        for (uint ID = StartID; ID < EndID; ++ID)
                         {
                             if (registry.ContainsKey(ID))
                             {
-                                logger.Log(LogLevel.Warning, $"Reserved log line entry already registered ({ID}).");
+                                logger.Log(LogLevel.Error, $"Reserved log line entry already registered ({ID}).");
                                 continue;
                             }
-                            var Source = reservedDataEntry.Source;
-                            var Version = reservedDataEntry.Version.Value;
-                            logger.Log(LogLevel.Debug, $"Reserving log line entry for ID {ID}, Source {Source}, Version {Version}.");
                             registry[ID] = new LogLineRegistryEntry()
                             {
                                 ID = ID,
@@ -65,7 +67,7 @@ namespace RainbowMage.OverlayPlugin
                         var ID = reservedDataEntry.ID.Value;
                         if (registry.ContainsKey(ID))
                         {
-                            logger.Log(LogLevel.Warning, $"Reserved log line entry already registered ({ID}).");
+                            logger.Log(LogLevel.Error, $"Reserved log line entry already registered ({ID}).");
                             continue;
                         }
                         var Source = reservedDataEntry.Source;
@@ -97,7 +99,7 @@ namespace RainbowMage.OverlayPlugin
             var ID = entry.ID;
             if (registry.ContainsKey(ID))
             {
-                // Allow re-registering the handler if the ID, Source, and Version match.
+                // Allow re-registering the handler if the ID and Source match.
                 // Implicitly don't allow re-registering the same handler if the Version changes to prevent log file confusion.
                 if (!registry[ID].Equals(entry))
                 {
@@ -148,7 +150,7 @@ namespace RainbowMage.OverlayPlugin
 
             var otherEntry = (ILogLineRegistryEntry)obj;
 
-            return ID == otherEntry.ID && Source == otherEntry.Source && Version == otherEntry.Version;
+            return ID == otherEntry.ID && Source == otherEntry.Source;
         }
 
         public override int GetHashCode()
@@ -156,7 +158,6 @@ namespace RainbowMage.OverlayPlugin
             int hash = 17;
             hash = hash * 31 + ID.GetHashCode();
             hash = hash * 31 + Source.GetHashCode();
-            hash = hash * 31 + Version.GetHashCode();
             return hash;
         }
     }

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Advanced_Combat_Tracker;
 using FFXIV_ACT_Plugin.Common;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace RainbowMage.OverlayPlugin
 {
@@ -295,6 +296,19 @@ namespace RainbowMage.OverlayPlugin
                 default:
                     return null;
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public bool WriteLogLineImpl(string line)
+        {
+            var plugin = GetPluginData();
+            if (plugin == null) return false;
+            var iocContainer = plugin.GetType().GetField("_iocContainer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(plugin);
+            var getServiceMethod = iocContainer.GetType().GetMethod("GetService");
+            var logOutput = getServiceMethod.Invoke(iocContainer, new object[] { typeof(FFXIV_ACT_Plugin.Logfile.ILogOutput) }) as FFXIV_ACT_Plugin.Logfile.ILogOutput;
+            logOutput.WriteLine((FFXIV_ACT_Plugin.Logfile.LogMessageType)111, DateTime.Now, line);
+
+            return true;
         }
 
         // LogLineDelegate(uint EventType, uint Seconds, string logline);

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -299,14 +299,14 @@ namespace RainbowMage.OverlayPlugin
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public bool WriteLogLineImpl(string line)
+        internal bool WriteLogLineImpl(uint ID, string line)
         {
             var plugin = GetPluginData();
             if (plugin == null) return false;
             var iocContainer = plugin.GetType().GetField("_iocContainer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(plugin);
             var getServiceMethod = iocContainer.GetType().GetMethod("GetService");
             var logOutput = getServiceMethod.Invoke(iocContainer, new object[] { typeof(FFXIV_ACT_Plugin.Logfile.ILogOutput) }) as FFXIV_ACT_Plugin.Logfile.ILogOutput;
-            logOutput.WriteLine((FFXIV_ACT_Plugin.Logfile.LogMessageType)111, DateTime.Now, line);
+            logOutput.WriteLine((FFXIV_ACT_Plugin.Logfile.LogMessageType)ID, DateTime.Now, line);
 
             return true;
         }

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -303,7 +303,7 @@ namespace RainbowMage.OverlayPlugin
         {
             var plugin = GetPluginData();
             if (plugin == null) return false;
-            var iocContainer = plugin.GetType().GetField("_iocContainer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(plugin);
+            var iocContainer = plugin.pluginObj.GetType().GetField("_iocContainer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(plugin.pluginObj);
             var getServiceMethod = iocContainer.GetType().GetMethod("GetService");
             var logOutput = getServiceMethod.Invoke(iocContainer, new object[] { typeof(FFXIV_ACT_Plugin.Logfile.ILogOutput) }) as FFXIV_ACT_Plugin.Logfile.ILogOutput;
             logOutput.WriteLine((FFXIV_ACT_Plugin.Logfile.LogMessageType)ID, DateTime.Now, line);

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -47,6 +47,10 @@
       <HintPath>..\Thirdparty\FFXIV_ACT_Plugin\SDK\FFXIV_ACT_Plugin.Common.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="FFXIV_ACT_Plugin.Common">
+      <HintPath>..\Thirdparty\FFXIV_ACT_Plugin\SDK\FFXIV_ACT_Plugin.Logfile.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -47,10 +47,6 @@
       <HintPath>..\Thirdparty\FFXIV_ACT_Plugin\SDK\FFXIV_ACT_Plugin.Common.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="FFXIV_ACT_Plugin.Common">
-      <HintPath>..\Thirdparty\FFXIV_ACT_Plugin\SDK\FFXIV_ACT_Plugin.Logfile.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -112,6 +112,7 @@
     <Compile Include="MemoryProcessors\FFXIVMemory.cs" />
     <Compile Include="Integration\FFXIVExportVariables.cs" />
     <Compile Include="Integration\FFXIVRepository.cs" />
+    <Compile Include="Integration\FFXIVCustomLogLines.cs" />
     <Compile Include="JSApi\IApiBase.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="JSApi\MinimalApi.cs" />
@@ -504,6 +505,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="resources\preview.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="resources\reserved_log_lines.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -240,6 +240,7 @@ namespace RainbowMage.OverlayPlugin
                             _container.Register(new FFXIVRepository(_container));
                             _container.Register(new NetworkParser(_container));
                             _container.Register(new TriggIntegration(_container));
+                            _container.Register(new FFXIVCustomLogLines(_container));
 
                             // This timer runs on the UI thread (it has to since we create UI controls) but LoadAddons()
                             // can block for some time. We run it on the background thread to avoid blocking the UI.

--- a/OverlayPlugin.Core/Resources.Designer.cs
+++ b/OverlayPlugin.Core/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace RainbowMage.OverlayPlugin {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to FFXIVCustomLogLines: Failed to load reserved log line: {0}.
+        /// </summary>
+        internal static string ErrorCouldNotLoadReservedLogLines {
+            get {
+                return ResourceManager.GetString("ErrorCouldNotLoadReservedLogLines", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name must not be empty or white space only..
         /// </summary>
         internal static string ErrorOverlayNameEmpty {

--- a/OverlayPlugin.Core/Resources.resx
+++ b/OverlayPlugin.Core/Resources.resx
@@ -279,6 +279,9 @@
   <data name="ErrorCouldNotLoadPresets" xml:space="preserve">
     <value>NewOverlayDialog: Failed to load presets: {0}</value>
   </data>
+  <data name="ErrorCouldNotLoadReservedLogLines" xml:space="preserve">
+    <value>FFXIVCustomLogLines: Failed to load reserved log line: {0}</value>
+  </data>
   <data name="OverlayPreviewName" xml:space="preserve">
     <value>Preview</value>
     <comment>This is used as the temporary name for the preview overlay.</comment>

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -1,0 +1,22 @@
+[
+    {
+        "StartID": 0,
+        "EndID": 255,
+        "Source": "FFXIV_ACT_Plugin",
+        "Version": 0,
+        "Comment": "Reserved for base FFXIV_ACT_Plugin use"
+    },
+    {
+        "ID": 256,
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "Line to be emitted when a new log line is registered"
+    },
+    {
+        "StartID": 257,
+        "EndID": 512,
+        "Source": "OverlayPlugin",
+        "Version": 0,
+        "Comment": "Reserved for future OverlayPlugin use"
+    }
+]


### PR DESCRIPTION
This is an extremely basic proof of concept method to write a log line to the FFXIV_ACT_Plugin log file. I'm opening this PR to solicit feedback from maintainers and from those downstream that have expressed an interest or need in this functionality.

As this function currently stands, invoking it such that:

```cs
repo.WriteLogLineImpl("test|data|abcdef");
```

Will result in a log line in-stream such as the middle line in the following:
```
12|2022-09-01T20:34:35.2730000-04:00|24|213|409|2546|412|2707|572|213|1060|2263|2707|2707|1691|400|826|0|400|4000174C11F22F|21e59f13244db681
111|2022-09-01T20:34:45.8200097-04:00|test|data|abcdef|691cce4a752de84f
00|2022-09-01T20:37:44.0000000-04:00|0038|Sonar|Rank A: Hellsclaw  Eastern La Noscea ( 19.6  , 31.3 ) <Cactuar>|b65e3ce0bdda7dc3
```

Obviously this is extremely basic as it stands and requires significant refinement.

I would propose three variations of this method as follows:

1. A method to write a log line with structured data, with a proposed line ID of 110
2. A method to write a log line with unstructured data, with a proposed line ID of 111
3. A method to write a log line with bulk data, e.g. JSON, with a proposed line ID of 112

The signatures of these methods could look like (with example calls and outputs):

```cs
public bool WriteStructuredLogLine(string Source, uint ID, string data);
WriteStructuredLogLine("OverlayPlugin", OverlayPluginLogLineIDs.MapEffect, "800375A9|00400020|04|A2|0050");
110|2022-08-30T21:51:05.0000000-07:00|OverlayPlugin|14|800375A9|00400020|04|A2|0050|0123456789abcdef
```
```cs
public bool WriteUnstructuredLogLine(string Source, string data);
WriteStructuredLogLine("Cactbot", "Some text maybe debug info idk?");
111|2022-08-30T21:51:05.0000000-07:00|Cactbot|Some text maybe debug info idk?|0123456789abcdef
```
```cs
public bool WriteUnstructuredLogLine(string Source, string data);
WriteStructuredLogLine("OverlayPlugin", @"{""combatants"":[]}");
112|2022-08-30T21:51:05.0000000-07:00|OverlayPlugin|{"combatants":[]}|0123456789abcdef
```