### PR TITLE
Add "Weapon ID"

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
@@ -96,6 +96,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastDurationMax = mem.CastDurationMax,
 
                     TransformationId = mem.TransformationId,
+                    WeaponId = mem.WeaponId
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
@@ -213,6 +214,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1AB2)]
             public ushort WorldID;
+
+            [FieldOffset(0x1AC6)]
+            public byte WeaponId;
 
             [FieldOffset(0x1B28)]
             public fixed byte Effects[EffectBytes];

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
@@ -94,6 +94,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastTargetID = mem.CastTargetID,
                     CastDurationCurrent = mem.CastDurationCurrent,
                     CastDurationMax = mem.CastDurationMax,
+                    
+                    TransformationId = mem.TransformationId,
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
@@ -181,6 +183,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1DA)]
             public ushort MaxCP;
+            
+            [FieldOffset(0x1DC)] 
+            public short TransformationId;
 
             [FieldOffset(0x1E0)]
             public byte Job;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory61.cs
@@ -94,7 +94,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastTargetID = mem.CastTargetID,
                     CastDurationCurrent = mem.CastDurationCurrent,
                     CastDurationMax = mem.CastDurationMax,
-                    
+
                     TransformationId = mem.TransformationId,
                 };
                 combatant.IsTargetable =
@@ -183,8 +183,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1DA)]
             public ushort MaxCP;
-            
-            [FieldOffset(0x1DC)] 
+
+            [FieldOffset(0x1DC)]
             public short TransformationId;
 
             [FieldOffset(0x1E0)]

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
@@ -96,6 +96,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastDurationMax = mem.CastDurationMax,
 
                     TransformationId = mem.TransformationId,
+                    WeaponId = mem.WeaponId
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
@@ -213,6 +214,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1ACA)]
             public ushort WorldID;
+
+            [FieldOffset(0x1ADE)]
+            public byte WeaponId;
 
             [FieldOffset(0x1B48)]
             public fixed byte Effects[EffectBytes];

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
@@ -94,6 +94,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastTargetID = mem.CastTargetID,
                     CastDurationCurrent = mem.CastDurationCurrent,
                     CastDurationMax = mem.CastDurationMax,
+                    
+                    TransformationId = mem.TransformationId,
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
@@ -181,6 +183,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1DA)]
             public ushort MaxCP;
+            
+            [FieldOffset(0x1DC)] 
+            public short TransformationId;
 
             [FieldOffset(0x1E0)]
             public byte Job;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory62.cs
@@ -94,7 +94,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastTargetID = mem.CastTargetID,
                     CastDurationCurrent = mem.CastDurationCurrent,
                     CastDurationMax = mem.CastDurationMax,
-                    
+
                     TransformationId = mem.TransformationId,
                 };
                 combatant.IsTargetable =
@@ -183,8 +183,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1DA)]
             public ushort MaxCP;
-            
-            [FieldOffset(0x1DC)] 
+
+            [FieldOffset(0x1DC)]
             public short TransformationId;
 
             [FieldOffset(0x1E0)]

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -96,6 +96,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastDurationMax = mem.CastDurationMax,
 
                     TransformationId = mem.TransformationId,
+                    WeaponId = mem.WeaponId
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
@@ -215,6 +216,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1AF6)]
             public ushort WorldID;
+
+            [FieldOffset(0x1B0A)]
+            public byte WeaponId;
 
             [FieldOffset(0x1B68)]
             public fixed byte Effects[EffectBytes];

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -94,6 +94,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastTargetID = mem.CastTargetID,
                     CastDurationCurrent = mem.CastDurationCurrent,
                     CastDurationMax = mem.CastDurationMax,
+                    
+                    TransformationId = mem.TransformationId,
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
@@ -181,6 +183,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1DA)]
             public ushort MaxCP;
+            
+            [FieldOffset(0x1DC)] 
+            public short TransformationId;
 
             [FieldOffset(0x1E0)]
             public byte Job;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -94,7 +94,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     CastTargetID = mem.CastTargetID,
                     CastDurationCurrent = mem.CastDurationCurrent,
                     CastDurationMax = mem.CastDurationMax,
-                    
+
                     TransformationId = mem.TransformationId,
                 };
                 combatant.IsTargetable =
@@ -183,8 +183,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
             [FieldOffset(0x1DA)]
             public ushort MaxCP;
-            
-            [FieldOffset(0x1DC)] 
+
+            [FieldOffset(0x1DC)]
             public short TransformationId;
 
             [FieldOffset(0x1E0)]

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
@@ -146,6 +146,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         public float CastDurationCurrent;
         public float CastDurationMax;
 
+        public short TransformationId;
+
         private Single GetDistance(Combatant target)
         {
             var distanceX = (float)Math.Abs(PosX - target.PosX);

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
@@ -147,6 +147,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         public float CastDurationMax;
 
         public short TransformationId;
+        public byte WeaponId;
 
         private Single GetDistance(Combatant target)
         {


### PR DESCRIPTION
For lack of a better name, I'm calling it "Weapon ID". This seems to be the one that is applicable to Omega weapons, but I want to leave the existing TransformationID field alone since it seems to convey something that could be useful in the future (more of a full-model transformation rather than just the weapon).