### PR TITLE
make `tools/fetch_deps.py` generate same output in different os

### DIFF
--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -180,10 +180,9 @@ def main(update_hashes=False):
 
 
 def archive_file_output_path(path: str, dest_path: str, archive_top_dir: str) -> str:
-    local_path = os.path.join(dest_path, os.path.relpath(path, archive_top_dir))
     # normpath only convert '/' to '\' on windows.
-    local_path = os.path.normpath(local_path.replace(ntpath.sep, posixpath.sep))
-    return local_path
+    local_path = os.path.join(dest_path, os.path.relpath(path.replace(ntpath.sep, posixpath.sep), archive_top_dir))
+    return os.path.normpath(local_path)
 
 
 if __name__ == '__main__':

--- a/tools/fetch_deps.py
+++ b/tools/fetch_deps.py
@@ -49,7 +49,7 @@ def main(update_hashes=False):
         sys.exit(1)
 
     deps_path = os.path.join(base, 'DEPS.py')
-    with open(deps_path, 'r') as stream:
+    with open(deps_path, 'r', encoding='utf-8') as stream:
         exec(stream.read(), scope)
 
     deps = scope.get('deps', {})
@@ -58,7 +58,7 @@ def main(update_hashes=False):
     dl_path = os.path.join(base, '.deps_dl')
 
     if os.path.isfile(cache_path):
-        with open(cache_path, 'r') as stream:
+        with open(cache_path, 'r', encoding='utf-8') as stream:
             cache = json.load(stream)
 
     old = set(cache.keys())
@@ -172,20 +172,20 @@ def main(update_hashes=False):
 
     finally:
         print('Saving dependency cache...')
-        with open(cache_path, 'w') as stream:
+        with open(cache_path, 'w', newline='\n') as stream:
             json.dump(cache, stream)
 
         if rep_map:
             print('Updating hashes...')
             print(rep_map)
 
-            with open(deps_path, 'r') as stream:
+            with open(deps_path, 'r', encoding='utf-8') as stream:
                 data = stream.read()
 
             for old, new in rep_map.items():
                 data = data.replace(old, new)
 
-            with open(deps_path, 'w') as stream:
+            with open(deps_path, 'w', newline='\n') as stream:
                 stream.write(data)
 
         print('Cleaning up...')


### PR DESCRIPTION
currently update hashes will generate DEPS.py with `crlf` EOL on windows, this pr make sure it always generate lf eol, same with committed file.

should also fix #24 , caused by different path separator