### PR TITLE
Add IsVisible property to Combatant

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
@@ -150,6 +150,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         // This function always returns a combatant object, even if empty.
         protected abstract unsafe Combatant GetCombatantFromByteArray(byte[] source, uint mycharID, bool isPlayer, bool exceptEffects = false);
 
+        protected unsafe byte[] GetByteArray(IntPtr address, int length)
+        {
+            return memory.GetByteArray(address, length);
+        }
+
         protected unsafe List<EffectEntry> GetEffectEntries(byte* source, ObjectType type, uint mycharID)
         {
             var result = new List<EffectEntry>();

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
@@ -7,7 +7,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
     public abstract class CombatantMemory : ICombatantMemory
     {
-        private FFXIVMemory memory;
+        protected FFXIVMemory memory;
         private ILogger logger;
 
         private IntPtr charmapAddress = IntPtr.Zero;
@@ -149,11 +149,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         // Will return any kind of combatant, even if not a mob.
         // This function always returns a combatant object, even if empty.
         protected abstract unsafe Combatant GetCombatantFromByteArray(byte[] source, uint mycharID, bool isPlayer, bool exceptEffects = false);
-
-        protected unsafe byte[] GetByteArray(IntPtr address, int length)
-        {
-            return memory.GetByteArray(address, length);
-        }
 
         protected unsafe List<EffectEntry> GetEffectEntries(byte* source, ObjectType type, uint mycharID)
         {

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
@@ -7,7 +7,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
     public abstract class CombatantMemory : ICombatantMemory
     {
-        protected FFXIVMemory memory;
+        private FFXIVMemory memory;
         private ILogger logger;
 
         private IntPtr charmapAddress = IntPtr.Zero;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -171,7 +171,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             [FieldOffset(0x100)]
             public IntPtr DrawObjectAddr;
 
-            [FieldOffset(0x104)]
+            [FieldOffset(0x114)]
             public int ModelStatus;
 
             [FieldOffset(0x1C4)]

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -102,15 +102,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
                     && ((combatant.Status == ObjectStatus.NormalActorStatus) || (combatant.Status == ObjectStatus.NormalSubActorStatus));
-
-                var drawObjectBytes = memory.GetByteArray(mem.DrawObjectAddr, DrawObject.Size);
-                if (drawObjectBytes?.Length > 0)
+                if (mem.DrawObjectAddr != IntPtr.Zero)
                 {
+                    var drawObjectBytes = memory.GetByteArray(mem.DrawObjectAddr, DrawObject.Size);
                     fixed (byte* dptr = &drawObjectBytes[0])
                     {
-                        IntPtr intPtr = new IntPtr((void*)dptr);
-                        var drawObj = (DrawObject)Marshal.PtrToStructure(intPtr, typeof(DrawObject));
-                        combatant.IsVisible = mem.DrawObjectAddr != IntPtr.Zero && (drawObj.Flags & 1UL) != 0;
+                        var drawObj = *(DrawObject*)&dptr[0];
+                        combatant.IsVisible = (drawObj.Flags & 1UL) != 0;
                     }
                 }
                 if (combatant.Type != ObjectType.PC && combatant.Type != ObjectType.Monster)

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -57,7 +57,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     MonsterType = (MonsterType)mem.MonsterType,
                     Status = (ObjectStatus)mem.Status,
                     ModelStatus = (ModelStatus)mem.ModelStatus,
-                    DrawObject = GetByteArray(mem.DrawObjectAddr, DrawObject.Size),
                     // Normalize all possible aggression statuses into the basic 4 ones.
                     AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
                     NPCTargetID = mem.NPCTargetID,
@@ -103,9 +102,10 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     (combatant.ModelStatus == ModelStatus.Visible)
                     && ((combatant.Status == ObjectStatus.NormalActorStatus) || (combatant.Status == ObjectStatus.NormalSubActorStatus));
 
-                if (combatant.DrawObject?.Length > 0)
+                var drawObjectBytes = memory.GetByteArray(mem.DrawObjectAddr, DrawObject.Size);
+                if (drawObjectBytes?.Length > 0)
                 {
-                    fixed (byte* dptr = &combatant.DrawObject[0])
+                    fixed (byte* dptr = &drawObjectBytes[0])
                     {
                         IntPtr intPtr = new IntPtr((void*)dptr);
                         var drawObj = (DrawObject)Marshal.PtrToStructure(intPtr, typeof(DrawObject));

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -8,12 +8,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
     class CombatantMemory63 : CombatantMemory, ICombatantMemory63
     {
+        private FFXIVMemory memory;
         private const string charmapSignature = "488B5720B8000000E0483BD00F84????????488D0D";
 
         public CombatantMemory63(TinyIoCContainer container)
             : base(container, charmapSignature, CombatantMemory.Size, EffectMemory.Size)
         {
-
+            memory = container.Resolve<FFXIVMemory>();
         }
 
         public override Version GetVersion()

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
@@ -100,6 +100,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         public ObjectType Type;
         public MonsterType MonsterType;
         public ObjectStatus Status;
+        public bool IsVisible;
+        [NonSerialized]
+        public byte[] DrawObject;
         public ModelStatus ModelStatus;
         public AggressionStatus AggressionStatus;
         public uint TargetID;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
@@ -101,8 +101,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         public MonsterType MonsterType;
         public ObjectStatus Status;
         public bool IsVisible;
-        [NonSerialized]
-        public byte[] DrawObject;
         public ModelStatus ModelStatus;
         public AggressionStatus AggressionStatus;
         public uint TargetID;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
@@ -53,7 +53,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
          */
     }
 
-    /// <summary>An int offset by 0x104 from the combatant's address that describes the 3D model visibility.</summary>
+    /// <summary>An int offset by 0x114 from the combatant's address that describes the 3D model visibility.</summary>
     // In a fight like O1N, where the main boss (Alte Roite) momentarily disappears and appears at the edge of the map to do his knockback,
     // the ModelStatus gets set to 16384 (Hidden), but the ObjectStatus remains at 191. The fact that the ObjectStatus doesn't change to 189 could mean that 
     // the boss is still accepting damage in this invisibility period, and that no ghosting will occur. Checking the logs shows that


### PR DESCRIPTION
This PR aims to add an "IsVisible" property to Combatant.

The main motivation for this is the unreliableness of `ModelStatus` in my testing. Specifically all the different values it can have (maybe this offset just hasn't been updated for 6.3?).

I'm putting this PR in draft since I am not familiar enough with the codebase to know if this is the preferred way to handle this, keeping in mind future/previous major patches. At the very least, I know the offsets are correct and it is returning the correct value.

[FFXIVClientStructs reference](https://github.com/aers/FFXIVClientStructs/blob/f6154f8d39aabbe116e1673beeb289a1ca42d977/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/DrawObject.cs#L12)

(p.s. is there any documentation on debugging OP? for changes I've been doing a release build for every change ;_;)