### PR TITLE
Use FindCandidate for TargetMemory

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory60.cs
@@ -1,4 +1,6 @@
-﻿namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
+﻿using System;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
 {
     interface ITargetMemory60 : ITargetMemory { }
 
@@ -14,5 +16,10 @@
         public TargetMemory60(TinyIoCContainer container)
             : base(container, targetSignature, targetTargetOffset, focusTargetOffset, hoverTargetOffset)
         { }
+
+        public override Version GetVersion()
+        {
+            return new Version(6, 0);
+        }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory63.cs
@@ -1,4 +1,6 @@
-﻿namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
+﻿using System;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
 {
     interface ITargetMemory63 : ITargetMemory { }
 
@@ -14,5 +16,10 @@
         public TargetMemory63(TinyIoCContainer container)
             : base(container, targetSignature, targetTargetOffset, focusTargetOffset, hoverTargetOffset)
         { }
+
+        public override Version GetVersion()
+        {
+            return new Version(6, 3);
+        }
     }
 }


### PR DESCRIPTION
The target memory offsets from #155 are good, however it does not end
up ever scanning for the pointers and continually tries looking
checking addresses that are always zero.

TargetMemory apparently(?) was never updated to use FindCandidate
and implemented it manually, so have it do the same dance as well.