### PR TITLE
Use server timestamp for writing log lines

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -95,7 +95,7 @@ namespace RainbowMage.OverlayPlugin
                     var entry = registry[registeredCustomLogLineID];
                     var Source = entry.Source.Replace("\r", "\\r").Replace("\n", "\\n");
                     var Name = entry.Name.Replace("\r", "\\r").Replace("\n", "\\n");
-                    repository.WriteLogLineImpl(registeredCustomLogLineID, $"{registeredCustomLogLineID}|{Source}|{Name}|{entry.Version}");
+                    repository.WriteLogLineImpl(registeredCustomLogLineID, DateTime.Now, $"{registeredCustomLogLineID}|{Source}|{Name}|{entry.Version}");
                 }
             } catch(Exception ex)
             {
@@ -103,7 +103,7 @@ namespace RainbowMage.OverlayPlugin
             }
         }
 
-        public Func<string, bool> RegisterCustomLogLine(ILogLineRegistryEntry entry)
+        public Func<string, DateTime, bool> RegisterCustomLogLine(ILogLineRegistryEntry entry)
         {
             // Don't allow any attempt to write a custom log line with FFXIV_ACT_Plugin as the source.
             // This prevents a downstream plugin from attempting to register e.g. `00` lines by just pretending to be FFXIV_ACT_Plugin.
@@ -126,15 +126,15 @@ namespace RainbowMage.OverlayPlugin
             // Write out that a new log line has been registered. Prevent newlines in the string input for sanity.
             var Source = entry.Source.Replace("\r", "\\r").Replace("\n", "\\n");
             var Name = entry.Name.Replace("\r", "\\r").Replace("\n", "\\n");
-            repository.WriteLogLineImpl(registeredCustomLogLineID, $"{ID}|{Source}|{Name}|{entry.Version}");
+            repository.WriteLogLineImpl(registeredCustomLogLineID, DateTime.Now, $"{ID}|{Source}|{Name}|{entry.Version}");
             registry[ID] = entry;
-            return (line) => {
+            return (line, timestamp) => {
                 if (line.Contains("\r") || line.Contains("\n"))
                 {
                     logger.Log(LogLevel.Warning, $"Attempted to write custom log line with CR or LF with ID of {ID}");
                     return false;
                 }
-                repository.WriteLogLineImpl(ID, line);
+                repository.WriteLogLineImpl(ID, timestamp, line);
                 return true;
             };
         }

--- a/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
@@ -56,13 +56,14 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private IOpcodeConfigEntry opcode = null;
         private readonly int offsetMessageType;
         private readonly int offsetPacketData;
+        private readonly FFXIVRepository ffxiv;
 
-        private Func<string, bool> logWriter;
+        private Func<string, DateTime, bool> logWriter;
 
         public LineCEDirector(TinyIoCContainer container)
         {
             logger = container.Resolve<ILogger>();
-            var ffxiv = container.Resolve<FFXIVRepository>();
+            ffxiv = container.Resolve<FFXIVRepository>();
             var netHelper = container.Resolve<NetworkParser>();
             if (!ffxiv.IsFFXIVPluginPresent())
                 return;
@@ -110,8 +111,9 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
                 {
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
                     CEDirector_v62 CEDirectorPacket = *(CEDirector_v62*)&buffer[offsetPacketData];
-                    logWriter(CEDirectorPacket.ToString());
+                    logWriter(CEDirectorPacket.ToString(), serverTime);
 
                     return;
                 }

--- a/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
@@ -12,13 +12,14 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private IOpcodeConfigEntry opcode = null;
         private readonly int offsetMessageType;
         private readonly int offsetPacketData;
+        private readonly FFXIVRepository ffxiv;
 
         private const ushort FateAddCategory = 0x935;
         private const ushort FateRemoveCategory = 0x936;
         private const ushort FateUpdateCategory = 0x93E;
         private static readonly List<ushort> FateCategories = new List<ushort>() { FateAddCategory, FateRemoveCategory, FateUpdateCategory };
 
-        private Func<string, bool> logWriter;
+        private Func<string, DateTime, bool> logWriter;
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         public struct ActorControlSelf_v62
@@ -42,7 +43,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         public LineFateControl(TinyIoCContainer container)
         {
             logger = container.Resolve<ILogger>();
-            var ffxiv = container.Resolve<FFXIVRepository>();
+            ffxiv = container.Resolve<FFXIVRepository>();
             var netHelper = container.Resolve<NetworkParser>();
             if (!ffxiv.IsFFXIVPluginPresent())
                 return;
@@ -90,6 +91,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     ActorControlSelf_v62 mapEffectPacket = *(ActorControlSelf_v62*)&buffer[offsetPacketData];
                     if (FateCategories.Contains(mapEffectPacket.category))
                     {
+                        DateTime serverTime = ffxiv.EpochToDateTime(epoch);
                         string category = "";
                         switch (mapEffectPacket.category)
                         {
@@ -112,7 +114,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                             $"{mapEffectPacket.param4:X8}|" +
                             $"{mapEffectPacket.param5:X8}|" +
                             $"{mapEffectPacket.param6:X8}|" +
-                            $"{mapEffectPacket.padding1:X8}"
+                            $"{mapEffectPacket.padding1:X8}",
+                            serverTime
                         );
                     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -33,13 +33,14 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private IOpcodeConfigEntry opcode = null;
         private readonly int offsetMessageType;
         private readonly int offsetPacketData;
+        private readonly FFXIVRepository ffxiv;
 
-        private Func<string, bool> logWriter;
+        private Func<string, DateTime, bool> logWriter;
 
         public LineMapEffect(TinyIoCContainer container)
         {
             logger = container.Resolve<ILogger>();
-            var ffxiv = container.Resolve<FFXIVRepository>();
+            ffxiv = container.Resolve<FFXIVRepository>();
             var netHelper = container.Resolve<NetworkParser>();
             if (!ffxiv.IsFFXIVPluginPresent())
                 return;
@@ -87,8 +88,9 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
                 {
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
                     MapEffect_v62 mapEffectPacket = *(MapEffect_v62*)&buffer[offsetPacketData];
-                    logWriter(mapEffectPacket.ToString());
+                    logWriter(mapEffectPacket.ToString(), serverTime);
 
                     return;
                 }


### PR DESCRIPTION
Per discord discussion, use server epoch time to write custom log lines, also allow downstream callers to pass in a datetime.