### PR TITLE
Added ChangeMap as an event type

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -68,6 +68,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
         private const string LogLineEvent = "LogLine";
         private const string ImportedLogLinesEvent = "ImportedLogLines";
         private const string ChangeZoneEvent = "ChangeZone";
+        private const string ChangeMapEvent = "ChangeMap";
         private const string ChangePrimaryPlayerEvent = "ChangePrimaryPlayer";
         private const string FileChangedEvent = "FileChanged";
         private const string OnlineStatusChangedEvent = "OnlineStatusChanged";
@@ -98,6 +99,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
             RegisterCachedEventTypes(new List<string> {
                 ChangePrimaryPlayerEvent,
                 ChangeZoneEvent,
+                ChangeMapEvent,
                 OnlineStatusChangedEvent,
                 PartyChangedEvent,
             });
@@ -397,6 +399,24 @@ namespace RainbowMage.OverlayPlugin.EventSources
                         }));
                         break;
 
+                    case LogMessageType.ChangeMap:
+                        if (line.Length < 6) return;
+                        
+                        var mapID = Convert.ToUInt32(line[2], 10);
+                        var regionName = line[3];
+                        var placeName = line[4];
+                        var placeNameSub = line[5];
+                        
+                        DispatchAndCacheEvent(JObject.FromObject(new
+                        {
+                            type = ChangeMapEvent,
+                            mapID,
+                            regionName,
+                            placeName,
+                            placeNameSub
+                        }));
+                        break;
+                    
                     case LogMessageType.ChangePrimaryPlayer:
                         if (line.Length < 4) return;
 

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -45,6 +45,7 @@ namespace RainbowMage.OverlayPlugin
         NetworkEffectResult,
         NetworkStatusList,
         NetworkUpdateHp,
+        ChangeMap,
         Settings = 249,
         Process,
         Debug,


### PR DESCRIPTION
One part of https://github.com/OverlayPlugin/OverlayPlugin/issues/40

Works similar to ZoneChange. This allows clients that connect after-the-fact to know what the current map is, like with Zones and Primary Player.

This line:
`40|2022-09-11T13:01:21.7100000-07:00|72|La Noscea|Mist|Mist|8552f2f253b9782d`

would turn into this:
`{"type":"ChangeMap","mapID":72,"regionName":"La Noscea","placeName":"Mist","placeNameSub":"Mist"}`