### PR TITLE
Added playSound event handler.

### DIFF
--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -179,6 +179,16 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 ActGlobals.oFormActMain.TTS(text);
                 return null;
             });
+            
+            RegisterEventHandler("playSound", (msg) =>
+            {
+                var file = msg["file"]?.ToString();
+                if (file == null)
+                    return null;
+
+                ActGlobals.oFormActMain.PlaySound(file);
+                return null;
+            });
 
             RegisterEventHandler("broadcast", (msg) =>
             {

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -179,7 +179,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 ActGlobals.oFormActMain.TTS(text);
                 return null;
             });
-            
+
             RegisterEventHandler("playSound", (msg) =>
             {
                 var file = msg["file"]?.ToString();


### PR DESCRIPTION
Closes #151

Example:

```json
{
  "call": "playSound",
  "file": "C:\\Users\\Foo\\Documents\\sonar.wav"
}
```

It just calls `ActGlobals.oFormActMain.PlaySound(file)`, which uses whatever sound settings are configured in ACT. Main motivation is to support the ACT to Discord bridge. OP works fine with it for TTS, but does not have a way of playing sounds through ACT.