### PR TITLE
Added GameVersion event

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -47,6 +47,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
         private const string ImportedLogLinesEvent = "ImportedLogLines";
         private const string ChangeZoneEvent = "ChangeZone";
         private const string ChangeMapEvent = "ChangeMap";
+        private const string GameVersionEvent = "GameVersion";
         private const string ChangePrimaryPlayerEvent = "ChangePrimaryPlayer";
         private const string FileChangedEvent = "FileChanged";
         private const string OnlineStatusChangedEvent = "OnlineStatusChanged";
@@ -80,6 +81,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 ChangePrimaryPlayerEvent,
                 ChangeZoneEvent,
                 ChangeMapEvent,
+                GameVersionEvent,
                 OnlineStatusChangedEvent,
                 PartyChangedEvent,
             });
@@ -476,6 +478,14 @@ namespace RainbowMage.OverlayPlugin.EventSources
                         {
                             StopACTCombat();
                         }
+                        break;
+                    case LogMessageType.Process:
+                        var gameVersion = repository.GetGameVersion();
+                        DispatchAndCacheEvent(JObject.FromObject(new
+                        {
+                            type = GameVersionEvent,
+                            gameVersion
+                        }));
                         break;
                 }
 


### PR DESCRIPTION
Example:
```
>>> {"call":"subscribe","events":["GameVersion"]}

<<< {"type":"GameVersion","gameVersion":"2022.11.09.0000.0000"}
```

The only oddity is that I'm grabbing the version from the FFXIV plugin directly, rather than the log line. This avoids having to come up with a regex to parse the individual bits of the log line (e.g. `Detected Process ID: 24908, Client Mode: FFXIV_64, IsAdmin: True, Game Version: 2022.11.09.0000.0000`). 