### PR TITLE
Add generic memory version sorter

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory.cs
@@ -203,5 +203,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
             return result;
         }
 
+        public abstract Version GetVersion();
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory.cs
@@ -83,6 +83,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
             return;
         }
 
+        public abstract Version GetVersion();
+
         [StructLayout(LayoutKind.Explicit, Size = Size)]
         struct MemoryAggroListEntry
         {
@@ -202,7 +204,5 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
             }
             return result;
         }
-
-        public abstract Version GetVersion();
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory60.cs
@@ -1,4 +1,6 @@
-﻿namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
+﻿using System;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
 {
     interface IAggroMemory60 : IAggroMemory {}
 
@@ -10,5 +12,9 @@
         public AggroMemory60(TinyIoCContainer container)
             : base(container, Enmity.EnmityMemory60.enmitySignature, aggroEnmityOffset)
         { }
+
+        public override Version GetVersion() {
+            return new Version(6, 0);
+        }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
@@ -4,12 +4,9 @@ using System.Diagnostics;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
 {
-    public interface IAggroMemory
+    public interface IAggroMemory : IVersionedMemory
     {
         List<AggroEntry> GetAggroList(List<Combatant.Combatant> combatantList);
-
-        void ScanPointers();
-        bool IsValid();
     }
 
     public class AggroMemoryManager : IAggroMemory
@@ -42,16 +39,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
         {
             List<IAggroMemory> candidates = new List<IAggroMemory>();
             candidates.Add(container.Resolve<IAggroMemory60>());
-
-            foreach (var c in candidates)
-            {
-                c.ScanPointers();
-                if (c.IsValid())
-                {
-                    memory = c;
-                    break;
-                }
-            }
+            memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
         }
 
         public bool IsValid()
@@ -70,6 +58,12 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
                 return null;
             }
             return memory.GetAggroList(combatantList);
+        }
+
+        Version IVersionedMemory.GetVersion() {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
@@ -51,6 +51,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
             return true;
         }
 
+        Version IVersionedMemory.GetVersion()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
+        }
+
         public List<AggroEntry> GetAggroList(List<Combatant.Combatant> combatantList)
         {
             if (!IsValid())
@@ -58,12 +65,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
                 return null;
             }
             return memory.GetAggroList(combatantList);
-        }
-
-        Version IVersionedMemory.GetVersion() {
-            if (!IsValid())
-                return null;
-            return memory.GetVersion();
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
@@ -90,6 +90,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             return;
         }
 
+        public abstract Version GetVersion();
+
         public Combatant GetSelfCombatant()
         {
             IntPtr address = memory.ReadIntPtr(charmapAddress);

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
@@ -15,6 +15,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         {
             
         }
+
+        public override Version GetVersion() {
+            return new Version(6, 1);
+        }
+
         // Returns a combatant if the combatant is a mob or a PC.
         protected override unsafe Combatant GetMobFromByteArray(byte[] source, uint mycharID)
         {

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
@@ -15,6 +15,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         {
             
         }
+
+        public override Version GetVersion() {
+            return new Version(6, 2);
+        }
+
         // Returns a combatant if the combatant is a mob or a PC.
         protected override unsafe Combatant GetMobFromByteArray(byte[] source, uint mycharID)
         {

--- a/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemory.cs
@@ -79,6 +79,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
             return;
         }
 
+        public abstract Version GetVersion();
+
         [StructLayout(LayoutKind.Explicit, Size = Size)]
         struct MemoryEnmityListEntry
         {

--- a/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemory60.cs
@@ -1,4 +1,6 @@
-﻿namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
+﻿using System;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
 {
     interface IEnmityMemory60 : IEnmityMemory {}
 
@@ -10,5 +12,9 @@
         public EnmityMemory60(TinyIoCContainer container)
             : base(container, enmitySignature, enmitySignatureOffset)
         { }
+
+        public override Version GetVersion() {
+            return new Version(6, 0);
+        }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemoryManager.cs
@@ -1,14 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
 {
-    public interface IEnmityMemory
+    public interface IEnmityMemory : IVersionedMemory
     {
         List<EnmityEntry> GetEnmityEntryList(List<Combatant.Combatant> combatantList);
-
-        void ScanPointers();
-        bool IsValid();
     }
 
     public class EnmityMemoryManager : IEnmityMemory
@@ -41,16 +39,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
         {
             List<IEnmityMemory> candidates = new List<IEnmityMemory>();
             candidates.Add(container.Resolve<IEnmityMemory60>());
-
-            foreach (var c in candidates)
-            {
-                c.ScanPointers();
-                if (c.IsValid())
-                {
-                    memory = c;
-                    break;
-                }
-            }
+            memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
         }
 
         public bool IsValid()
@@ -60,6 +49,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
                 return false;
             }
             return true;
+        }
+
+        Version IVersionedMemory.GetVersion()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
         }
 
         public List<EnmityEntry> GetEnmityEntryList(List<Combatant.Combatant> combatantList)

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory.cs
@@ -89,6 +89,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
             return;
         }
 
+        public abstract Version GetVersion();
+
         private bool GetDynamicPointerAddress()
         {
             if (enmityHudAddress == IntPtr.Zero) return false;

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory60.cs
@@ -18,6 +18,10 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
             : base(container, enmityHudSignature, enmityHudPointerPath, enmityHudCountOffset, enmityHudEntryOffset, EnmityHudEntryMemory.Size)
         { }
 
+        public override Version GetVersion() {
+            return new Version(6, 0);
+        }
+
         [StructLayout(LayoutKind.Explicit, Size = Size)]
         struct EnmityHudEntryMemory
         {

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory62.cs
@@ -18,6 +18,10 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
             : base(container, enmityHudSignature, enmityHudPointerPath, enmityHudCountOffset, enmityHudEntryOffset, EnmityHudEntryMemory.Size)
         { }
 
+        public override Version GetVersion() {
+            return new Version(6, 2);
+        }
+
         [StructLayout(LayoutKind.Explicit, Size = Size)]
         struct EnmityHudEntryMemory
         {

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
@@ -1,14 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
 {
-    public interface IEnmityHudMemory
+    public interface IEnmityHudMemory : IVersionedMemory
     {
         List<EnmityHudEntry> GetEnmityHudEntries();
-
-        void ScanPointers();
-        bool IsValid();
     }
 
     public class EnmityHudMemoryManager : IEnmityHudMemory
@@ -41,24 +39,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
         public void ScanPointers()
         {
             List<IEnmityHudMemory> candidates = new List<IEnmityHudMemory>();
-            // For CN/KR, try the lang-specific candidate first, then fall back to intl
-            if (
-                repository.GetMachinaRegion() == GameRegion.Chinese ||
-                repository.GetMachinaRegion() == GameRegion.Korean)
-            {
-                candidates.Add(container.Resolve<IEnmityHudMemory60>());
-            }
+            candidates.Add(container.Resolve<IEnmityHudMemory60>());
             candidates.Add(container.Resolve<IEnmityHudMemory62>());
-
-            foreach (var c in candidates)
-            {
-                c.ScanPointers();
-                if (c.IsValid())
-                {
-                    memory = c;
-                    break;
-                }
-            }
+            memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
         }
 
         public bool IsValid()
@@ -68,6 +51,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
                 return false;
             }
             return true;
+        }
+
+        Version IVersionedMemory.GetVersion()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
         }
 
         public List<EnmityHudEntry> GetEnmityHudEntries()

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -1,10 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors
 {
+    public interface IVersionedMemory
+    {
+        Version GetVersion();
+        void ScanPointers();
+        bool IsValid();
+    }
+
     public class FFXIVMemory
     {
         private event EventHandler<Process> OnProcessChange;
@@ -13,6 +21,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         private Process process;
         private IntPtr processHandle;
         private FFXIVRepository repository;
+
+        // The "international" version always uses the most recent.
+        private static Version globalVersion = new Version(99, 0);
+        private static Version cnVersion = new Version(6, 2);
+        private static Version koVersion = new Version(6, 1);
 
         public FFXIVMemory(TinyIoCContainer container)
         {
@@ -350,6 +363,57 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             }
 
             return matches_list;
+        }
+
+        // Returns the best candidate from a list of versioned memory candidates.
+        // Side effect: this function sorts the list provided in place.
+        public static T FindCandidate<T>(List<T> candidates, GameRegion region) where T : IVersionedMemory
+        {
+            // General algorithm, for a given desired version X:
+            // 1) return the first element <= X
+            // 2) return elements after X in ascending order
+            // 3) return elements before X in descending order (just in case)
+            //
+            // e.g. if X = 6.1 with [5.2, null, 5.3, 6.0, 6.2] return 6.0, 6.2, 5.3, 5.2
+
+            Version target;
+            if (region == GameRegion.Chinese)
+                target = cnVersion;
+            else if (region == GameRegion.Korean)
+                target = koVersion;
+            else
+                target = globalVersion;
+
+            candidates.OrderBy(x => x.GetVersion());
+            int idx = candidates.FindIndex(x => x.GetVersion() > target);
+
+            // If not found, all candidates are <= target version, so walk in descending order.
+            // If found, then idx is the first candidate larger than target, so try to
+            // start on the candidate before it.
+            if (idx == -1)
+                idx = candidates.Count;
+            else
+                idx = Math.Max(idx - 1, 0);
+
+            for (var i = idx; i < candidates.Count; ++i)
+            {
+                var candidate = candidates[i];
+                candidate.ScanPointers();
+                if (candidate.IsValid())
+                    return candidate;
+            }
+
+            if (idx == 0)
+                return default(T);
+
+            for (var i = idx - 1; i >= 0; ++i)
+            {
+                var candidate = candidates[i];
+                candidate.ScanPointers();
+                if (candidate.IsValid())
+                    return candidate;
+            }
+            return default(T);
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -366,7 +366,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         }
 
         // Returns the best candidate from a list of versioned memory candidates.
-        // Side effect: this function sorts the list provided in place.
         public static T FindCandidate<T>(List<T> candidates, GameRegion region) where T : IVersionedMemory
         {
             // General algorithm, for a given desired version X:
@@ -374,7 +373,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             // 2) return elements after X in ascending order
             // 3) return elements before X in descending order (just in case)
             //
-            // e.g. if X = 6.1 with [5.2, null, 5.3, 6.0, 6.2] return 6.0, 6.2, 5.3, 5.2
+            // e.g. if X = 6.1 with [5.2, 5.3, 6.0, 6.2] return 6.0, 6.2, 5.3, 5.2
 
             Version target;
             if (region == GameRegion.Chinese)
@@ -384,7 +383,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             else
                 target = globalVersion;
 
-            candidates.OrderBy(x => x.GetVersion());
+            candidates = candidates.OrderBy(x => x.GetVersion()).ToList();
             int idx = candidates.FindIndex(x => x.GetVersion() > target);
 
             // If not found, all candidates are <= target version, so walk in descending order.

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -395,7 +395,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             else
                 idx = Math.Max(idx - 1, 0);
 
-            for (var i = idx; i < candidates.Count; ++i)
+            for (var i = idx; i < candidates.Count; i++)
             {
                 var candidate = candidates[i];
                 candidate.ScanPointers();
@@ -406,7 +406,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
             if (idx == 0)
                 return default(T);
 
-            for (var i = idx - 1; i >= 0; ++i)
+            for (var i = idx - 1; i >= 0; i--)
             {
                 var candidate = candidates[i];
                 candidate.ScanPointers();

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemory.cs
@@ -80,6 +80,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
             return;
         }
 
+        public abstract Version GetVersion();
+
         public bool GetInCombat()
         {
             if (!IsValid())

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemory61.cs
@@ -1,4 +1,6 @@
-﻿namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
+﻿using System;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
 {
     interface IInCombatMemory61 : IInCombatMemory {}
 
@@ -8,5 +10,10 @@
         private const int inCombatSignatureOffset = -12;
         private const int inCombatRIPOffset = 1;
         public InCombatMemory61(TinyIoCContainer container) : base(container, inCombatSignature, inCombatSignatureOffset, inCombatRIPOffset) { }
+
+        public override Version GetVersion() {
+            return new Version(6, 1);
+        }
+
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
@@ -1,14 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
 {
-    public interface IInCombatMemory
+    public interface IInCombatMemory : IVersionedMemory
     {
         bool GetInCombat();
-
-        void ScanPointers();
-        bool IsValid();
     }
 
     class InCombatMemoryManager : IInCombatMemory
@@ -41,16 +39,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
         {
             List<IInCombatMemory> candidates = new List<IInCombatMemory>();
             candidates.Add(container.Resolve<IInCombatMemory61>());
-
-            foreach (var c in candidates)
-            {
-                c.ScanPointers();
-                if (c.IsValid())
-                {
-                    memory = c;
-                    break;
-                }
-            }
+            memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
         }
 
         public bool IsValid()
@@ -60,6 +49,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
                 return false;
             }
             return true;
+        }
+
+        Version IVersionedMemory.GetVersion()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
         }
 
         public bool GetInCombat()


### PR DESCRIPTION
Rather than adding explicit logic to every single FooMemoryManager for which FooMemoryXX to use, make FooMemoryXX implement a new IVersionedMemory interface which can be sorted generically.

This will let the best candidate be picked first (for performance) and then after that checking other candidates so that OverlayPlugin will continue to work for updated regions in the short term without an OverlayPlugin update.

For performance reasons, we should still update OverlayPlugin's built-in version when we can, but this will help with transitions.