### PR TITLE
Use Machina for game region detection

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -88,10 +88,13 @@ namespace RainbowMage.OverlayPlugin.EventSources
             RegisterEventHandler("getLanguage", (msg) =>
             {
                 var lang = repository.GetLanguage();
+                var region = repository.GetMachinaRegion();
                 return JObject.FromObject(new
                 {
                     language = lang.ToString("g"),
                     languageId = lang.ToString("d"),
+                    region = region.ToString("g"),
+                    regionId = region.ToString("d"),
                 });
             });
             

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -57,6 +57,13 @@ namespace RainbowMage.OverlayPlugin
         Timer
     }
 
+    public enum GameRegion
+    {
+        Global = 1,
+        Chinese = 2,
+        Korean = 3
+    }
+
     class FFXIVRepository
     {
         private readonly ILogger logger;
@@ -299,6 +306,22 @@ namespace RainbowMage.OverlayPlugin
                 default:
                     return null;
             }
+        }
+
+        public GameRegion GetMachinaRegion()
+        {
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var opcode_manager_type = mach.GetType("Machina.FFXIV.Headers.Opcodes.OpcodeManager");
+                var opcode_manager = opcode_manager_type.GetProperty("Instance").GetValue(null);
+                var machina_region = opcode_manager_type.GetProperty("GameRegion").GetValue(opcode_manager).ToString();
+
+                if (Enum.TryParse<GameRegion>(machina_region, out var region))
+                    return region;
+            }
+            catch (Exception) { }
+            return GameRegion.Global;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
@@ -30,11 +30,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         {
             List<ICombatantMemory> candidates = new List<ICombatantMemory>();
             // For CN/KR, try the lang-specific candidate first, then fall back to intl
-            if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Chinese)
+            if (repository.GetMachinaRegion() == GameRegion.Chinese)
             {
                 candidates.Add(container.Resolve<ICombatantMemory61>());
             }
-            else if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Korean)
+            else if (repository.GetMachinaRegion() == GameRegion.Korean)
             {
                 candidates.Add(container.Resolve<ICombatantMemory60>());
             }

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
@@ -28,8 +28,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
             List<IEnmityHudMemory> candidates = new List<IEnmityHudMemory>();
             // For CN/KR, try the lang-specific candidate first, then fall back to intl
             if (
-                repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Chinese ||
-                repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Korean)
+                repository.GetMachinaRegion() == GameRegion.Chinese ||
+                repository.GetMachinaRegion() == GameRegion.Korean)
             {
                 candidates.Add(container.Resolve<IEnmityHudMemory60>());
             }

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
@@ -27,7 +27,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
         {
             List<IInCombatMemory> candidates = new List<IInCombatMemory>();
             // For CN, try the lang-specific candidate first, then fall back to intl
-            if (repository.GetLanguage() == FFXIV_ACT_Plugin.Common.Language.Korean)
+            if (repository.GetMachinaRegion() == GameRegion.Korean)
             {
                 candidates.Add(container.Resolve<IInCombatMemory60>());
             }


### PR DESCRIPTION
Additionally, added `region`/`regionId` to the `getLanguage` event handler, though I think this could go either way (e.g. new event handler).

Closes #88.