### PR TITLE
Enable custom log lines again

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -327,9 +327,6 @@ namespace RainbowMage.OverlayPlugin
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal bool WriteLogLineImpl(uint ID, string line)
         {
-            // TODO: re-enable this once https://github.com/anoyetta/ACT.Hojoring/issues/366 is fixed.
-            return false;
-
             if (logOutputWriteLineFunc == null)
             {
                 var plugin = GetPluginData();


### PR DESCRIPTION
FFXIV_ACT_Plugin 2.6.6.7 contains the formatting fixes, so re-enable these log lines.