### PR TITLE
Add network log line for fate control information

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    public class LineFateControl
+    {
+        public const uint LogFileLineID = 258;
+        private ILogger logger;
+        private IOpcodeConfigEntry opcode = null;
+        private readonly int offsetMessageType;
+        private readonly int offsetPacketData;
+
+        private const ushort FateAddCategory = 0x935;
+        private const ushort FateRemoveCategory = 0x936;
+        private const ushort FateUpdateCategory = 0x93E;
+        private static readonly List<ushort> FateCategories = new List<ushort>() { FateAddCategory, FateRemoveCategory, FateUpdateCategory };
+
+        private Func<string, bool> logWriter;
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        public struct ActorControlSelf_v62
+        {
+            public ushort category;
+            public ushort padding;
+            public uint param1;
+            public uint param2;
+            public uint param3;
+            public uint param4;
+            public uint param5;
+            public uint param6;
+            public uint padding1;
+
+            public override string ToString()
+            {
+                return $"{category:X4}|{padding:X4}|{param1:X8}|{param2:X8}|{param3:X8}|{param4:X8}|{param5:X8}|{param6:X8}|{padding1:X8}";
+            }
+        }
+
+        public LineFateControl(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            var ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                offsetPacketData = Marshal.SizeOf(msgHeaderType);
+                var packetType = mach.GetType("Machina.FFXIV.Headers.Server_ActorControlSelf");
+                opcode = new OpcodeConfigEntry()
+                {
+                    opcode = netHelper.GetOpcode("ActorControlSelf"),
+                    size = (uint) Marshal.SizeOf(typeof(ActorControlSelf_v62)),
+                };
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            if (message.Length < opcode.size + offsetPacketData)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
+                {
+                    ActorControlSelf_v62 mapEffectPacket = *(ActorControlSelf_v62*)&buffer[offsetPacketData];
+                    if (FateCategories.Contains(mapEffectPacket.category))
+                    {
+                        string category = "";
+                        switch (mapEffectPacket.category)
+                        {
+                            case FateAddCategory:
+                                category = "Add";
+                                break;
+                            case FateRemoveCategory:
+                                category = "Remove";
+                                break;
+                            case FateUpdateCategory:
+                                category = "Update";
+                                break;
+                        }
+                        logWriter(
+                            $"{category}|" +
+                            $"{mapEffectPacket.padding:X4}|" +
+                            $"{mapEffectPacket.param1:X8}|" +
+                            $"{mapEffectPacket.param2:X8}|" +
+                            $"{mapEffectPacket.param3:X8}|" +
+                            $"{mapEffectPacket.param4:X8}|" +
+                            $"{mapEffectPacket.param5:X8}|" +
+                            $"{mapEffectPacket.param6:X8}|" +
+                            $"{mapEffectPacket.padding1:X8}"
+                        );
+                    }
+
+                    return;
+                }
+            }
+        }
+
+    }
+}

--- a/OverlayPlugin.Core/NetworkProcessors/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/OverlayPluginLogLines.cs
@@ -11,6 +11,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         {
             container.Register(new OverlayPluginLogLineConfig(container));
             container.Register(new LineMapEffect(container));
+            container.Register(new LineFateControl(container));
         }
     }
 

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -101,6 +101,7 @@
     <Compile Include="MemoryProcessors\EnmityMemory54.cs" />
     <Compile Include="MemoryProcessors\EnmityMemoryCommon.cs" />
     <Compile Include="NetworkProcessors\FateWatcher.cs" />
+    <Compile Include="NetworkProcessors\LineFateControl.cs" />
     <Compile Include="NetworkProcessors\LineMapEffect.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcess.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcessCn.cs" />

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -19,7 +19,13 @@
         "Comment": "MapEffect data"
     },
     {
-        "StartID": 258,
+        "ID": 258,
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "ActorControlSelf Fate data"
+    },
+    {
+        "StartID": 259,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
Some code/logic pulled from https://github.com/quisquous/cactbot/blob/main/plugin/CactbotEventSource/FateWatcher.cs

Depends on #51 for now, since that PR has the groundwork for additional log lines on the OP side. As such, only the commit(s) starting with `Add network log line for fate control information` ([here](https://github.com/OverlayPlugin/OverlayPlugin/commit/5e01443f49a6d30771496c14e51de6dbf3cae84c) until I need to rebase to main after #51 is merged) are relevant.

Examples:

```
258|2022-09-16T22:40:58.6325655-04:00|Add|F0DF|000001F3|00000000|00000000|00000000|00000000|00000000|00000000|68145aa82eda3487
258|2022-09-16T22:40:49.1684933-04:00|Remove|046C|000001DB|00000000|00000000|00000000|00000000|00000000|00007F69|548153581733055d
258|2022-09-16T22:40:49.9944946-04:00|Update|F0DF|000001F0|00000000|00000000|00000000|00000000|00000000|00007F69|4fcac1c21e740f77
```

I figured mapping the control code to a textual status would be better here in case they change in the future, though I'm not sure exactly how often they change.