### PR TITLE
Add event source call to read party list from memory

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -84,6 +84,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
         {
             this.Name = "MiniParse";
             this.repository = container.Resolve<FFXIVRepository>();
+            var partyListMemory = new MemoryProcessors.PartyMemory62(container);
 
             // FileChanged isn't actually raised by this event source. That event is generated in MiniParseOverlay directly.
             RegisterEventTypes(new List<string> {
@@ -149,6 +150,12 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 {
                     combatants
                 });
+            });
+
+            RegisterEventHandler("getPartyList", (msg) =>
+            {
+                var partyList = partyListMemory.GetPartyList();
+                return JObject.FromObject(partyList);
             });
 
             RegisterEventHandler("saveData", (msg) =>

--- a/OverlayPlugin.Core/MemoryProcessors/PartyMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/PartyMemory62.cs
@@ -1,0 +1,258 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors
+{
+    public class PartyMemory62 : PartyMemoryCommon
+    {
+        private FFXIVMemory memory;
+        private ILogger logger;
+        private DateTime lastSigScan = DateTime.MinValue;
+        private uint loggedScanErrors = 0;
+
+        private IntPtr partyAddress = IntPtr.Zero;
+
+        private const string partyListSignature = "8B7C24440FB66C2440400FB6D5488D0D";
+
+        // Offsets from the signature to find the correct address.
+        private const int partyListSignatureOffset = 0;
+
+        // Constants.
+        private const uint emptyID = 0xE0000000;
+
+        public PartyMemory62(TinyIoCContainer container)
+        {
+            this.memory = new FFXIVMemory(container);
+            this.memory.OnProcessChange += ResetPointers;
+            this.logger = container.Resolve<ILogger>();
+            GetPointerAddress();
+        }
+
+        private void ResetPointers(object sender, EventArgs _)
+        {
+            partyAddress = IntPtr.Zero;
+        }
+
+        private bool HasValidPointers()
+        {
+            if (partyAddress == IntPtr.Zero)
+                return false;
+            return true;
+        }
+
+        public override bool IsValid()
+        {
+            if (!memory.IsValid())
+                return false;
+
+            if (!HasValidPointers())
+                GetPointerAddress();
+
+            if (!HasValidPointers())
+                return false;
+
+            return true;
+        }
+
+        private bool GetPointerAddress()
+        {
+            if (!memory.IsValid())
+                return false;
+
+            // Don't scan too often to avoid excessive CPU load
+            if ((DateTime.Now - lastSigScan) < TimeSpan.FromSeconds(5))
+                return false;
+
+            lastSigScan = DateTime.Now;
+            bool success = true;
+            bool bRIP = true;
+
+            List<IntPtr> list = memory.SigScan(partyListSignature, 0, bRIP);
+            foreach (var entry in list)
+            {
+                logger.Log(LogLevel.Warning, "partyAddress: 0x{0:X}", entry.ToInt64());
+            }
+            if (list != null && list.Count > 0)
+            {
+                partyAddress = list[0] + partyListSignatureOffset;
+            }
+            else
+            {
+                partyAddress = IntPtr.Zero;
+                logger.Log(LogLevel.Warning, $"{list != null}, {list != null && list.Count > 0}");
+                success = false;
+            }
+
+            logger.Log(LogLevel.Debug, "partyAddress: 0x{0:X}", partyAddress.ToInt64());
+
+            return success;
+        }
+
+        public override unsafe PartyList GetPartyList()
+        {
+            var result = new PartyList();
+            var seen = new HashSet<uint>();
+
+            if (!IsValid())
+            {
+                return result;
+            }
+
+            byte[] source = memory.GetByteArray(partyAddress, PartyListMemory.Size);
+            if (source == null || source.Length == 0)
+                return result;
+
+            fixed (byte* p = source)
+            {
+                PartyListMemory list = *(PartyListMemory*)&p[0];
+
+                if (list.PartySize > 27 || list.PartySize < 0)
+                    return result;
+                
+                for (var i = 0; i < list.PartySize; ++i)
+                {
+                    PartyListEntryMemory entry = *(PartyListEntryMemory*)&list.Entries[PartyListEntryMemory.Size * i];
+                    result.Entries.Add(new PartyEntry() {
+                        ID = entry.ObjectID,
+                        Name = FFXIVMemory.GetStringFromBytes(entry.Name, PartyListEntryMemory.nameBytes),
+                        Flags = entry.Flags,
+                        RawEntry = GetRawEntry(entry),
+                    });
+                }
+
+                result.Address = (ulong)partyAddress.ToInt64();
+            }
+
+            return result;
+        }
+
+        private unsafe JObject GetRawEntry(PartyListEntryMemory entry)
+        {
+            JObject ret = JObject.FromObject(entry);
+            List<EffectEntry> effects = new List<EffectEntry>();
+
+            for (int i = 0; i < 30; ++i)
+            {
+                EffectEntry effect = *(EffectEntry*)&entry.Effects[i * 0xC];
+                if (effect.BuffID > 0 &&
+                    effect.Stack >= 0 &&
+                    effect.Timer >= 0.0f &&
+                    effect.ActorID > 0)
+                {
+                    effects.Add(effect);
+                }
+            }
+
+            ret["Effects"] = JArray.FromObject(effects);
+
+            return ret;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = Size, Pack = 1)]
+        public unsafe struct PartyListEntryMemory
+        {
+            public const int Size = 0x230;
+            public const int nameBytes = 64;
+
+            [FieldOffset(0)]
+            public ulong CharacterPointer;
+
+            [FieldOffset(8)]
+            public fixed byte Effects[EffectEntry.Size * 30];
+
+            [FieldOffset(0x170)]
+            public uint Unk_170;
+
+            [FieldOffset(0x174)]
+            public ushort Unk_174;
+
+            [FieldOffset(0x178)]
+            public long Unk_178;
+
+            [FieldOffset(0x180)]
+            public byte Unk_180;
+
+            [FieldOffset(0x190)]
+            public float X;
+            [FieldOffset(0x194)]
+            public float Y;
+            [FieldOffset(0x198)]
+            public float Z;
+            [FieldOffset(0x1A0)]
+            public long ContentID;
+            [FieldOffset(0x1A8)]
+            public uint ObjectID;
+            [FieldOffset(0x1AC)]
+            public uint Unk_ObjectID_1;
+            [FieldOffset(0x1B0)]
+            public uint Unk_ObjectID_2;
+            [FieldOffset(0x1B4)]
+            public uint CurrentHP;
+            [FieldOffset(0x1B8)]
+            public uint MaxHP;
+            [FieldOffset(0x1BC)]
+            public ushort CurrentMP;
+            [FieldOffset(0x1BE)]
+            public ushort MaxMP;
+            [FieldOffset(0x1C0)]
+            public ushort TerritoryType;
+            [FieldOffset(0x1C2)]
+            public ushort HomeWorld;
+            [FieldOffset(0x1C4)]
+            public fixed byte Name[0x40];
+            [FieldOffset(0x204)]
+            public byte Sex;
+            [FieldOffset(0x205)]
+            public byte ClassJob;
+            [FieldOffset(0x206)]
+            public byte Level;
+
+            // 0x18 byte struct at 0x208
+            [FieldOffset(0x208)]
+            public byte Unk_208;
+            [FieldOffset(0x20C)]
+            public uint Unk_20C;
+            [FieldOffset(0x210)]
+            public ushort Unk_210;
+            [FieldOffset(0x214)]
+            public uint Unk_214;
+            [FieldOffset(0x218)]
+            public ushort Unk_218;
+            [FieldOffset(0x21A)]
+            public ushort Unk_21A;
+            [FieldOffset(0x220)]
+            public byte Flags;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public unsafe struct PartyListMemory
+        {
+            public static int Size => Marshal.SizeOf(typeof(PartyListMemory));
+
+            [FieldOffset(0)]
+            public unsafe fixed byte Entries[PartyListEntryMemory.Size * 28];
+            [FieldOffset(15700)]
+            public byte PartyFlag1;
+            [FieldOffset(15708)]
+            public byte PartySize;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Size = Size, Pack = 1)]
+        public unsafe struct EffectEntry
+        {
+            public const int Size = 0xC;
+            [FieldOffset(0)]
+            public ushort BuffID;
+            [FieldOffset(2)]
+            public ushort Stack;
+            [FieldOffset(4)]
+            public float Timer;
+            [FieldOffset(8)]
+            public uint ActorID;
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/PartyMemoryCommon.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/PartyMemoryCommon.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors
+{
+    public class PartyList
+    {
+        public ulong Address;
+        public List<PartyEntry> Entries = new List<PartyEntry>();
+        public byte Flags;
+    }
+
+    public struct PartyEntry
+    {
+        public uint ID;
+        public string Name;
+        public byte Flags;
+        public JObject RawEntry;
+    }
+
+    public abstract class PartyMemoryCommon
+    {
+        abstract public bool IsValid();
+        abstract public unsafe PartyList GetPartyList();
+    }
+}

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -100,12 +100,14 @@
     <Compile Include="MemoryProcessors\EnmityMemory55.cs" />
     <Compile Include="MemoryProcessors\EnmityMemory54.cs" />
     <Compile Include="MemoryProcessors\EnmityMemoryCommon.cs" />
+    <Compile Include="MemoryProcessors\PartyMemoryCommon.cs" />
     <Compile Include="NetworkProcessors\FateWatcher.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcess.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcessCn.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcessIntl.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcessKo.cs" />
     <Compile Include="MemoryProcessors\FFXIVMemory.cs" />
+    <Compile Include="MemoryProcessors\PartyMemory62.cs" />
     <Compile Include="Integration\FFXIVExportVariables.cs" />
     <Compile Include="Integration\FFXIVRepository.cs" />
     <Compile Include="JSApi\IApiBase.cs" />


### PR DESCRIPTION
This is an extremely WIP PR adding an event source call to read party list from memory, as opposed to the FFXIV_ACT_Plugin's repository.

This does not resolve the issue of party members out-of-zone not having an ID, but it does indicate that they're in the party at least.

As far as I've been able to determine, if a party member is out-of-zone, they flat out don't have an ID in memory. Any scans for their ID in memory will only turn up false positives, and if you wait long enough for the chat buffer to clear and memory to be recycled, they can still be actively in the party with their ID not in memory at all.

This also does not resolve the issue of party list being blank if it's cross-world. There's potentially something in-memory for cross-world but I'm not sure, it might be some leftover memory stuff from a Dalamud plugin.

Example with two party members, both in the current zone:
```json
{
  "Address": 140696506851872,
  "Entries": [
    {
      "ID": 268440117,
      "Name": "Someone Else",
      "Flags": 5,
      "RawEntry": {
        "CharacterPointer": 0,
        "Effects": [
          {
            "BuffID": 365,
            "Stack": 10,
            "Timer": 30,
            "ActorID": 3758096384
          },
          {
            "BuffID": 364,
            "Stack": 30,
            "Timer": 30,
            "ActorID": 3758096384
          },
          {
            "BuffID": 91,
            "Stack": 0,
            "Timer": 0,
            "ActorID": 268440117
          }
        ],
        "Unk_170": 0,
        "Unk_174": 0,
        "Unk_178": 0,
        "Unk_180": 0,
        "X": -118.547363,
        "Y": 25.5281982,
        "Z": -152.269775,
        "ContentID": 18014498549037320,
        "ObjectID": 268440117,
        "Unk_ObjectID_1": 3758096384,
        "Unk_ObjectID_2": 3758096384,
        "CurrentHP": 91957,
        "MaxHP": 91957,
        "CurrentMP": 10000,
        "MaxMP": 10000,
        "TerritoryType": 979,
        "HomeWorld": 79,
        "Name": {
          "FixedElementField": 83
        },
        "Sex": 0,
        "ClassJob": 21,
        "Level": 90,
        "Unk_208": 0,
        "Unk_20C": 0,
        "Unk_210": 0,
        "Unk_214": 0,
        "Unk_218": 0,
        "Unk_21A": 0,
        "Flags": 5
      }
    },
    {
      "ID": 268440116,
      "Name": "Some One",
      "Flags": 5,
      "RawEntry": {
        "CharacterPointer": 0,
        "Effects": [
          {
            "BuffID": 365,
            "Stack": 10,
            "Timer": 30,
            "ActorID": 3758096384
          },
          {
            "BuffID": 364,
            "Stack": 30,
            "Timer": 30,
            "ActorID": 3758096384
          }
        ],
        "Unk_170": 0,
        "Unk_174": 0,
        "Unk_178": 0,
        "Unk_180": 0,
        "X": -122.972534,
        "Y": 21.5609131,
        "Z": -135.393372,
        "ContentID": 18014498569974320,
        "ObjectID": 268440116,
        "Unk_ObjectID_1": 3758096384,
        "Unk_ObjectID_2": 3758096384,
        "CurrentHP": 57023,
        "MaxHP": 57023,
        "CurrentMP": 10000,
        "MaxMP": 10000,
        "TerritoryType": 979,
        "HomeWorld": 79,
        "Name": {
          "FixedElementField": 83
        },
        "Sex": 1,
        "ClassJob": 24,
        "Level": 90,
        "Unk_208": 0,
        "Unk_20C": 0,
        "Unk_210": 0,
        "Unk_214": 0,
        "Unk_218": 0,
        "Unk_21A": 0,
        "Flags": 5
      }
    }
  ],
  "Flags": 0
}
```

Example with one party member out-of-zone:
```json
{
  "Address": 140696506851872,
  "Entries": [
    {
      "ID": 0,
      "Name": "Someone Else",
      "Flags": 0,
      "RawEntry": {
        "CharacterPointer": 0,
        "Effects": [],
        "Unk_170": 0,
        "Unk_174": 0,
        "Unk_178": 0,
        "Unk_180": 0,
        "X": -1000,
        "Y": -1000,
        "Z": -1000,
        "ContentID": 18014498549037320,
        "ObjectID": 0,
        "Unk_ObjectID_1": 3758096384,
        "Unk_ObjectID_2": 3758096384,
        "CurrentHP": 0,
        "MaxHP": 0,
        "CurrentMP": 0,
        "MaxMP": 0,
        "TerritoryType": 979,
        "HomeWorld": 79,
        "Name": {
          "FixedElementField": 83
        },
        "Sex": 0,
        "ClassJob": 0,
        "Level": 0,
        "Unk_208": 0,
        "Unk_20C": 0,
        "Unk_210": 0,
        "Unk_214": 0,
        "Unk_218": 0,
        "Unk_21A": 0,
        "Flags": 0
      }
    },
    {
      "ID": 268440116,
      "Name": "Some One",
      "Flags": 5,
      "RawEntry": {
        "CharacterPointer": 0,
        "Effects": [
          {
            "BuffID": 365,
            "Stack": 10,
            "Timer": 30,
            "ActorID": 3758096384
          },
          {
            "BuffID": 364,
            "Stack": 30,
            "Timer": 30,
            "ActorID": 3758096384
          }
        ],
        "Unk_170": 0,
        "Unk_174": 0,
        "Unk_178": 0,
        "Unk_180": 0,
        "X": 2.5177002,
        "Y": -7.00390625,
        "Z": -2.456726,
        "ContentID": 18014498569974320,
        "ObjectID": 268440116,
        "Unk_ObjectID_1": 3758096384,
        "Unk_ObjectID_2": 3758096384,
        "CurrentHP": 55783,
        "MaxHP": 55783,
        "CurrentMP": 10000,
        "MaxMP": 10000,
        "TerritoryType": 982,
        "HomeWorld": 79,
        "Name": {
          "FixedElementField": 83
        },
        "Sex": 1,
        "ClassJob": 24,
        "Level": 90,
        "Unk_208": 0,
        "Unk_20C": 0,
        "Unk_210": 0,
        "Unk_214": 0,
        "Unk_218": 0,
        "Unk_21A": 0,
        "Flags": 5
      }
    }
  ],
  "Flags": 0
}
```