### PR TITLE
Fix issues with using KR/CN lang on intl client

### DIFF
--- a/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
@@ -68,18 +68,17 @@ namespace RainbowMage.OverlayPlugin.EventSources
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void PickMemoryCandidates(FFXIVRepository repository)
         {
+            // For CN/KR, try the lang-specific candidate first, then fall back to intl
+            memoryCandidates = new List<EnmityMemory>();
             if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Chinese)
             {
-                memoryCandidates = new List<EnmityMemory>() { new EnmityMemory61(container) };
+                memoryCandidates.Add(new EnmityMemory61(container));
             }
             else if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Korean)
             {
-                memoryCandidates = new List<EnmityMemory>() { new EnmityMemory60(container) };
+                memoryCandidates.Add(new EnmityMemory60(container));
             }
-            else
-            {
-                memoryCandidates = new List<EnmityMemory>() { new EnmityMemory62(container) };
-            }
+            memoryCandidates.Add(new EnmityMemory62(container));
         }
 
         public override Control CreateConfigControl()

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -255,22 +255,24 @@ namespace RainbowMage.OverlayPlugin.EventSources
         }
 
         MemoryProcessors.EnmityMemory memory = null;
+        List<MemoryProcessors.EnmityMemory> memoryCandidates = null;
         private void CheckMemory()
         {
             if (memory == null || (memory != null && !memory.IsValid()))
             {
-                List<MemoryProcessors.EnmityMemory> memoryCandidates;
-                if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Chinese)
+                if (memoryCandidates == null)
                 {
-                    memoryCandidates = new List<MemoryProcessors.EnmityMemory>() { new MemoryProcessors.EnmityMemory61(container) };
-                }
-                else if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Korean)
-                {
-                    memoryCandidates = new List<MemoryProcessors.EnmityMemory>() { new MemoryProcessors.EnmityMemory60(container) };
-                }
-                else
-                {
-                    memoryCandidates = new List<MemoryProcessors.EnmityMemory>() { new MemoryProcessors.EnmityMemory62(container) };
+                    memoryCandidates = new List<MemoryProcessors.EnmityMemory>();
+                    // For CN/KR, try the lang-specific candidate first, then fall back to intl
+                    if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Chinese)
+                    {
+                        memoryCandidates.Add(new MemoryProcessors.EnmityMemory61(container));
+                    }
+                    else if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Korean)
+                    {
+                        memoryCandidates.Add(new MemoryProcessors.EnmityMemory60(container));
+                    }
+                    memoryCandidates.Add(new MemoryProcessors.EnmityMemory62(container));
                 }
 
                 foreach (var candidate in memoryCandidates)


### PR DESCRIPTION
Per report by @xpdota on discord <https://discord.com/channels/551474815727304704/594899820976668673/1023093964758331442>.

Try lang-specific version for scanning first, and if that fails fall back to intl version.

Also, in MiniParseEventSource, don't regenerate candidate list on every call to getCombatants when there's no valid memory, to allow rate limiting in candidate code to apply properly.