### PR TITLE
Add CE Director log line

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    [Serializable]
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct CEDirector_v62
+    {
+        [FieldOffset(0x0)]
+        public uint popTime;
+        [FieldOffset(0x4)]
+        public ushort timeRemaining;
+        [FieldOffset(0x6)]
+        public ushort unk9;
+        [FieldOffset(0x8)]
+        public byte ceKey;
+        [FieldOffset(0x9)]
+        public byte numPlayers;
+        [FieldOffset(0xA)]
+        public byte status;
+        [FieldOffset(0xB)]
+        public byte unk10;
+        [FieldOffset(0xC)]
+        public byte progress;
+        [FieldOffset(0xD)]
+        public byte unk11;
+        [FieldOffset(0xE)]
+        public byte unk12;
+        [FieldOffset(0xF)]
+        public byte unk13;
+
+        public override string ToString()
+        {
+            return 
+                $"{popTime:X8}|" +
+                $"{timeRemaining:X4}|" +
+                $"{unk9:X4}|" +
+                $"{ceKey:X2}|" +
+                $"{numPlayers:X2}|" +
+                $"{status:X2}|" +
+                $"{unk10:X2}|" +
+                $"{progress:X2}|" +
+                $"{unk11:X2}|" +
+                $"{unk12:X2}|" +
+                $"{unk13:X2}";
+        }
+    }
+
+    public class LineCEDirector
+    {
+        public const uint LogFileLineID = 259;
+        private ILogger logger;
+        private OverlayPluginLogLineConfig opcodeConfig;
+        private IOpcodeConfigEntry opcode = null;
+        private readonly int offsetMessageType;
+        private readonly int offsetPacketData;
+
+        private Func<string, bool> logWriter;
+
+        public LineCEDirector(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            var ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                offsetPacketData = Marshal.SizeOf(msgHeaderType);
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            // Wait for network data to actually fetch opcode info from file and register log line
+            // This is because the FFXIV_ACT_Plugin's `GetGameVersion` method only returns valid data
+            // if the player is currently logged in/a network connection is active
+            if (opcode == null)
+            {
+                opcode = opcodeConfig["CEDirector"];
+            }
+
+            if (message.Length < opcode.size + offsetPacketData)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
+                {
+                    CEDirector_v62 CEDirectorPacket = *(CEDirector_v62*)&buffer[offsetPacketData];
+                    logWriter(CEDirectorPacket.ToString());
+
+                    return;
+                }
+            }
+        }
+
+    }
+}

--- a/OverlayPlugin.Core/NetworkProcessors/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/OverlayPluginLogLines.cs
@@ -12,6 +12,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             container.Register(new OverlayPluginLogLineConfig(container));
             container.Register(new LineMapEffect(container));
             container.Register(new LineFateControl(container));
+            container.Register(new LineCEDirector(container));
         }
     }
 
@@ -28,7 +29,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
             var pluginDirectory = main.PluginDirectory;
 
-            var opcodesPath = Path.Combine(pluginDirectory, "resources", "opcodes.json");
+            var opcodesPath = Path.Combine(pluginDirectory, "resources", "opcodes.jsonc");
 
             try
             {

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -102,6 +102,7 @@
     <Compile Include="MemoryProcessors\EnmityMemoryCommon.cs" />
     <Compile Include="NetworkProcessors\FateWatcher.cs" />
     <Compile Include="NetworkProcessors\LineFateControl.cs" />
+    <Compile Include="NetworkProcessors\LineCEDirector.cs" />
     <Compile Include="NetworkProcessors\LineMapEffect.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcess.cs" />
     <Compile Include="MemoryProcessors\FFXIVProcessCn.cs" />
@@ -509,7 +510,7 @@
     <Content Include="resources\reserved_log_lines.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="resources\opcodes.json">
+    <Content Include="resources\opcodes.jsonc">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -11,6 +11,14 @@
             "size": 11
         }
     },
+    "2022.07.05.0000.0000": {
+        // Region: KR
+        // Version: 6.05h
+        "CEDirector": {
+            "opcode": 423,
+            "size": 16
+        }
+    },
     "2022.07.08.0000.0000": {
         "MapEffect": {
             "opcode": 123,
@@ -24,9 +32,15 @@
         }
     },
     "2022.08.20.0000.0000": {
+        // Region CN
+        // Version 6.11
         "MapEffect": {
             "opcode": 154,
             "size": 11
+        },
+        "CEDirector": {
+            "opcode": 854,
+            "size": 16
         }
     },
     "2022.08.25.0000.0000": {
@@ -36,9 +50,15 @@
         }
     },
     "2022.09.07.0000.0000": {
+        // Region: Global
+        // Version: 6.21
         "MapEffect": {
             "opcode": 822,
             "size": 11
+        },
+        "CEDirector": {
+            "opcode": 750,
+            "size": 16
         }
     }
 }

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -25,7 +25,13 @@
         "Comment": "ActorControlSelf Fate data"
     },
     {
-        "StartID": 259,
+        "ID": 259,
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "Critical Engagement data"
+    },
+    {
+        "StartID": 260,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
Still WIP, need the version string for KO/CN clients to add opcode entries for those versions. Also, same as the Fate PR, only the commits starting with `Add CEDirector log line` are relevant, as this depends on groundwork laid by #51.