### PR TITLE
Add *.Designer.cs to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.cs text eol=lf
+*.Designer.cs text eol=lf
 *.csproj text eol=lf
 *.png binary


### PR DESCRIPTION
Feel free to close this if you feel this is user error.
I do not have any `core.autocrlf` or `core.eol` settings in my git config, and on a fresh checkout of the repo, I get CRLF warnings on specifically the `*.Designer.cs` files. Adding this line to the `.gitattributes` resolves it, despite there being an entry for `*.cs`. Perhaps the wildcard doesn't work as I am expecting it to?