### PR TITLE
Add RSV log line

### DIFF
--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -22,6 +22,7 @@ namespace RainbowMage.OverlayPlugin
             container.Register(new LineCEDirector(container));
             container.Register(new LineInCombat(container));
             container.Register(new LineCombatant(container));
+            container.Register(new LineRSV(container));
         }
     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -1,0 +1,111 @@
+using RainbowMage.OverlayPlugin.MemoryProcessors;
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    [Serializable]
+    [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
+    internal unsafe struct RSV_v62
+    {
+        public const int structSize = 1080;
+        public const int keySize = 0x30;
+        public const int valueSize = 0x404;
+        [FieldOffset(0x0)]
+        public uint unknown1;
+        [FieldOffset(0x4)]
+        public fixed byte key[keySize];
+        [FieldOffset(0x34)]
+        public fixed byte value[valueSize];
+
+        public override string ToString()
+        {
+            fixed (byte* key = this.key) fixed (byte* value = this.value)
+            {
+                return
+                    $"|" +
+                    $"{unknown1:X8}|" +
+                    $"{FFXIVMemory.GetStringFromBytes(key, keySize)}|" +
+                    $"{FFXIVMemory.GetStringFromBytes(value, valueSize)}";
+            }
+        }
+
+        public string ToString(string locale)
+        {
+            fixed (byte* key = this.key) fixed (byte* value = this.value)
+            {
+                return
+                    $"{locale}|" +
+                    $"{unknown1:X8}|" +
+                    $"{FFXIVMemory.GetStringFromBytes(key, keySize)}|" +
+                    $"{FFXIVMemory.GetStringFromBytes(value, valueSize)}";
+            }
+        }
+    }
+
+    public class LineRSV
+    {
+        public const uint LogFileLineID = 262;
+        private ILogger logger;
+        private readonly int offsetMessageType;
+        private readonly int offsetPacketData;
+
+        private Func<string, bool> logWriter;
+        private FFXIVRepository ffxiv;
+
+        public LineRSV(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                offsetPacketData = Marshal.SizeOf(msgHeaderType);
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            if (message.Length < RSV_v62.structSize + offsetPacketData)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                RSV_v62 RSVPacket = *(RSV_v62*)&buffer[offsetPacketData];
+                if (
+                    RSVPacket.key[0] == '_' &&
+                    RSVPacket.key[1] == 'r' &&
+                    RSVPacket.key[2] == 's' &&
+                    RSVPacket.key[3] == 'v'
+                )
+                {
+                    logWriter(RSVPacket.ToString(ffxiv.GetLocaleString()));
+
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -1,7 +1,7 @@
-using RainbowMage.OverlayPlugin.MemoryProcessors;
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using RainbowMage.OverlayPlugin.MemoryProcessors;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -38,8 +38,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 return
                     $"{locale}|" +
                     $"{unknown1:X8}|" +
-                    $"{FFXIVMemory.GetStringFromBytes(key, keySize)}|" +
-                    $"{FFXIVMemory.GetStringFromBytes(value, valueSize)}";
+                    $"{FFXIVMemory.GetStringFromBytes(key, keySize).Replace("\r", "\\r").Replace("\n", "\\n")}|" +
+                    $"{FFXIVMemory.GetStringFromBytes(value, valueSize).Replace("\r", "\\r").Replace("\n", "\\n")}";
             }
         }
     }

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -51,7 +51,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private readonly int offsetMessageType;
         private readonly int offsetPacketData;
 
-        private Func<string, bool> logWriter;
+        private Func<string, DateTime, bool> logWriter;
         private FFXIVRepository ffxiv;
 
         public LineRSV(TinyIoCContainer container)
@@ -101,7 +101,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     RSVPacket.key[3] == 'v'
                 )
                 {
-                    logWriter(RSVPacket.ToString(ffxiv.GetLocaleString()));
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                    logWriter(RSVPacket.ToString(ffxiv.GetLocaleString()), serverTime);
 
                     return;
                 }

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -80,6 +80,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             var customLogLines = container.Resolve<FFXIVCustomLogLines>();
             this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
             {
+                Name = "RSVData",
                 Source = "OverlayPlugin",
                 ID = LogFileLineID,
                 Version = 1,

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -128,6 +128,7 @@
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory62.cs" />
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory.cs" />
     <Compile Include="NetworkProcessors\FateWatcher.cs" />
+    <Compile Include="NetworkProcessors\LineRSV.cs" />
     <Compile Include="NetworkProcessors\LineFateControl.cs" />
     <Compile Include="NetworkProcessors\LineCEDirector.cs" />
     <Compile Include="NetworkProcessors\LineMapEffect.cs" />

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -207,6 +207,10 @@
         "CEDirector": {
             "opcode": 275,
             "size": 16
+        },
+        "RSVData": {
+            "opcode": 631,
+            "size": 1080
         }
     },
     "2023.01.25.0000.0000": {

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -283,6 +283,10 @@
         "CEDirector": {
             "opcode": 685,
             "size": 16
+        },
+        "RSVData": {
+            "opcode": 239,
+            "size": 1080
         }
     },
     "2023.03.30.0000.0000": {

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -49,7 +49,14 @@
         "Comment": "Combatant Memory Information"
     },
     {
-        "StartID": 262,
+        "ID": 262,
+        "Name":  "RSVData",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "RSV Key/Value data"
+    },
+    {
+        "StartID": 263,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
Completely untested but should, in theory, work. I should be able to test this when one of my groups runs later tonight.

Potential issues:
1. As it currently stands this might produce false positives if there's uncleared memory between large packets?
2. Technically requires 4 byte comparisons, rather than 1 for the other log lines
3. Probably not very resilient to version changes, but considering the other added log lines will require opcode updates anyways, it's probably okay?