### PR TITLE
Fix timestamps for custom log lines not using local timezone

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -342,7 +342,7 @@ namespace RainbowMage.OverlayPlugin
                     logger.Log(LogLevel.Error, e.ToString());
                 }
             }
-            return machinaEpochToDateTimeWrapper(epoch);
+            return machinaEpochToDateTimeWrapper(epoch).ToLocalTime();
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
I thought it was better to fix this at the most common point, rather than requiring every caller to fix the timezone.