### PR TITLE
add parts of type definition

### DIFF
--- a/docs/assets/shared/index.d.ts
+++ b/docs/assets/shared/index.d.ts
@@ -1,0 +1,22 @@
+export interface Party {
+  id: string;
+  name: string;
+  worldId: number;
+  job: number;
+  inParty: boolean;
+}
+
+declare global {
+  namespace OverlayPlugin {
+    function addOverlayListener(event: 'LogLine', cb: (ev: { type: 'LogLine'; line: string[]; rawLine: string; }) => void): void;
+    function addOverlayListener(event: 'PartyChanged', cb: (ev: { type: 'PartyChanged'; party: Party[]; }) => void): void;
+
+    function callOverlayHandler(msg: { call: 'saveData'; key: string; data: unknown }): Promise<void>;
+    function callOverlayHandler<T = unknown>(msg: { call: 'loadData'; key: string; }): Promise<({ data?: T } | undefined)>;
+  }
+
+  const callOverlayHandler: typeof OverlayPlugin.callOverlayHandler;
+  const addOverlayListener: typeof OverlayPlugin.addOverlayListener;
+}
+
+export {};


### PR DESCRIPTION
ref: https://github.com/quisquous/cactbot/issues/4916

Some type definition in cactbot are actually provided by overlay plugin, I think we can move them here and add more document about them.