### PR TITLE
Convert MiniParseEventSource getCombatants to read memory

### DIFF
--- a/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
@@ -203,6 +203,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
                 var combatants = memory.GetCombatantList();
 
+                combatants.RemoveAll((c) => c.Type != ObjectType.PC && c.Type != ObjectType.Monster);
+
                 if (targetData)
                 {
                     // See CreateTargetData() below

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.IO;
 using Advanced_Combat_Tracker;
 using FFXIV_ACT_Plugin.Common;
+using System.Collections.Generic;
 
 namespace RainbowMage.OverlayPlugin
 {
@@ -220,6 +221,28 @@ namespace RainbowMage.OverlayPlugin
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public IDictionary<uint, string> GetResourceDictionary(ResourceType resourceType)
+        {
+            try
+            {
+                return GetResourceDictionaryImpl(resourceType);
+            }
+            catch (FileNotFoundException)
+            {
+                // The FFXIV plugin isn't loaded
+                return null;
+            }
+        }
+
+        public IDictionary<uint, string> GetResourceDictionaryImpl(ResourceType resourceType)
+        {
+            var repo = GetRepository();
+            if (repo == null) return null;
+
+            return repo.GetResourceDictionary(resourceType);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public string GetPlayerName()
         {
             try
@@ -311,13 +334,13 @@ namespace RainbowMage.OverlayPlugin
             if (sub != null)
             {
                 sub.ProcessChanged += new ProcessChangedDelegate(handler);
-                /*
+
                 var repo = GetRepository();
                 if (repo != null)
                 {
                     var process = repo.GetCurrentFFXIVProcess();
                     if (process != null) handler(process);
-                }*/
+                }
             }
         }
     }

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory52.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory52.cs
@@ -347,7 +347,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public Single PosZ;
 
             [FieldOffset(0xB0)]
-            public Single Rotation;
+            public Single Heading;
 
             [FieldOffset(0x17F8)]
             public uint TargetID;
@@ -407,7 +407,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
-                    Rotation = mem.Rotation,
+                    Heading = mem.Heading,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory53.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory53.cs
@@ -349,7 +349,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public Single PosZ;
 
             [FieldOffset(0xB0)]
-            public Single Rotation;
+            public Single Heading;
 
             [FieldOffset(0x17F8)]
             public uint TargetID;
@@ -409,7 +409,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
-                    Rotation = mem.Rotation,
+                    Heading = mem.Heading,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory54.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory54.cs
@@ -346,7 +346,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public Single PosZ;
 
             [FieldOffset(0xB0)]
-            public Single Rotation;
+            public Single Heading;
 
             [FieldOffset(0x18B8)]
             public uint TargetID;
@@ -406,7 +406,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
-                    Rotation = mem.Rotation,
+                    Heading = mem.Heading,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory55.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory55.cs
@@ -358,7 +358,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public Single PosZ;
 
             [FieldOffset(0xB0)]
-            public Single Rotation;
+            public Single Heading;
 
             [FieldOffset(0x18D8)]
             public uint TargetID;
@@ -423,7 +423,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
-                    Rotation = mem.Rotation,
+                    Heading = mem.Heading,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory60.cs
@@ -446,8 +446,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
                     RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
-                    PosY = mem.PosY,
-                    PosZ = mem.PosZ,
+                    // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
+                    PosY = mem.PosZ,
+                    PosZ = mem.PosY,
                     Heading = mem.Heading,
                     Radius = mem.Radius,
                     TargetID = mem.TargetID,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory60.cs
@@ -327,26 +327,20 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0x74)]
             public uint ID;
 
+            [FieldOffset(0x80)]
+            public uint BNpcID;
+
             [FieldOffset(0x84)]
             public uint OwnerID;
 
             [FieldOffset(0x8C)]
-            public byte Type;
-
-            [FieldOffset(0x19C3)]
-            public byte MonsterType;
-
-            [FieldOffset(0x94)]
-            public byte Status;
-
-            [FieldOffset(0x104)]
-            public int ModelStatus;
-
-            [FieldOffset(0x19DF)]
-            public byte AggressionStatus;
+            public byte Type; // Maybe rename `type`?
 
             [FieldOffset(0x92)]
             public byte EffectiveDistance;
+
+            [FieldOffset(0x94)]
+            public byte Status;
 
             [FieldOffset(0xA0)]
             public Single PosX;
@@ -358,13 +352,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public Single PosZ;
 
             [FieldOffset(0xB0)]
-            public Single Rotation;
+            public Single Heading;
 
             [FieldOffset(0XC0)]
             public Single Radius;
 
-            [FieldOffset(0x1940)]
-            public uint TargetID;
+            [FieldOffset(0x104)]
+            public int ModelStatus;
 
             [FieldOffset(0x1C4)]
             public int CurrentHP;
@@ -372,11 +366,39 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0x1C8)]
             public int MaxHP;
 
+            [FieldOffset(0x1CC)]
+            public int CurrentMP;
+
+            [FieldOffset(0x1D0)]
+            public int MaxMP;
+
             [FieldOffset(0x1E0)]
             public byte Job;
 
+            [FieldOffset(0x1E1)]
+            public byte Level;
+
+            [FieldOffset(0x19C3)]
+            public byte MonsterType;
+
+            [FieldOffset(0x19DF)]
+            public byte AggressionStatus;
+
+            [FieldOffset(0x1940)]
+            public uint TargetID;
+
+            [FieldOffset(0x1984)]
+            public uint BNpcNameID;
+
+            [FieldOffset(0x19A0)]
+            public ushort CurrentWorldID;
+
+            [FieldOffset(0x19A2)]
+            public ushort WorldID;
+
             [FieldOffset(0x1A38)]
             public fixed byte Effects[effectBytes];
+            // Missing PartyType
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 12)]
@@ -426,12 +448,22 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
-                    Rotation = mem.Rotation,
+                    Heading = mem.Heading,
                     Radius = mem.Radius,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
                     Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+
+                    BNpcID = mem.BNpcID,
+                    CurrentMP = mem.CurrentMP,
+                    MaxMP = mem.MaxMP,
+                    Level = mem.Level,
+
+                    BNpcNameID = mem.BNpcNameID,
+
+                    WorldID = mem.WorldID,
+                    CurrentWorldID = mem.CurrentWorldID,
                 };
                 combatant.IsTargetable = 
                     (combatant.ModelStatus == ModelStatus.Visible) 

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory61.cs
@@ -322,26 +322,20 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0x74)]
             public uint ID;
 
+            [FieldOffset(0x80)]
+            public uint BNpcID;
+
             [FieldOffset(0x84)]
             public uint OwnerID;
 
             [FieldOffset(0x8C)]
-            public byte Type;
-
-            [FieldOffset(0x19C3)]
-            public byte MonsterType;
-
-            [FieldOffset(0x94)]
-            public byte Status;
-
-            [FieldOffset(0x104)]
-            public int ModelStatus;
-
-            [FieldOffset(0x19DF)]
-            public byte AggressionStatus;
+            public byte Type; // Maybe rename `type`?
 
             [FieldOffset(0x92)]
             public byte EffectiveDistance;
+
+            [FieldOffset(0x94)]
+            public byte Status;
 
             [FieldOffset(0xA0)]
             public Single PosX;
@@ -353,13 +347,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public Single PosZ;
 
             [FieldOffset(0xB0)]
-            public Single Rotation;
+            public Single Heading;
 
             [FieldOffset(0XC0)]
             public Single Radius;
 
-            [FieldOffset(0x1A50)]
-            public uint TargetID;
+            [FieldOffset(0x104)]
+            public int ModelStatus;
 
             [FieldOffset(0x1C4)]
             public int CurrentHP;
@@ -367,11 +361,39 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0x1C8)]
             public int MaxHP;
 
+            [FieldOffset(0x1CC)]
+            public int CurrentMP;
+
+            [FieldOffset(0x1D0)]
+            public int MaxMP;
+
             [FieldOffset(0x1E0)]
             public byte Job;
 
+            [FieldOffset(0x1E1)]
+            public byte Level;
+
+            [FieldOffset(0x19C3)]
+            public byte MonsterType;
+
+            [FieldOffset(0x19DF)]
+            public byte AggressionStatus;
+
+            [FieldOffset(0x1A50)]
+            public uint TargetID;
+
+            [FieldOffset(0x1A94)]
+            public uint BNpcNameID;
+
+            [FieldOffset(0x1AB0)]
+            public ushort CurrentWorldID;
+
+            [FieldOffset(0x1AB2)]
+            public ushort WorldID;
+
             [FieldOffset(0x1B28)]
             public fixed byte Effects[effectBytes];
+            // Missing PartyType
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 12)]
@@ -421,12 +443,22 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
-                    Rotation = mem.Rotation,
+                    Heading = mem.Heading,
                     Radius = mem.Radius,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
                     Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+
+                    BNpcID = mem.BNpcID,
+                    CurrentMP = mem.CurrentMP,
+                    MaxMP = mem.MaxMP,
+                    Level = mem.Level,
+
+                    BNpcNameID = mem.BNpcNameID,
+
+                    WorldID = mem.WorldID,
+                    CurrentWorldID = mem.CurrentWorldID,
                 };
                 combatant.IsTargetable = 
                     (combatant.ModelStatus == ModelStatus.Visible) 

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory61.cs
@@ -441,8 +441,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
                     RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
-                    PosY = mem.PosY,
-                    PosZ = mem.PosZ,
+                    // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
+                    PosY = mem.PosZ,
+                    PosZ = mem.PosY,
                     Heading = mem.Heading,
                     Radius = mem.Radius,
                     TargetID = mem.TargetID,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory62.cs
@@ -439,8 +439,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
                     RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
-                    PosY = mem.PosY,
-                    PosZ = mem.PosZ,
+                    // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
+                    PosY = mem.PosZ,
+                    PosZ = mem.PosY,
                     Heading = mem.Heading,
                     Radius = mem.Radius,
                     TargetID = mem.TargetID,

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory62.cs
@@ -297,8 +297,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             {
                 CombatantMemory mem = *(CombatantMemory*)&p[0];
                 ObjectType type = (ObjectType)mem.Type;
-                if (type != ObjectType.PC && type != ObjectType.Monster)
-                    return null;
                 if (mem.ID == 0 || mem.ID == emptyID)
                     return null;
             }
@@ -322,26 +320,20 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0x74)]
             public uint ID;
 
+            [FieldOffset(0x80)]
+            public uint BNpcID;
+
             [FieldOffset(0x84)]
             public uint OwnerID;
 
             [FieldOffset(0x8C)]
-            public byte Type;
-
-            [FieldOffset(0x19C3)]
-            public byte MonsterType;
-
-            [FieldOffset(0x94)]
-            public byte Status;
-
-            [FieldOffset(0x104)]
-            public int ModelStatus;
-
-            [FieldOffset(0x19DF)]
-            public byte AggressionStatus;
+            public byte Type; // Maybe rename `type`?
 
             [FieldOffset(0x92)]
             public byte EffectiveDistance;
+
+            [FieldOffset(0x94)]
+            public byte Status;
 
             [FieldOffset(0xA0)]
             public Single PosX;
@@ -353,13 +345,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public Single PosZ;
 
             [FieldOffset(0xB0)]
-            public Single Rotation;
+            public Single Heading;
 
             [FieldOffset(0XC0)]
             public Single Radius;
 
-            [FieldOffset(0x1A68)]
-            public uint TargetID;
+            [FieldOffset(0x104)]
+            public int ModelStatus;
 
             [FieldOffset(0x1C4)]
             public int CurrentHP;
@@ -367,11 +359,39 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0x1C8)]
             public int MaxHP;
 
+            [FieldOffset(0x1CC)]
+            public int CurrentMP;
+
+            [FieldOffset(0x1D0)]
+            public int MaxMP;
+
             [FieldOffset(0x1E0)]
             public byte Job;
 
+            [FieldOffset(0x1E1)]
+            public byte Level;
+
+            [FieldOffset(0x19C3)]
+            public byte MonsterType;
+
+            [FieldOffset(0x19DF)]
+            public byte AggressionStatus;
+
+            [FieldOffset(0x1A68)]
+            public uint TargetID;
+
+            [FieldOffset(0x1AAC)]
+            public uint BNpcNameID;
+
+            [FieldOffset(0x1AC8)]
+            public ushort CurrentWorldID;
+
+            [FieldOffset(0x1ACA)]
+            public ushort WorldID;
+
             [FieldOffset(0x1B48)]
             public fixed byte Effects[effectBytes];
+            // Missing PartyType
         }
 
         [StructLayout(LayoutKind.Explicit, Size = 12)]
@@ -421,12 +441,22 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosX = mem.PosX,
                     PosY = mem.PosY,
                     PosZ = mem.PosZ,
-                    Rotation = mem.Rotation,
+                    Heading = mem.Heading,
                     Radius = mem.Radius,
                     TargetID = mem.TargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
                     Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+
+                    BNpcID = mem.BNpcID,
+                    CurrentMP = mem.CurrentMP,
+                    MaxMP = mem.MaxMP,
+                    Level = mem.Level,
+
+                    BNpcNameID = mem.BNpcNameID,
+
+                    WorldID = mem.WorldID,
+                    CurrentWorldID = mem.CurrentWorldID,
                 };
                 combatant.IsTargetable = 
                     (combatant.ModelStatus == ModelStatus.Visible) 

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemory62.cs
@@ -347,7 +347,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0xB0)]
             public Single Heading;
 
-            [FieldOffset(0XC0)]
+            [FieldOffset(0xC0)]
             public Single Radius;
 
             [FieldOffset(0x104)]
@@ -365,11 +365,26 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             [FieldOffset(0x1D0)]
             public int MaxMP;
 
+            [FieldOffset(0x1D4)]
+            public ushort CurrentGP;
+
+            [FieldOffset(0x1D6)]
+            public ushort MaxGP;
+
+            [FieldOffset(0x1D8)]
+            public ushort CurrentCP;
+
+            [FieldOffset(0x1DA)]
+            public ushort MaxCP;
+
             [FieldOffset(0x1E0)]
             public byte Job;
 
             [FieldOffset(0x1E1)]
             public byte Level;
+
+            [FieldOffset(0xC60)]
+            public uint PCTargetID;
 
             [FieldOffset(0x19C3)]
             public byte MonsterType;
@@ -378,7 +393,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             public byte AggressionStatus;
 
             [FieldOffset(0x1A68)]
-            public uint TargetID;
+            public uint NPCTargetID;
 
             [FieldOffset(0x1AAC)]
             public uint BNpcNameID;
@@ -391,6 +406,24 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
 
             [FieldOffset(0x1B48)]
             public fixed byte Effects[effectBytes];
+
+            [FieldOffset(0x1CD0)]
+            public byte IsCasting1;
+
+            [FieldOffset(0x1CD2)]
+            public byte IsCasting2;
+
+            [FieldOffset(0x1CD4)]
+            public uint CastBuffID;
+
+            [FieldOffset(0x1CE0)]
+            public uint CastTargetID;
+
+            [FieldOffset(0x1D04)]
+            public float CastDurationCurrent;
+
+            [FieldOffset(0x1D08)]
+            public float CastDurationMax;
             // Missing PartyType
         }
 
@@ -437,6 +470,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     ModelStatus = (ModelStatus)mem.ModelStatus,
                     // Normalize all possible aggression statuses into the basic 4 ones.
                     AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
+                    NPCTargetID = mem.NPCTargetID,
                     RawEffectiveDistance = mem.EffectiveDistance,
                     PosX = mem.PosX,
                     // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
@@ -444,7 +478,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     PosZ = mem.PosY,
                     Heading = mem.Heading,
                     Radius = mem.Radius,
-                    TargetID = mem.TargetID,
+                    // In-memory there are separate values for PC's current target and NPC's current target
+                    TargetID = mem.PCTargetID != 0xE0000000 ? mem.PCTargetID : mem.NPCTargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
                     Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
@@ -452,12 +487,24 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
                     BNpcID = mem.BNpcID,
                     CurrentMP = mem.CurrentMP,
                     MaxMP = mem.MaxMP,
+                    CurrentGP = mem.CurrentGP,
+                    MaxGP = mem.MaxGP,
+                    CurrentCP = mem.CurrentCP,
+                    MaxCP = mem.MaxCP,
                     Level = mem.Level,
+                    PCTargetID = mem.PCTargetID,
 
                     BNpcNameID = mem.BNpcNameID,
 
                     WorldID = mem.WorldID,
                     CurrentWorldID = mem.CurrentWorldID,
+
+                    IsCasting1 = mem.IsCasting1,
+                    IsCasting2 = mem.IsCasting2,
+                    CastBuffID = mem.CastBuffID,
+                    CastTargetID = mem.CastTargetID,
+                    CastDurationCurrent = mem.CastDurationCurrent,
+                    CastDurationMax = mem.CastDurationMax,
                 };
                 combatant.IsTargetable = 
                     (combatant.ModelStatus == ModelStatus.Visible) 

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemoryCommon.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemoryCommon.cs
@@ -134,8 +134,20 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
 
         public uint BNpcNameID;
 
-        public ushort WorldID; // Might be inverted with CurrentWorldID
+        public ushort WorldID;
         public ushort CurrentWorldID;
+        public uint NPCTargetID;
+        public ushort CurrentGP;
+        public ushort MaxGP;
+        public ushort CurrentCP;
+        public ushort MaxCP;
+        public uint PCTargetID;
+        public byte IsCasting1;
+        public byte IsCasting2;
+        public uint CastBuffID;
+        public uint CastTargetID;
+        public float CastDurationCurrent;
+        public float CastDurationMax;
 
         private Single GetDistance(Combatant target)
         {

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityMemoryCommon.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityMemoryCommon.cs
@@ -117,7 +117,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         public Single PosX;
         public Single PosY;
         public Single PosZ;
-        public Single Rotation;
+        public Single Heading;
         public Single Radius;
 
         public string Distance;
@@ -126,6 +126,16 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         public byte RawEffectiveDistance;
 
         public List<EffectEntry> Effects;
+
+        public uint BNpcID;
+        public int CurrentMP;
+        public int MaxMP;
+        public byte Level;
+
+        public uint BNpcNameID;
+
+        public ushort WorldID; // Might be inverted with CurrentWorldID
+        public ushort CurrentWorldID;
 
         private Single GetDistance(Combatant target)
         {


### PR DESCRIPTION
Closes #33.

This could use more thorough testing by others. I was basically guessing at the CN and KO offsets for 6.0 and 6.1.

Field `Rotation` was renamed to `Heading` to match the existing FFXIV_ACT_Plugin data model. The downstream data model documented in cactbot will need to be updated to reflect this change.

Was not able to find `PartyType` in memory, so this PR still calls the FFXIV_ACT_Plugin combatant list to look that up.

The check for actor type was moved to `EnmityEventSource.cs` so that this can return all active actors.