### PR TITLE
Adjust custom log lines per discussions

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -106,7 +106,8 @@ namespace RainbowMage.OverlayPlugin
                         if (lineParts.Length == 3)
                         {
                             uint lineID = UInt32.Parse(lineParts[0]);
-                            if (registry.ContainsKey(lineID))
+                            // Only reformat log line if it's not already formatted
+                            if (registry.ContainsKey(lineID) && logInfo.logLine != null && logInfo.logLine[0] != '[')
                             {
                                 ILogLineRegistryEntry entry = registry[lineID];
                                 if (entry.Source != "FFXIV_ACT_Plugin")

--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Advanced_Combat_Tracker;
 
 namespace RainbowMage.OverlayPlugin
 {
@@ -98,31 +97,6 @@ namespace RainbowMage.OverlayPlugin
                     var Name = entry.Name.Replace("\r", "\\r").Replace("\n", "\\n");
                     repository.WriteLogLineImpl(registeredCustomLogLineID, $"{registeredCustomLogLineID}|{Source}|{Name}|{entry.Version}");
                 }
-
-                ActGlobals.oFormActMain.BeforeLogLineRead += (isImport, logInfo) => {
-                    try
-                    {
-                        string[] lineParts = logInfo.originalLogLine.Split(new char[] { '|' }, 3);
-                        if (lineParts.Length == 3)
-                        {
-                            uint lineID = UInt32.Parse(lineParts[0]);
-                            // Only reformat log line if it's not already formatted
-                            if (registry.ContainsKey(lineID) && logInfo.logLine != null && logInfo.logLine[0] != '[')
-                            {
-                                ILogLineRegistryEntry entry = registry[lineID];
-                                if (entry.Source != "FFXIV_ACT_Plugin")
-                                {
-                                    logInfo.detectedType = (int)lineID;
-                                    logInfo.logLine = $"[{logInfo.detectedTime:HH:mm:ss.fff}] {entry.Name} {logInfo.detectedType:X8}:{lineParts[2].Replace('|', ':')}";
-                                }
-                            }
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        // TODO: Maybe log this with a max of 10 then stop logging?
-                    }
-                };
             } catch(Exception ex)
             {
                 logger.Log(LogLevel.Error, string.Format(Resources.ErrorCouldNotLoadReservedLogLines, ex));

--- a/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
@@ -86,6 +86,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             var customLogLines = container.Resolve<FFXIVCustomLogLines>();
             this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
             {
+                Name = "CEDirector",
                 Source = "OverlayPlugin",
                 ID = LogFileLineID,
                 Version = 1,

--- a/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
@@ -49,6 +49,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             var customLogLines = container.Resolve<FFXIVCustomLogLines>();
             this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
             {
+                Name = "FateDirector",
                 Source = "OverlayPlugin",
                 ID = LogFileLineID,
                 Version = 1,

--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -63,6 +63,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             var customLogLines = container.Resolve<FFXIVCustomLogLines>();
             this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
             {
+                Name = "MapEffect",
                 Source = "OverlayPlugin",
                 ID = LogFileLineID,
                 Version = 1,

--- a/OverlayPlugin.Core/NetworkProcessors/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/OverlayPluginLogLines.cs
@@ -21,6 +21,10 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private Dictionary<string, Dictionary<string, OpcodeConfigEntry>> config = new Dictionary<string, Dictionary<string, OpcodeConfigEntry>>();
         private ILogger logger;
         private FFXIVRepository repository;
+
+        private int exceptionCount = 0;
+        private const int maxExceptionsLogged = 3;
+
         public OverlayPluginLogLineConfig(TinyIoCContainer container)
         {
             logger = container.Resolve<ILogger>();
@@ -38,7 +42,11 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             }
             catch (Exception ex)
             {
-                logger.Log(LogLevel.Error, string.Format(Resources.ErrorCouldNotLoadReservedLogLines, ex));
+                if (exceptionCount < maxExceptionsLogged)
+                {
+                    ++exceptionCount;
+                    logger.Log(LogLevel.Error, string.Format(Resources.ErrorCouldNotLoadReservedLogLines, ex));
+                }
             }
         }
 
@@ -49,18 +57,30 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 var version = repository.GetGameVersion();
                 if (version == null)
                 {
-                    logger.Log(LogLevel.Error, "Could not detect game version from FFXIV_ACT_Plugin");
+                    if (exceptionCount < maxExceptionsLogged)
+                    {
+                        ++exceptionCount;
+                        logger.Log(LogLevel.Error, "Could not detect game version from FFXIV_ACT_Plugin");
+                    }
                     return null;
                 }
                 if (!config.ContainsKey(version))
                 {
-                    logger.Log(LogLevel.Error, $"No opcodes for game version {version}");
+                    if (exceptionCount < maxExceptionsLogged)
+                    {
+                        ++exceptionCount;
+                        logger.Log(LogLevel.Error, $"No opcodes for game version {version}");
+                    }
                     return null;
                 }
                 var versionOpcodes = config[version];
                 if (!versionOpcodes.ContainsKey(name))
                 {
-                    logger.Log(LogLevel.Error, $"No opcode for game version {version}, opcode name {name}");
+                    if (exceptionCount < maxExceptionsLogged)
+                    {
+                        ++exceptionCount;
+                        logger.Log(LogLevel.Error, $"No opcode for game version {version}, opcode name {name}");
+                    }
                     return null;
                 }
                 return versionOpcodes[name];

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -8,24 +8,28 @@
     },
     {
         "ID": 256,
+        "Name":  "RegisterLogLine",
         "Source": "OverlayPlugin",
         "Version": 1,
         "Comment": "Line to be emitted when a new log line is registered"
     },
     {
         "ID": 257,
+        "Name":  "MapEffect",
         "Source": "OverlayPlugin",
         "Version": 1,
         "Comment": "MapEffect data"
     },
     {
         "ID": 258,
+        "Name":  "FateDirector",
         "Source": "OverlayPlugin",
         "Version": 1,
         "Comment": "ActorControlSelf Fate data"
     },
     {
         "ID": 259,
+        "Name":  "CEDirector",
         "Source": "OverlayPlugin",
         "Version": 1,
         "Comment": "Critical Engagement data"


### PR DESCRIPTION
Per discussion with @quisquous, adjust custom log lines.
- Log entries now have a Name property, required for all instances except a range of reserved IDs.
- A 256 line is now written documenting that 256 lines exist
- Log level of the count of reserved log line IDs changed to debug
- New custom log lines now auto-formatted for use by custom triggers
![image](https://user-images.githubusercontent.com/6119598/191152551-716d6df3-3e32-4f9b-b3b7-cd58afaca54c.png)

These changes have not been tested in-game, only via importing log file.