### PR TITLE
Ignore errors when loading FFXIV_ACT_Plugin in various places

### DIFF
--- a/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
@@ -53,7 +53,12 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         public EnmityEventSource(TinyIoCContainer container) : base(container)
         {
-            combatantMemory = container.Resolve<ICombatantMemory>();
+            var haveCombatantMemory = container.TryResolve(out combatantMemory);
+            if (!haveCombatantMemory)
+            {
+                Log(LogLevel.Warning, "Could not construct EnmityEventSource: missing combatantMemory");
+                return;
+            }
             targetMemory = container.Resolve<ITargetMemory>();
             enmityMemory = container.Resolve<IEnmityMemory>();
             aggroMemory = container.Resolve<IAggroMemory>();
@@ -177,7 +182,10 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         protected override void Update()
         {
-            EnmityTick.Invoke();
+            if (combatantMemory != null)
+            {
+                EnmityTick.Invoke();
+            }
         }
 
         [Serializable]

--- a/OverlayPlugin.Core/EventSources/FFXIVClientStructsEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVClientStructsEventSource.cs
@@ -39,6 +39,12 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         public FFXIVClientStructsEventSource(TinyIoCContainer container) : base(container)
         {
+            var haveAtkStageMemory = container.TryResolve(out atkStageMemory);
+            if (!haveAtkStageMemory)
+            {
+                Log(LogLevel.Warning, "Could not construct FFXIVClientStructsEventSource: Missing atkStageMemory");
+                return;
+            }
             atkStageMemory = container.Resolve<IAtkStageMemory>();
             memory = container.Resolve<FFXIVMemory>();
 

--- a/OverlayPlugin.Core/Integration/UnstableNewLogLines.cs
+++ b/OverlayPlugin.Core/Integration/UnstableNewLogLines.cs
@@ -33,8 +33,7 @@ namespace RainbowMage.OverlayPlugin.Integration
             enmitySource = container.Resolve<EnmityEventSource>();
             logger = container.Resolve<ILogger>();
             logPath = Path.GetDirectoryName(ActGlobals.oFormActMain.LogFilePath) + "_OverlayPlugin.log";
-            lineInCombat = container.Resolve<LineInCombat>();
-
+            container.TryResolve(out lineInCombat);
 
             var config = container.Resolve<BuiltinEventConfig>();
             config.LogLinesChanged += (o, e) =>
@@ -58,7 +57,10 @@ namespace RainbowMage.OverlayPlugin.Integration
         public void Enable()
         {
             parser.OnOnlineStatusChanged += OnOnlineStatusChange;
-            lineInCombat.OnInCombatChanged += OnCombatStatusChange;
+            if (lineInCombat != null)
+            {
+                lineInCombat.OnInCombatChanged += OnCombatStatusChange;
+            }
 
             logThread = new Thread(new ThreadStart(WriteBackgroundLog));
             logThread.IsBackground = true;
@@ -68,7 +70,10 @@ namespace RainbowMage.OverlayPlugin.Integration
         public void Disable()
         {
             parser.OnOnlineStatusChanged -= OnOnlineStatusChange;
-            lineInCombat.OnInCombatChanged -= OnCombatStatusChange;
+            if (lineInCombat != null)
+            {
+                lineInCombat.OnInCombatChanged -= OnCombatStatusChange;
+            }
             logQueue?.Enqueue(null);
         }
 

--- a/OverlayPlugin.Core/OverlayHider.cs
+++ b/OverlayPlugin.Core/OverlayHider.cs
@@ -34,7 +34,8 @@ namespace RainbowMage.OverlayPlugin
             container.Resolve<NativeMethods>().ActiveWindowChanged += ActiveWindowChangedHandler;
             container.Resolve<NetworkParser>().OnOnlineStatusChanged += OnlineStatusChanged;
             LineInCombat lineInCombat;
-            if (container.TryResolve(out lineInCombat)) {
+            if (container.TryResolve(out lineInCombat))
+            {
                 lineInCombat.OnInCombatChanged += CombatStatusChanged;
             }
 

--- a/OverlayPlugin.Core/OverlayHider.cs
+++ b/OverlayPlugin.Core/OverlayHider.cs
@@ -33,7 +33,10 @@ namespace RainbowMage.OverlayPlugin
 
             container.Resolve<NativeMethods>().ActiveWindowChanged += ActiveWindowChangedHandler;
             container.Resolve<NetworkParser>().OnOnlineStatusChanged += OnlineStatusChanged;
-            container.Resolve<LineInCombat>().OnInCombatChanged += CombatStatusChanged;
+            LineInCombat lineInCombat;
+            if (container.TryResolve(out lineInCombat)) {
+                lineInCombat.OnInCombatChanged += CombatStatusChanged;
+            }
 
             try
             {

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -247,29 +247,37 @@ namespace RainbowMage.OverlayPlugin
                             // ** Init phase 2
                             this.label.Text = "Init Phase 2: Integrations";
 
-                            // Initialize the parser in the second phase since it needs the FFXIV plugin.
-                            // If OverlayPlugin is placed above the FFXIV plugin, it won't be available in the first
-                            // phase but it'll be loaded by the time we enter the second phase.
-                            _container.Register(new FFXIVRepository(_container));
-                            _container.Register(new NetworkParser(_container));
-                            _container.Register(new TriggIntegration(_container));
-                            _container.Register(new FFXIVCustomLogLines(_container));
-                            _container.Register(new MemoryProcessors.AtkStage.FFXIVClientStructs.Data(_container));
+                            // Wrap FFXIV plugin related initialization in try/catch to allow OP to work when FFXIV plugin isn't present
+                            try
+                            {
+                                // Initialize the parser in the second phase since it needs the FFXIV plugin.
+                                // If OverlayPlugin is placed above the FFXIV plugin, it won't be available in the first
+                                // phase but it'll be loaded by the time we enter the second phase.
+                                _container.Register(new FFXIVRepository(_container));
+                                _container.Register(new NetworkParser(_container));
+                                _container.Register(new TriggIntegration(_container));
+                                _container.Register(new FFXIVCustomLogLines(_container));
+                                _container.Register(new MemoryProcessors.AtkStage.FFXIVClientStructs.Data(_container));
 
-                            // Register FFXIV memory reading subcomponents.
-                            // Must be done before loading addons.
-                            _container.Register(new FFXIVMemory(_container));
+                                // Register FFXIV memory reading subcomponents.
+                                // Must be done before loading addons.
+                                _container.Register(new FFXIVMemory(_container));
 
-                            // These are registered to be lazy-loaded. Use interface to force TinyIoC to use singleton pattern.
-                            _container.Register<ICombatantMemory, CombatantMemoryManager>();
-                            _container.Register<ITargetMemory, TargetMemoryManager>();
-                            _container.Register<IAggroMemory, AggroMemoryManager>();
-                            _container.Register<IEnmityMemory, EnmityMemoryManager>();
-                            _container.Register<IEnmityHudMemory, EnmityHudMemoryManager>();
-                            _container.Register<IInCombatMemory, InCombatMemoryManager>();
-                            _container.Register<IAtkStageMemory, AtkStageMemoryManager>();
+                                // These are registered to be lazy-loaded. Use interface to force TinyIoC to use singleton pattern.
+                                _container.Register<ICombatantMemory, CombatantMemoryManager>();
+                                _container.Register<ITargetMemory, TargetMemoryManager>();
+                                _container.Register<IAggroMemory, AggroMemoryManager>();
+                                _container.Register<IEnmityMemory, EnmityMemoryManager>();
+                                _container.Register<IEnmityHudMemory, EnmityHudMemoryManager>();
+                                _container.Register<IInCombatMemory, InCombatMemoryManager>();
+                                _container.Register<IAtkStageMemory, AtkStageMemoryManager>();
 
-                            _container.Register(new OverlayPluginLogLines(_container));
+                                _container.Register(new OverlayPluginLogLines(_container));
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.Log(LogLevel.Warning, "InitPlugin: Could not init FFXIV integration: {0}", ex);
+                            }
 
                             // This timer runs on the UI thread (it has to since we create UI controls) but LoadAddons()
                             // can block for some time. We run it on the background thread to avoid blocking the UI.


### PR DESCRIPTION
This PR fixes #142 

I'm not really happy with this and I feel like there's got to be a better way. This might require an overhaul of the structure of the plugin init process and better silo-ing of the event sources though.