### PR TITLE
Bump aers/FFXIVClientStructs to latest

### DIFF
--- a/DEPS.py
+++ b/DEPS.py
@@ -22,9 +22,9 @@ deps = {
         'hash': ['sha256', '032f43f2674008c761af19bf536374128c16241fb234699a55f9fb603fcfbae7'],
     },
     'FFXIVClientStructs': {
-        'url': 'https://github.com/aers/FFXIVClientStructs/archive/300b9c5401ebf67015517ba4a38c25b4a993bb7f.zip',
+        'url': 'https://github.com/aers/FFXIVClientStructs/archive/08e6c7ed7747ad68a38e5762863b5874fe04b8b8.zip',
         'dest': 'OverlayPlugin.Core/Thirdparty/FFXIVClientStructs/Global',
         'strip': 1,
-        'hash': ['sha256', '38c25a7cd3fba30fdc1f596a1f096e159d141385f197a89a54d3cbb76a8c466b'],
+        'hash': ['sha256', 'b6d73da57240717876eff07fca5489644698dcc894eda58b32d2852b172badac'],
     },
 }

--- a/DEPS.py
+++ b/DEPS.py
@@ -22,9 +22,9 @@ deps = {
         'hash': ['sha256', '032f43f2674008c761af19bf536374128c16241fb234699a55f9fb603fcfbae7'],
     },
     'FFXIVClientStructs': {
-        'url': 'https://github.com/aers/FFXIVClientStructs/archive/9cb2eb33826f62f7e3525e1f6ca08a974b35c76b.zip',
+        'url': 'https://github.com/aers/FFXIVClientStructs/archive/300b9c5401ebf67015517ba4a38c25b4a993bb7f.zip',
         'dest': 'OverlayPlugin.Core/Thirdparty/FFXIVClientStructs/Global',
         'strip': 1,
-        'hash': ['sha256', '8c9307a01a479f6253ad205fffe8a711302d5c6418fded4b7044919f8ce42269'],
+        'hash': ['sha256', '38c25a7cd3fba30fdc1f596a1f096e159d141385f197a89a54d3cbb76a8c466b'],
     },
 }

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Templates/STD.Set.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Templates/STD.Set.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics;
+
+using System;
+using System.Runtime.InteropServices;
+using FFXIVClientStructs.Global.STD;
+using FFXIVClientStructs.Global.FFXIV.Client.Graphics;
+using FFXIVClientStructs.Global.FFXIV.Common.Math;
+namespace FFXIVClientStructs.Global.STD { 
+
+[StructLayout(LayoutKind.Sequential, Size = 0x10)]
+public unsafe struct StdSet{
+	public void* Head;
+	public ulong Count;
+}}
+
+

--- a/OverlayPlugin.sln
+++ b/OverlayPlugin.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OverlayPlugin", "OverlayPlu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OverlayPlugin.Updater", "OverlayPlugin.Updater\OverlayPlugin.Updater.csproj", "{82B1D288-51A6-411F-A5F9-E37C6A72E7DA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StripFFXIVClientStructs", "tools\StripFFXIVClientStructs\StripFFXIVClientStructs\StripFFXIVClientStructs.csproj", "{F826ED1A-187A-484F-ABE4-D794E5CE0F50}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{924C9C51-F027-44E7-93DA-BD120F3CCBB5}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -104,6 +106,17 @@ Global
 		{82B1D288-51A6-411F-A5F9-E37C6A72E7DA}.Release|x64.Build.0 = Release|Any CPU
 		{82B1D288-51A6-411F-A5F9-E37C6A72E7DA}.Release|x86.ActiveCfg = Release|Any CPU
 		{82B1D288-51A6-411F-A5F9-E37C6A72E7DA}.Release|x86.Build.0 = Release|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Debug|x64.Build.0 = Debug|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Debug|x86.Build.0 = Debug|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|x64.ActiveCfg = Release|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|x64.Build.0 = Release|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|x86.ActiveCfg = Release|Any CPU
+		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs.sln
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32413.511
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StripFFXIVClientStructs", "StripFFXIVClientStructs\StripFFXIVClientStructs.csproj", "{5AB0FC30-6618-4E51-87F5-D25F94FA303A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5AB0FC30-6618-4E51-87F5-D25F94FA303A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AB0FC30-6618-4E51-87F5-D25F94FA303A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AB0FC30-6618-4E51-87F5-D25F94FA303A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AB0FC30-6618-4E51-87F5-D25F94FA303A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F594E39D-35E2-4A97-A5FA-AC4DD1A70253}
+	EndGlobalSection
+EndGlobal

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace StripFFXIVClientStructs
 {

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -1,0 +1,172 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.IO;
+using System.Linq;
+
+namespace StripFFXIVClientStructs
+{
+    class StripFFXIVClientStructs
+    {
+        private static SyntaxKind[] KeepKinds = new SyntaxKind[] {
+            SyntaxKind.CompilationUnit, // Top-level/root object
+            SyntaxKind.UsingDirective, // `using` statements
+            SyntaxKind.FileScopedNamespaceDeclaration, // `namespace` statements + child objects
+            SyntaxKind.NamespaceDeclaration,
+            SyntaxKind.QualifiedName, // `namespace` name values
+            SyntaxKind.IdentifierName, // various name tokens
+            SyntaxKind.StructDeclaration, // actual struct declaration
+            SyntaxKind.AttributeList, // Attribute lists e.g. `[StructLayout], []...`
+            SyntaxKind.Attribute, // Attribute declaration
+            SyntaxKind.FieldDeclaration,
+            SyntaxKind.EnumDeclaration,
+            SyntaxKind.BaseList,
+            SyntaxKind.SimpleBaseType,
+            SyntaxKind.PredefinedType,
+            SyntaxKind.EnumMemberDeclaration,
+            SyntaxKind.EqualsValueClause,
+            SyntaxKind.NumericLiteralExpression,
+            SyntaxKind.UnaryMinusExpression,
+            SyntaxKind.GenericName,
+            SyntaxKind.TypeArgumentList,
+            SyntaxKind.LeftShiftExpression,
+            SyntaxKind.BitwiseOrExpression,
+            SyntaxKind.InterfaceDeclaration,
+            SyntaxKind.ParenthesizedExpression,
+            SyntaxKind.VariableDeclaration,
+            SyntaxKind.PointerType,
+            SyntaxKind.VariableDeclarator,
+            SyntaxKind.BracketedArgumentList,
+            SyntaxKind.Argument,
+            SyntaxKind.MultiplyExpression,
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxKind.ArgumentList,
+            SyntaxKind.ObjectInitializerExpression,
+            SyntaxKind.SimpleAssignmentExpression,
+            SyntaxKind.DivideExpression,
+            SyntaxKind.CastExpression,
+            SyntaxKind.FunctionPointerType,
+            SyntaxKind.FunctionPointerParameterList,
+            SyntaxKind.FunctionPointerParameter,
+        };
+        private static SyntaxKind[] DiscardKinds = new SyntaxKind[] {
+            SyntaxKind.TypeParameterList, // Type parameters for objects and funcs, e.g. `<T>` in `struct A<T>`
+            SyntaxKind.TypeParameterConstraintClause, // Type parameters for objects and funcs, e.g. `where T : unmanaged` in `struct A<T> where T : unmanaged`
+            SyntaxKind.PropertyDeclaration,
+            SyntaxKind.MethodDeclaration,
+            SyntaxKind.ConstructorDeclaration,
+            SyntaxKind.AttributeTargetSpecifier,
+            SyntaxKind.ClassDeclaration,
+            SyntaxKind.IncompleteMember,
+            SyntaxKind.GlobalStatement,
+            SyntaxKind.ConversionOperatorDeclaration,
+            SyntaxKind.RecordDeclaration,
+            SyntaxKind.IndexerDeclaration,
+            SyntaxKind.OperatorDeclaration,
+            SyntaxKind.DelegateDeclaration,
+            SyntaxKind.ImplicitObjectCreationExpression,
+        };
+        private static string[] KeepAttributes = new string[] {
+            "StructLayout",
+            "FieldOffset",
+        };
+        private static string[] DiscardAttributes = new string[] {
+            "DisableRuntimeMarshalling",
+            "Flags",
+            "",
+            "Addon",
+            "Agent",
+            "Obsolete",
+            "FixedArray",
+        };
+
+        static void Main(string[] args)
+        {
+            if (args.Length < 1)
+            {
+                System.Console.WriteLine("Missing required path");
+                return;
+            }
+            var path = args[0];
+            if (!Directory.Exists(path))
+            {
+                System.Console.WriteLine($"Path {path} does not exist");
+                return;
+            }
+            foreach (var file in Directory.GetFiles(path, "*.cs", SearchOption.AllDirectories))
+            {
+                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file));
+                var root = tree.GetRoot();
+                var outTree = recurseNode(root);
+                File.WriteAllText(file, outTree.ToString());
+            }
+            return;
+        }
+
+        private static SyntaxNode recurseNode(SyntaxNode root)
+        {
+            var rootKind = root.Kind();
+            if (!KeepKinds.Contains(rootKind))
+            {
+                if (!DiscardKinds.Contains(rootKind))
+                {
+                    throw new System.Exception($"Unknown type {rootKind}");
+                }
+                return null;
+            }
+            switch (rootKind)
+            {
+                case SyntaxKind.UsingDirective:
+                case SyntaxKind.QualifiedName:
+                case SyntaxKind.IdentifierName:
+                    return root;
+                case SyntaxKind.Attribute:
+                    var attributeName = root.ChildNodes().First().ToString();
+                    if (!KeepAttributes.Contains(attributeName))
+                    {
+                        if (!DiscardAttributes.Contains(attributeName))
+                        {
+                            throw new System.Exception($"Unknown attribute {attributeName}");
+                        }
+                        return null;
+                    }
+                    return root;
+                case SyntaxKind.FieldDeclaration:
+                    if (root.ToString().Contains(" = new("))
+                    {
+                        return null;
+                    }
+                    break;
+            }
+            // There's probably a better way to handle this
+            var dirty = true;
+            while (dirty)
+            {
+                dirty = false;
+                foreach (var node in root.ChildNodes().ToList())
+                {
+                    var newNode = recurseNode(node);
+                    if (newNode != node)
+                    {
+                        if (newNode != null)
+                        {
+                            if (newNode.ToString() == node.ToString())
+                            {
+                                continue;
+                            }
+                            root = root.ReplaceNode(node, newNode);
+                        }
+                        else
+                        {
+                            root = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
+                        }
+                        // Re-loop, this node set has been modified
+                        dirty = true;
+                        break;
+                    }
+                }
+            }
+
+            return root;
+        }
+    }
+}

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -77,6 +77,7 @@ namespace StripFFXIVClientStructs
             "Agent",
             "Obsolete",
             "FixedArray",
+            "FixedSizeArray",
         };
 
         static void Main(string[] args)
@@ -120,7 +121,7 @@ namespace StripFFXIVClientStructs
                 case SyntaxKind.IdentifierName:
                     return root;
                 case SyntaxKind.Attribute:
-                    var attributeName = root.ChildNodes().First().ToString();
+                    var attributeName = root.ChildNodes().First().GetFirstToken().ToString();
                     if (!KeepAttributes.Contains(attributeName))
                     {
                         if (!DiscardAttributes.Contains(attributeName))

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0-2.final" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR bumps the FFXIVClientStructs to the latest commit as of 2023-01-11 23:20:00.

This PR also includes a rework to the way the files are being stripped and prepped to do much of the heavy lifting via Roslyn's AST tools.

I'd like to move the rest of the logic over to this as well but don't have the time to do so currently.

(Also this shows a .NET Core 3.1 project existing alongside the current projects, which works fine as long as the newer project isn't directly referenced by the older projects as an assembly).