### PR TITLE
Fix bug with `TargetID` calculation

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
@@ -68,7 +68,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     Heading = mem.Heading,
                     Radius = mem.Radius,
                     // In-memory there are separate values for PC's current target and NPC's current target
-                    TargetID = mem.PCTargetID != 0xE0000000 ? mem.PCTargetID : mem.NPCTargetID,
+                    TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
                     Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
@@ -68,7 +68,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     Heading = mem.Heading,
                     Radius = mem.Radius,
                     // In-memory there are separate values for PC's current target and NPC's current target
-                    TargetID = mem.PCTargetID != 0xE0000000 ? mem.PCTargetID : mem.NPCTargetID,
+                    TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
                     Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),


### PR DESCRIPTION
As reported on Discord here:
<https://discord.com/channels/551474815727304704/594899820976668673/1028759365643153568>

We might want a multi-layered logic approach here, I'm not sure what's best. Previously OP didn't have to deal with this difference and just treated `TargetID` as `NPCTargetID` at all times, but that's not correct for PCs.