### PR TITLE
Rewrite FFXIVClientStructs-related code

### DIFF
--- a/DEPS.py
+++ b/DEPS.py
@@ -22,9 +22,9 @@ deps = {
         'hash': ['sha256', '032f43f2674008c761af19bf536374128c16241fb234699a55f9fb603fcfbae7'],
     },
     'FFXIVClientStructs': {
-        'url': 'https://github.com/aers/FFXIVClientStructs/archive/08e6c7ed7747ad68a38e5762863b5874fe04b8b8.zip',
-        'dest': 'OverlayPlugin.Core/Thirdparty/FFXIVClientStructs/Global',
+        'url': 'https://github.com/aers/FFXIVClientStructs/archive/218cea8679cf8e9630440dfd6d7cf3294c9e0280.zip',
+        'dest': 'OverlayPlugin.Core/Thirdparty/FFXIVClientStructs/Base/Global',
         'strip': 1,
-        'hash': ['sha256', 'b6d73da57240717876eff07fca5489644698dcc894eda58b32d2852b172badac'],
+        'hash': ['sha256', 'c790fd49c05991db2c83f36d6493fc8d73491c6e682182258584e7841163258f'],
     },
 }

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory.cs
@@ -11,9 +11,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
 
         protected IntPtr atkStageInstanceAddress = IntPtr.Zero;
 
-        private int atkStageSingletonAddress;
+        private long atkStageSingletonAddress;
 
-        public AtkStageMemory(TinyIoCContainer container, int atkStageSingletonAddress)
+        public AtkStageMemory(TinyIoCContainer container, long atkStageSingletonAddress)
         {
             this.atkStageSingletonAddress = atkStageSingletonAddress;
             logger = container.Resolve<ILogger>();
@@ -51,7 +51,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
 
             List<string> fail = new List<string>();
 
-            long instanceAddress = memory.GetInt64(IntPtr.Add(memory.GetBaseAddress(), atkStageSingletonAddress));
+            long instanceAddress = memory.GetInt64(new IntPtr(memory.GetBaseAddress().ToInt64() + atkStageSingletonAddress));
 
             if (instanceAddress != 0)
             {
@@ -71,7 +71,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
                 return;
             }
 
-            logger.Log(LogLevel.Error, $"Failed to find atkStage memory via {GetType().Name}: {string.Join(", ", fail)}.");
+            // @TODO: Change this from Debug to Error once we're actually using atkStage
+            logger.Log(LogLevel.Debug, $"Failed to find atkStage memory via {GetType().Name}: {string.Join(", ", fail)}.");
             return;
         }
 

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory62.cs
@@ -12,10 +12,10 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
 
     class AtkStageMemory62 : AtkStageMemory, IAtkStageMemory62
     {
-        private static int GetAtkStageSingletonAddress(TinyIoCContainer container)
+        private static long GetAtkStageSingletonAddress(TinyIoCContainer container)
         {
             var data = container.Resolve<FFXIVClientStructs.Data>();
-            return (int)data.GetClassInstanceAddress(FFXIVClientStructs.DataNamespace.Global, "Component::GUI::AtkStage");
+            return (long)data.GetClassInstanceAddress(FFXIVClientStructs.DataNamespace.Global, "Component::GUI::AtkStage");
         }
 
         public AtkStageMemory62(TinyIoCContainer container) : base(container, GetAtkStageSingletonAddress(container)) { }

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Data.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Data.cs
@@ -31,6 +31,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage.FFXIVClientStructs
             yamlFilePath = Path.Combine(pluginDirectory, "resources", "FFXIVClientStructs.{0}.data.yml");
         }
 
+        // @TODO: At some point the runtime checks in this function should be moved to a compile-time test instead
+        // and this function can return `long` instead of `long?`
         public long? GetClassInstanceAddress(DataNamespace ns, string targetClass)
         {
             var curObj = GetBaseObject(ns);

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Data.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Data.cs
@@ -18,6 +18,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage.FFXIVClientStructs
         private readonly string yamlFilePath;
         private readonly Dictionary<DataNamespace, ClientStructsData> data = new Dictionary<DataNamespace, ClientStructsData>();
 
+        // @TODO: Is there some way to get this from the module instead?
+        private const long DataBaseOffset = 0x140000000;
+
         public Data(TinyIoCContainer container)
         {
             logger = container.Resolve<ILogger>();
@@ -49,7 +52,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage.FFXIVClientStructs
                 return null;
             }
 
-            return instances[0].ea;
+            return instances[0].ea - DataBaseOffset;
         }
 
         public ClientStructsData GetBaseObject(DataNamespace ns)

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -224,7 +224,7 @@
       <DependentUpon>WSConfigPanel.cs</DependentUpon>
     </Compile>
     <Compile Include="WebSocket\WSServer.cs" />
-    <Compile Include="Thirdparty\**\*.cs" />
+    <Compile Include="Thirdparty\FFXIVClientStructs\Transformed\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="resources\enmity\aggrolist.html">
@@ -312,7 +312,7 @@
     <Content Include="resources\targetbars\target_of_target.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Thirdparty\FFXIVClientStructs\Global\ida\data.yml">
+    <Content Include="Thirdparty\FFXIVClientStructs\Base\Global\ida\data.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>resources\FFXIVClientStructs.Global.data.yml</TargetPath>
     </Content>

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/Properties/launchSettings.json
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "StripFFXIVClientStructs": {
+      "commandName": "Project",
+      "commandLineArgs": "Global ..\\..\\..\\..\\..\\..\\OverlayPlugin.Core\\Thirdparty\\FFXIVClientStructs\\Base\\Global ..\\..\\..\\..\\..\\..\\OverlayPlugin.Core\\Thirdparty\\FFXIVClientStructs\\Transformed\\Global"
+    }
+  }
+}

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -12,6 +12,7 @@ namespace StripFFXIVClientStructs
 {
     class StripFFXIVClientStructs
     {
+        // SyntaxKinds in this array are explicitly discarded, e.g. we won't ever keep a property or method no matter the contents
         private static SyntaxKind[] DiscardKinds = new SyntaxKind[] {
             SyntaxKind.PropertyDeclaration,
             SyntaxKind.MethodDeclaration,
@@ -27,6 +28,8 @@ namespace StripFFXIVClientStructs
             SyntaxKind.DelegateDeclaration,
             SyntaxKind.ImplicitObjectCreationExpression,
         };
+
+        // Attributes in this array are discarded, but the underlying type is kept
         private static string[] DiscardAttributes = new string[] {
             "DisableRuntimeMarshalling",
             "Flags",
@@ -43,6 +46,8 @@ namespace StripFFXIVClientStructs
             "InfoProxy",
         };
 
+        // Files whose relative path start with an entry in this array are skipped for transformation
+        // or deleted if the source and destination are the same
         private static string[] DiscardFiles = new string[] {
             @"\FFXIVClientStructs\GlobalUsings.cs",
             @"\FFXIVClientStructs\AssemblyAttributes.cs",
@@ -61,6 +66,8 @@ namespace StripFFXIVClientStructs
             @"\ida",
         };
 
+        // Namespaces in this array are prepended to every file unless they're already present.
+        //{0} is replaced with the namespace, e.g. "Global"
         private static string[] GlobalUsings = new string[] {
             "System.Runtime.InteropServices",
             "FFXIVClientStructs.{0}.STD",
@@ -68,6 +75,9 @@ namespace StripFFXIVClientStructs
             "FFXIVClientStructs.{0}.FFXIV.Common.Math",
         };
 
+        // Entries in this dictionary will have their types remapped to concrete types.
+        // Even format numbers (e.g. {0}, {2}) will have a stripped version of the type that's safe to use in identifiers
+        // Odd format numbers will have the original type
         private static Dictionary<string, string> GenericMaps = new Dictionary<string, string>(){
             {
                 "StdPair",
@@ -190,10 +200,12 @@ namespace StripFFXIVClientStructs
 " },
         };
 
+        // Regex used to strip non-safe characters from types for use as type names
         private static Regex GenericTypeRenamer = new Regex("[^a-zA-Z0-9]");
 
         static void Main(string[] args)
         {
+            // @TODO: Maybe we can use an args parser here instead?
             if (args.Length < 1)
             {
                 Console.WriteLine("Missing required namespace");
@@ -214,6 +226,7 @@ namespace StripFFXIVClientStructs
                 Console.WriteLine($"Path {path} does not exist");
                 return;
             }
+            // Use `Path.GetFullPath` here (and for `dest`) to get a normalized path name for comparison
             path = Path.GetFullPath(path);
 
             string dest;
@@ -232,9 +245,11 @@ namespace StripFFXIVClientStructs
 
             foreach (var file in Directory.GetFiles(path, "*.cs", SearchOption.AllDirectories))
             {
+                // Relative path to the current file
                 var relFile = file.Replace(path, "");
                 if (DiscardFiles.Any((discard) => relFile.StartsWith(discard)))
                 {
+                    // If we're transforming in-place, delete files that we don't want to keep
                     if (path == dest)
                     {
                         File.Delete(file);
@@ -246,9 +261,13 @@ namespace StripFFXIVClientStructs
                 {
                     var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file));
                     var root = tree.GetRoot();
+                    // SyntaxRewriter must be on a per-file basis
                     var rewriter = new SyntaxRewriter(ns);
+                    // We know that this will always be CompilationUnitSyntax because that's what we get back from
+                    // `CSharpSyntaxTree.ParseText` for any given fully valid C# file
                     CompilationUnitSyntax outTree = (CompilationUnitSyntax)rewriter.Visit(root);
 
+                    // Add any missing global-level using statements
                     foreach (var usingValTemplate in GlobalUsings)
                     {
                         var usingVal = string.Format(usingValTemplate, ns);
@@ -263,6 +282,9 @@ namespace StripFFXIVClientStructs
 
                     var destFile = file.Replace(path, dest);
                     Directory.CreateDirectory(Directory.GetParent(destFile).FullName);
+                    // Call `NormalizeWhitespace()`, otherwise Roslyn will omit whitespace between nodes randomly 🤷🏼‍
+                    // Also call `ToFullString()` because sometimes it'll use the wrong output. I never figured out why this is needed.
+                    // The documentation doesn't indicate why, but sometimes it randomly returned old node text instead of replaced/udpated text?
                     File.WriteAllText(destFile, outTree.NormalizeWhitespace().ToFullString());
                 }
                 catch (Exception e)
@@ -276,17 +298,47 @@ namespace StripFFXIVClientStructs
 
         class SyntaxRewriter : CSharpSyntaxRewriter
         {
+            /// <summary>
+            /// `using` statements detected in this file
+            /// </summary>
             public List<string> usings = new List<string>();
+
+            /// <summary>
+            /// The namespace that this file should exist in, e.g. `Global`, `Korean`, `Chinese`
+            /// </summary>
             private string structsNS;
+
+            /// <summary>
+            /// Collector for nodes which need added to the top-level Struct
+            /// </summary>
             private Dictionary<string, SyntaxNode> PendingNodes = new Dictionary<string, SyntaxNode>();
+
+            /// <summary>
+            /// Holder for the current top-level struct. Technically could be a boolean instead, but it's sometimes
+            /// useful to be able to see this when debugging
+            /// </summary>
             private StructDeclarationSyntax topStruct = null;
+
+            /// <summary>
+            /// Collector for `using Abc = Ghi.Xyz` statements, to remap them to their full values.
+            /// This is a lot easier than trying to work from both directions when rewriting generics to concrete types.
+            /// </summary>
             private Dictionary<string, string> remapUsingAliases = new Dictionary<string, string>();
 
+            /// <param name="ns">Top-level namespace, e.g. `Global`</param>
             public SyntaxRewriter(string ns)
             {
                 structsNS = ns;
             }
 
+            /// <summary>
+            /// This function is called for any node first, before a node-specific function (e.g. `VisitUsingDirective`) is called
+            /// Note that this function should be called for ALL CASES where a node is modified,
+            /// this function should be called and the result returned, instead of returning the modified node directly.
+            /// 
+            /// Technically this isn't required for `return null` cases, but in any situation where that doesn't result
+            /// in an NPE it should be done as well.
+            /// </summary>
             [return: NotNullIfNotNull("node")]
             public override SyntaxNode Visit(SyntaxNode node)
             {
@@ -294,7 +346,7 @@ namespace StripFFXIVClientStructs
                 {
                     return base.Visit(node);
                 }
-#if true
+#if false
                 // For debugging/testing, since conditional breakpoints on `ToString`'d results don't work
                 // And checking `rawText.Contains` in a conditional breakpoint is incredibly slow
                 var rawText = node.ToString();
@@ -303,70 +355,67 @@ namespace StripFFXIVClientStructs
                     var b = "";
                 }
 #endif
+                // If this node's type is in the discard list, get rid of it
                 if (DiscardKinds.Contains(node.Kind()))
                 {
                     return base.Visit(null);
                 }
+
                 return base.Visit(node);
             }
 
             public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
             {
+                // Store off any `using Abc = ...` statements for replacement later, then remove it
                 if (node.ToString().Contains("="))
                 {
                     remapUsingAliases.Add(node.Alias.Name.Identifier.ValueText, node.Name.ToString());
                     return Visit(null);
                 }
+
+                // Remove the Havok using statements entirely
                 if (node.Name.ToString().EndsWith("Havok"))
                 {
                     return Visit(null);
                 }
+
+                // Store off this using statement's actual value for deduplication later
+                usings.Add(node.ChildNodes().First().ToString());
+
+                // If this using statement points at an FFXIVClientStructs namespace, and it's not using the `structsNS` namespace,
+                // insert it into the name
                 var newNameString = node.Name.ToString();
                 if (newNameString.StartsWith("FFXIVClientStructs") && !newNameString.StartsWith("FFXIVClientStructs." + structsNS))
                 {
-                    usings.Add(node.ChildNodes().First().ToString());
                     return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("FFXIVClientStructs." + structsNS + newNameString.Substring(18))).NormalizeWhitespace();
                 }
-                usings.Add(node.ChildNodes().First().ToString());
 
                 return base.VisitUsingDirective(node);
             }
-            public override SyntaxNode VisitTypeParameter(TypeParameterSyntax node)
-            {
-                SyntaxNode lastNode = null;
-                // Check to see if the next node in parent from this one contains " : unmanaged"
-                if (node.Parent.ChildNodes().Any((node) =>
-                {
-                    if (lastNode == node && node.ToString().Contains(" : unmanaged"))
-                    {
-                        return true;
-                    }
-                    lastNode = node;
-                    return false;
-                }
-                ))
-                {
-                    // Add a new concrete type for this generic parameter instead
-                    NamespaceDeclarationSyntax ns = (NamespaceDeclarationSyntax)node.Ancestors().First((node) => node.IsKind(SyntaxKind.NamespaceDeclaration));
-                }
-                return base.VisitTypeParameter(node);
-            }
+
             public override SyntaxNode VisitAttribute(AttributeSyntax node)
             {
+                // Check if we should discard this attribute and then do so
                 var attributeName = node.ChildNodes().First().GetFirstToken().ToString();
                 if (DiscardAttributes.Contains(attributeName))
                 {
                     return Visit(null);
                 }
+
                 return base.VisitAttribute(node);
             }
+
             public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
             {
+                // Check to see if we should remove this field entirely
                 var nodeString = node.ToString();
                 if (nodeString.Contains(" = new("))
                 {
                     return Visit(null);
                 }
+
+                // Technically this field and `Rad2Deg` could exist, but their type would need changed from `float` to `double`
+                // which is a bit messy to do here.
                 if (nodeString.StartsWith("public const float Deg2Rad"))
                 {
                     return Visit(null);
@@ -375,10 +424,13 @@ namespace StripFFXIVClientStructs
                 {
                     return Visit(null);
                 }
+
                 return base.VisitFieldDeclaration(node);
             }
+
             public override SyntaxNode VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
             {
+                // Check to see if we need to insert the `structsNS` into this namespace declaration
                 var newName = node.Name;
                 var newNameString = newName.ToString();
                 if (newNameString.StartsWith("FFXIVClientStructs") && !newNameString.StartsWith("FFXIVClientStructs." + structsNS))
@@ -389,46 +441,55 @@ namespace StripFFXIVClientStructs
                         newName, SyntaxFactory.Token(SyntaxKind.OpenBraceToken), node.Externs, node.Usings,
                         node.Members, SyntaxFactory.Token(SyntaxKind.CloseBraceToken), node.SemicolonToken));
                 }
+
                 return base.VisitNamespaceDeclaration(node);
             }
+
             public override SyntaxNode VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
             {
-                var newName = node.Name;
-                var newNameString = newName.ToString();
-                if (newNameString.StartsWith("FFXIVClientStructs") && !newNameString.StartsWith("FFXIVClientStructs." + structsNS))
-                {
-                    newName = SyntaxFactory.ParseName("FFXIVClientStructs." + structsNS + newNameString.Substring(18));
-                }
+                // Completely remap newer file-scoped namespace declarations to older braced namespace declarations
                 return Visit(SyntaxFactory.NamespaceDeclaration(
                     node.AttributeLists, node.Modifiers, node.NamespaceKeyword,
-                    newName, SyntaxFactory.Token(SyntaxKind.OpenBraceToken), node.Externs, node.Usings,
+                    node.Name, SyntaxFactory.Token(SyntaxKind.OpenBraceToken), node.Externs, node.Usings,
                     node.Members, SyntaxFactory.Token(SyntaxKind.CloseBraceToken), node.SemicolonToken));
             }
+
             public override SyntaxNode VisitAttributeList(AttributeListSyntax node)
             {
+                // Call base.VisitAttributeList first so that any attributes can be removed as needed
                 var newNode = base.VisitAttributeList(node);
+
+                // Check if the list is empty, if so then remove it entirely
                 if (newNode.ChildNodes().Count() == 0)
                 {
                     return Visit(null);
                 }
+
                 return newNode;
             }
+
             public override SyntaxNode VisitFunctionPointerType(FunctionPointerTypeSyntax node)
             {
+                // Replace delegate function pointers with void pointers
                 if (node.ToString().Trim().StartsWith("delegate*"))
                 {
                     return Visit(SyntaxFactory.PointerType(SyntaxFactory.ParseTypeName("void")));
                 }
+
                 return base.VisitFunctionPointerType(node);
             }
             public override SyntaxNode VisitGenericName(GenericNameSyntax node)
             {
                 var gnIdentifier = node.Identifier.ToString();
+
+                // Remap `Pointer<T>` to `T*`
                 if (gnIdentifier == "Pointer")
                 {
                     return Visit(SyntaxFactory.PointerType((TypeSyntax)node.ChildNodes().First().ChildNodes().First()));
                 }
 
+                // If this name is in the generic maps key, do the remap here to a concrete type.
+                // This logic is recursive, so it handles nested generics properly.
                 if (GenericMaps.ContainsKey(gnIdentifier))
                 {
                     var typeStringFormatParams = new List<string>();
@@ -436,17 +497,22 @@ namespace StripFFXIVClientStructs
                     foreach (var t in node.TypeArgumentList.Arguments)
                     {
                         var strippedString = GenericTypeRenamer.Replace(t.ToString(), "");
+                        // Format params are always in pairs, the stripped name and then the original name.
                         typeStringFormatParams.Add(strippedString);
                         typeStringFormatParams.Add(t.ToString());
                         newName += strippedString;
                     }
+                    // Only add this entry if it's not already mapped.
+                    // Handles cases where the same generic is used for multiple fields.
                     if (!PendingNodes.ContainsKey(newName))
                     {
                         var typeString = string.Format(GenericMaps[gnIdentifier], typeStringFormatParams.ToArray());
                         PendingNodes.Add(newName, base.Visit(SyntaxFactory.ParseSyntaxTree(typeString).GetRoot().ChildNodes().First()));
                     }
+
                     return base.Visit(SyntaxFactory.ParseName(newName));
                 }
+
                 return base.VisitGenericName(node);
             }
 
@@ -457,21 +523,31 @@ namespace StripFFXIVClientStructs
                 {
                     topStruct = node;
                     StructDeclarationSyntax newNode = (StructDeclarationSyntax)base.VisitStructDeclaration(node);
-                    if (PendingNodes.Count > 0 && !newNode.Ancestors().Any((ancestor) => ancestor.IsKind(SyntaxKind.StructDeclaration)))
+                    if (PendingNodes.Count > 0)
                     {
                         newNode = newNode.InsertNodesAfter(newNode.ChildNodes().Last(), PendingNodes.Values.ToArray());
                         PendingNodes.Clear();
                     }
+
+                    // This is intentionally a call to `base.VisitStructDeclaration` to avoid issues with recursion
                     var newStruct = base.VisitStructDeclaration(newNode);
+
+                    // Clear `topStruct` after we've handled PendingNodes, to allow additional structs in the current
+                    // file's namespace to be processed properly
                     topStruct = null;
+
                     return newStruct;
                 }
+
                 return base.VisitStructDeclaration(node);
             }
 
             public override SyntaxNode VisitTypeArgumentList(TypeArgumentListSyntax node)
             {
+                // Call base.VisitTypeArgumentList first so that any types can be removed or remapped as needed
                 var newNode = base.VisitTypeArgumentList(node);
+
+                // Check if the list is empty, if so then remove it entirely
                 if (newNode.ChildNodes().Count() == 0)
                 {
                     return Visit(null);
@@ -484,24 +560,31 @@ namespace StripFFXIVClientStructs
                 switch (node.Identifier.ValueText)
                 {
                     case "nint":
+                        // nint = native int, only available in newer C# lang versions
                         return Visit(SyntaxFactory.ParseName("long"));
                     case "hkaSkeleton":
                     case "hkLoader":
                     case "hkaSkeletonMapper":
+                        // Remove all havok-related types
                         return Visit(SyntaxFactory.ParseName("void"));
                     case "MathF":
+                        // Remap `MathF` to `Math`. Need to use the `System` qualifier here to avoid it trying to
+                        // use FFXIV.Common.Math
                         return Visit(SyntaxFactory.ParseName("System.Math"));
                 }
 
+                // If this type name was an alias via `using`, remap it to its underlying type here
                 if (remapUsingAliases.ContainsKey(node.Identifier.ValueText))
                 {
                     return Visit(SyntaxFactory.ParseName(remapUsingAliases[node.Identifier.ValueText]));
                 }
+
                 return base.VisitIdentifierName(node);
             }
 
             public override SyntaxNode VisitBaseList(BaseListSyntax node)
             {
+                // Strip off base types that don't exist on older language versions
                 var types = node.Types.Where((type) =>
                 {
                     switch (type.ToString().Split("<")[0])
@@ -512,14 +595,20 @@ namespace StripFFXIVClientStructs
                     }
                     return true;
                 }).ToArray();
+
+                // If we removed any, rebuild the list. This recurses back to our VisitBaseList, so it handles an empty count properly.
                 if (types.Length != node.Types.Count)
                 {
                     return Visit(SyntaxFactory.BaseList(node.ColonToken, SyntaxFactory.SeparatedList(types)));
                 }
+
+                // If we don't have any types in the base type list, remove it entirely.
+                // Otherwise you end up with `struct Something : {`
                 if (node.Types.Count == 0)
                 {
-                    return null;
+                    return Visit(null);
                 }
+
                 return base.VisitBaseList(node);
             }
         }

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -242,7 +242,8 @@ namespace StripFFXIVClientStructs
                     continue;
                 }
 
-                try {
+                try
+                {
                     var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file));
                     var root = tree.GetRoot();
                     var rewriter = new SyntaxRewriter(ns);
@@ -254,7 +255,7 @@ namespace StripFFXIVClientStructs
 
                         if (!rewriter.usings.Contains(usingVal))
                         {
-                            outTree = outTree.AddUsings(new [] {
+                            outTree = outTree.AddUsings(new[] {
                                 SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(usingVal))
                             });
                         }
@@ -263,7 +264,9 @@ namespace StripFFXIVClientStructs
                     var destFile = file.Replace(path, dest);
                     Directory.CreateDirectory(Directory.GetParent(destFile).FullName);
                     File.WriteAllText(destFile, outTree.NormalizeWhitespace().ToFullString());
-                } catch (Exception e) {
+                }
+                catch (Exception e)
+                {
                     Console.WriteLine(file);
                     throw e;
                 }
@@ -332,7 +335,8 @@ namespace StripFFXIVClientStructs
             {
                 SyntaxNode lastNode = null;
                 // Check to see if the next node in parent from this one contains " : unmanaged"
-                if (node.Parent.ChildNodes().Any((node) => {
+                if (node.Parent.ChildNodes().Any((node) =>
+                {
                     if (lastNode == node && node.ToString().Contains(" : unmanaged"))
                     {
                         return true;
@@ -498,7 +502,8 @@ namespace StripFFXIVClientStructs
 
             public override SyntaxNode VisitBaseList(BaseListSyntax node)
             {
-                var types = node.Types.Where((type) => {
+                var types = node.Types.Where((type) =>
+                {
                     switch (type.ToString().Split("<")[0])
                     {
                         case "IEquatable":

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -1,56 +1,18 @@
-﻿using System.IO;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace StripFFXIVClientStructs
 {
     class StripFFXIVClientStructs
     {
-        private static SyntaxKind[] KeepKinds = new SyntaxKind[] {
-            SyntaxKind.CompilationUnit, // Top-level/root object
-            SyntaxKind.UsingDirective, // `using` statements
-            SyntaxKind.FileScopedNamespaceDeclaration, // `namespace` statements + child objects
-            SyntaxKind.NamespaceDeclaration,
-            SyntaxKind.QualifiedName, // `namespace` name values
-            SyntaxKind.IdentifierName, // various name tokens
-            SyntaxKind.StructDeclaration, // actual struct declaration
-            SyntaxKind.AttributeList, // Attribute lists e.g. `[StructLayout], []...`
-            SyntaxKind.Attribute, // Attribute declaration
-            SyntaxKind.FieldDeclaration,
-            SyntaxKind.EnumDeclaration,
-            SyntaxKind.BaseList,
-            SyntaxKind.SimpleBaseType,
-            SyntaxKind.PredefinedType,
-            SyntaxKind.EnumMemberDeclaration,
-            SyntaxKind.EqualsValueClause,
-            SyntaxKind.NumericLiteralExpression,
-            SyntaxKind.UnaryMinusExpression,
-            SyntaxKind.GenericName,
-            SyntaxKind.TypeArgumentList,
-            SyntaxKind.LeftShiftExpression,
-            SyntaxKind.BitwiseOrExpression,
-            SyntaxKind.InterfaceDeclaration,
-            SyntaxKind.ParenthesizedExpression,
-            SyntaxKind.VariableDeclaration,
-            SyntaxKind.PointerType,
-            SyntaxKind.VariableDeclarator,
-            SyntaxKind.BracketedArgumentList,
-            SyntaxKind.Argument,
-            SyntaxKind.MultiplyExpression,
-            SyntaxKind.SimpleMemberAccessExpression,
-            SyntaxKind.ArgumentList,
-            SyntaxKind.ObjectInitializerExpression,
-            SyntaxKind.SimpleAssignmentExpression,
-            SyntaxKind.DivideExpression,
-            SyntaxKind.CastExpression,
-            SyntaxKind.FunctionPointerType,
-            SyntaxKind.FunctionPointerParameterList,
-            SyntaxKind.FunctionPointerParameter,
-        };
         private static SyntaxKind[] DiscardKinds = new SyntaxKind[] {
-            SyntaxKind.TypeParameterList, // Type parameters for objects and funcs, e.g. `<T>` in `struct A<T>`
-            SyntaxKind.TypeParameterConstraintClause, // Type parameters for objects and funcs, e.g. `where T : unmanaged` in `struct A<T> where T : unmanaged`
             SyntaxKind.PropertyDeclaration,
             SyntaxKind.MethodDeclaration,
             SyntaxKind.ConstructorDeclaration,
@@ -65,10 +27,6 @@ namespace StripFFXIVClientStructs
             SyntaxKind.DelegateDeclaration,
             SyntaxKind.ImplicitObjectCreationExpression,
         };
-        private static string[] KeepAttributes = new string[] {
-            "StructLayout",
-            "FieldOffset",
-        };
         private static string[] DiscardAttributes = new string[] {
             "DisableRuntimeMarshalling",
             "Flags",
@@ -78,96 +36,487 @@ namespace StripFFXIVClientStructs
             "Obsolete",
             "FixedArray",
             "FixedSizeArray",
+            "AssemblyCompany",
+            "AssemblyProduct",
+            "AssemblyTitle",
+            "AssemblyConfiguration",
+            "InfoProxy",
         };
+
+        private static string[] DiscardFiles = new string[] {
+            @"\FFXIVClientStructs\GlobalUsings.cs",
+            @"\FFXIVClientStructs\AssemblyAttributes.cs",
+            @"\FFXIVClientStructs\Interop",
+            @"\FFXIVClientStructs\Attributes",
+            @"\FFXIVClientStructs.InteropSourceGenerators",
+            @"\FFXIVClientStructs.ResolverTester",
+            @"\FFXIVClientStructs\Havok",
+            @"\FFXIVClientStructs\FFXIV\Client\Graphics\Kernel\CVector.cs",
+            @"\FFXIVClientStructs\FFXIV\Component\GUI\AtkLinkedList.cs",
+            @"\FFXIVClientStructs\STD\Deque.cs",
+            @"\FFXIVClientStructs\STD\Map.cs",
+            @"\FFXIVClientStructs\STD\Pair.cs",
+            @"\FFXIVClientStructs\STD\Set.cs",
+            @"\FFXIVClientStructs\STD\Vector.cs",
+            @"\ida",
+        };
+
+        private static string[] GlobalUsings = new string[] {
+            "System.Runtime.InteropServices",
+            "FFXIVClientStructs.{0}.STD",
+            "FFXIVClientStructs.{0}.FFXIV.Client.Graphics",
+            "FFXIVClientStructs.{0}.FFXIV.Common.Math",
+        };
+
+        private static Dictionary<string, string> GenericMaps = new Dictionary<string, string>(){
+            {
+                "StdPair",
+                @"
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    public unsafe struct StdPair{0}{2}
+    {{
+        public {1} Item1;
+        public {3} Item2;
+    }}
+"},
+            {
+                "StdSet",
+                @"
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    public unsafe struct StdSet{0}
+    {{
+        public Node* Head;
+        public ulong Count;
+        public ref struct Enumerator
+        {{
+            private readonly Node* _head;
+            private Node* _current;
+        }}
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Node
+        {{
+            public Node* Left;
+            public Node* Parent;
+            public Node* Right;
+            public byte Color;
+            public bool IsNil;
+            public byte _18;
+            public byte _19;
+            public {1} Key;
+        }}
+    }}
+" },
+            {
+                "StdVector",
+                @"
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct StdVector{0}
+    {{
+        public {1}* First;
+        public {1}* Last;
+        public {1}* End;
+    }}
+" },
+            {
+                "StdMap",
+                @"
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    public unsafe struct StdMap{0}{2}
+    {{
+        public Node* Head;
+        public ulong Count;
+        public ref struct Enumerator
+        {{
+            private readonly Node* _head;
+            private Node* _current;
+        }}
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Node
+        {{
+            public Node* Left;
+            public Node* Parent;
+            public Node* Right;
+            public byte Color;
+            public bool IsNil;
+            public byte _18;
+            public byte _19;
+            public StdPair<{1}, {3}> KeyValuePair;
+        }}
+    }}
+" },
+            {
+                "StdDeque",
+                @"
+    [StructLayout(LayoutKind.Sequential, Size = 0x28)]
+    public unsafe struct StdDeque{0}
+    {{
+        public void* ContainerBase; // iterator base nonsense
+        public {1}* Map; // pointer to array of pointers (size MapSize) to arrays of T (size BlockSize)
+        public ulong MapSize; // size of map
+        public ulong MyOff; // offset of current first element
+        public ulong MySize; // current length 
+    }}
+" },
+            {
+                "AtkLinkedList",
+                @"
+    [StructLayout(LayoutKind.Sequential, Size = 0x18)]
+    public unsafe struct AtkLinkedList{0}
+    {{
+        [StructLayout(LayoutKind.Sequential)]
+        public struct Node
+        {{
+            public {1} Value;
+            public Node* Next;
+            public Node* Previous;
+        }}
+
+        public Node* End;
+        public Node* Start;
+        public uint Count;
+    }}
+" },
+            {
+                "CVector",
+                @"
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct CVector{0}
+    {{
+        public void* vtbl;
+        public StdVector<{1}> Vector;
+    }}
+" },
+        };
+
+        private static Regex GenericTypeRenamer = new Regex("[^a-zA-Z0-9]");
 
         static void Main(string[] args)
         {
             if (args.Length < 1)
             {
-                System.Console.WriteLine("Missing required path");
+                Console.WriteLine("Missing required namespace");
                 return;
             }
-            var path = args[0];
+
+            var ns = args[0];
+
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Missing required path");
+                return;
+            }
+
+            var path = args[1];
             if (!Directory.Exists(path))
             {
-                System.Console.WriteLine($"Path {path} does not exist");
+                Console.WriteLine($"Path {path} does not exist");
                 return;
             }
+            path = Path.GetFullPath(path);
+
+            string dest;
+            if (args.Length > 2)
+            {
+                dest = Path.GetFullPath(args[2]);
+                if (!Directory.Exists(dest))
+                {
+                    Directory.CreateDirectory(dest);
+                }
+            }
+            else
+            {
+                dest = path;
+            }
+
             foreach (var file in Directory.GetFiles(path, "*.cs", SearchOption.AllDirectories))
             {
-                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file));
-                var root = tree.GetRoot();
-                var outTree = recurseNode(root);
-                File.WriteAllText(file, outTree.ToString());
+                var relFile = file.Replace(path, "");
+                if (DiscardFiles.Any((discard) => relFile.StartsWith(discard)))
+                {
+                    if (path == dest)
+                    {
+                        File.Delete(file);
+                    }
+                    continue;
+                }
+
+                try {
+                    var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(file));
+                    var root = tree.GetRoot();
+                    var rewriter = new SyntaxRewriter(ns);
+                    CompilationUnitSyntax outTree = (CompilationUnitSyntax)rewriter.Visit(root);
+
+                    foreach (var usingValTemplate in GlobalUsings)
+                    {
+                        var usingVal = string.Format(usingValTemplate, ns);
+
+                        if (!rewriter.usings.Contains(usingVal))
+                        {
+                            outTree = outTree.AddUsings(new [] {
+                                SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(usingVal))
+                            });
+                        }
+                    }
+
+                    var destFile = file.Replace(path, dest);
+                    Directory.CreateDirectory(Directory.GetParent(destFile).FullName);
+                    File.WriteAllText(destFile, outTree.NormalizeWhitespace().ToFullString());
+                } catch (Exception e) {
+                    Console.WriteLine(file);
+                    throw e;
+                }
             }
             return;
         }
 
-        private static SyntaxNode recurseNode(SyntaxNode root)
+        class SyntaxRewriter : CSharpSyntaxRewriter
         {
-            var rootKind = root.Kind();
-            if (!KeepKinds.Contains(rootKind))
+            public List<string> usings = new List<string>();
+            private string structsNS;
+            private Dictionary<string, SyntaxNode> PendingNodes = new Dictionary<string, SyntaxNode>();
+            private StructDeclarationSyntax topStruct = null;
+            private Dictionary<string, string> remapUsingAliases = new Dictionary<string, string>();
+
+            public SyntaxRewriter(string ns)
             {
-                if (!DiscardKinds.Contains(rootKind))
-                {
-                    throw new System.Exception($"Unknown type {rootKind}");
-                }
-                return null;
-            }
-            switch (rootKind)
-            {
-                case SyntaxKind.UsingDirective:
-                case SyntaxKind.QualifiedName:
-                case SyntaxKind.IdentifierName:
-                    return root;
-                case SyntaxKind.Attribute:
-                    var attributeName = root.ChildNodes().First().GetFirstToken().ToString();
-                    if (!KeepAttributes.Contains(attributeName))
-                    {
-                        if (!DiscardAttributes.Contains(attributeName))
-                        {
-                            throw new System.Exception($"Unknown attribute {attributeName}");
-                        }
-                        return null;
-                    }
-                    return root;
-                case SyntaxKind.FieldDeclaration:
-                    if (root.ToString().Contains(" = new("))
-                    {
-                        return null;
-                    }
-                    break;
-            }
-            // There's probably a better way to handle this
-            var dirty = true;
-            while (dirty)
-            {
-                dirty = false;
-                foreach (var node in root.ChildNodes().ToList())
-                {
-                    var newNode = recurseNode(node);
-                    if (newNode != node)
-                    {
-                        if (newNode != null)
-                        {
-                            if (newNode.ToString() == node.ToString())
-                            {
-                                continue;
-                            }
-                            root = root.ReplaceNode(node, newNode);
-                        }
-                        else
-                        {
-                            root = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
-                        }
-                        // Re-loop, this node set has been modified
-                        dirty = true;
-                        break;
-                    }
-                }
+                structsNS = ns;
             }
 
-            return root;
+            [return: NotNullIfNotNull("node")]
+            public override SyntaxNode Visit(SyntaxNode node)
+            {
+                if (node == null)
+                {
+                    return base.Visit(node);
+                }
+#if true
+                // For debugging/testing, since conditional breakpoints on `ToString`'d results don't work
+                // And checking `rawText.Contains` in a conditional breakpoint is incredibly slow
+                var rawText = node.ToString();
+                if (rawText.Equals("CategoryMap"))
+                {
+                    var b = "";
+                }
+#endif
+                if (DiscardKinds.Contains(node.Kind()))
+                {
+                    return base.Visit(null);
+                }
+                return base.Visit(node);
+            }
+
+            public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
+            {
+                if (node.ToString().Contains("="))
+                {
+                    remapUsingAliases.Add(node.Alias.Name.Identifier.ValueText, node.Name.ToString());
+                    return Visit(null);
+                }
+                if (node.Name.ToString().EndsWith("Havok"))
+                {
+                    return Visit(null);
+                }
+                var newNameString = node.Name.ToString();
+                if (newNameString.StartsWith("FFXIVClientStructs") && !newNameString.StartsWith("FFXIVClientStructs." + structsNS))
+                {
+                    usings.Add(node.ChildNodes().First().ToString());
+                    return SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("FFXIVClientStructs." + structsNS + newNameString.Substring(18))).NormalizeWhitespace();
+                }
+                usings.Add(node.ChildNodes().First().ToString());
+
+                return base.VisitUsingDirective(node);
+            }
+            public override SyntaxNode VisitTypeParameter(TypeParameterSyntax node)
+            {
+                SyntaxNode lastNode = null;
+                // Check to see if the next node in parent from this one contains " : unmanaged"
+                if (node.Parent.ChildNodes().Any((node) => {
+                    if (lastNode == node && node.ToString().Contains(" : unmanaged"))
+                    {
+                        return true;
+                    }
+                    lastNode = node;
+                    return false;
+                }
+                ))
+                {
+                    // Add a new concrete type for this generic parameter instead
+                    NamespaceDeclarationSyntax ns = (NamespaceDeclarationSyntax)node.Ancestors().First((node) => node.IsKind(SyntaxKind.NamespaceDeclaration));
+                }
+                return base.VisitTypeParameter(node);
+            }
+            public override SyntaxNode VisitAttribute(AttributeSyntax node)
+            {
+                var attributeName = node.ChildNodes().First().GetFirstToken().ToString();
+                if (DiscardAttributes.Contains(attributeName))
+                {
+                    return Visit(null);
+                }
+                return base.VisitAttribute(node);
+            }
+            public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+            {
+                var nodeString = node.ToString();
+                if (nodeString.Contains(" = new("))
+                {
+                    return Visit(null);
+                }
+                if (nodeString.StartsWith("public const float Deg2Rad"))
+                {
+                    return Visit(null);
+                }
+                if (nodeString.StartsWith("public const float Rad2Deg"))
+                {
+                    return Visit(null);
+                }
+                return base.VisitFieldDeclaration(node);
+            }
+            public override SyntaxNode VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
+            {
+                var newName = node.Name;
+                var newNameString = newName.ToString();
+                if (newNameString.StartsWith("FFXIVClientStructs") && !newNameString.StartsWith("FFXIVClientStructs." + structsNS))
+                {
+                    newName = SyntaxFactory.ParseName("FFXIVClientStructs." + structsNS + newNameString.Substring(18));
+                    return Visit(SyntaxFactory.NamespaceDeclaration(
+                        node.AttributeLists, node.Modifiers, node.NamespaceKeyword,
+                        newName, SyntaxFactory.Token(SyntaxKind.OpenBraceToken), node.Externs, node.Usings,
+                        node.Members, SyntaxFactory.Token(SyntaxKind.CloseBraceToken), node.SemicolonToken));
+                }
+                return base.VisitNamespaceDeclaration(node);
+            }
+            public override SyntaxNode VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
+            {
+                var newName = node.Name;
+                var newNameString = newName.ToString();
+                if (newNameString.StartsWith("FFXIVClientStructs") && !newNameString.StartsWith("FFXIVClientStructs." + structsNS))
+                {
+                    newName = SyntaxFactory.ParseName("FFXIVClientStructs." + structsNS + newNameString.Substring(18));
+                }
+                return Visit(SyntaxFactory.NamespaceDeclaration(
+                    node.AttributeLists, node.Modifiers, node.NamespaceKeyword,
+                    newName, SyntaxFactory.Token(SyntaxKind.OpenBraceToken), node.Externs, node.Usings,
+                    node.Members, SyntaxFactory.Token(SyntaxKind.CloseBraceToken), node.SemicolonToken));
+            }
+            public override SyntaxNode VisitAttributeList(AttributeListSyntax node)
+            {
+                var newNode = base.VisitAttributeList(node);
+                if (newNode.ChildNodes().Count() == 0)
+                {
+                    return Visit(null);
+                }
+                return newNode;
+            }
+            public override SyntaxNode VisitFunctionPointerType(FunctionPointerTypeSyntax node)
+            {
+                if (node.ToString().Trim().StartsWith("delegate*"))
+                {
+                    return Visit(SyntaxFactory.PointerType(SyntaxFactory.ParseTypeName("void")));
+                }
+                return base.VisitFunctionPointerType(node);
+            }
+            public override SyntaxNode VisitGenericName(GenericNameSyntax node)
+            {
+                var gnIdentifier = node.Identifier.ToString();
+                if (gnIdentifier == "Pointer")
+                {
+                    return Visit(SyntaxFactory.PointerType((TypeSyntax)node.ChildNodes().First().ChildNodes().First()));
+                }
+
+                if (GenericMaps.ContainsKey(gnIdentifier))
+                {
+                    var typeStringFormatParams = new List<string>();
+                    var newName = gnIdentifier;
+                    foreach (var t in node.TypeArgumentList.Arguments)
+                    {
+                        var strippedString = GenericTypeRenamer.Replace(t.ToString(), "");
+                        typeStringFormatParams.Add(strippedString);
+                        typeStringFormatParams.Add(t.ToString());
+                        newName += strippedString;
+                    }
+                    if (!PendingNodes.ContainsKey(newName))
+                    {
+                        var typeString = string.Format(GenericMaps[gnIdentifier], typeStringFormatParams.ToArray());
+                        PendingNodes.Add(newName, base.Visit(SyntaxFactory.ParseSyntaxTree(typeString).GetRoot().ChildNodes().First()));
+                    }
+                    return base.Visit(SyntaxFactory.ParseName(newName));
+                }
+                return base.VisitGenericName(node);
+            }
+
+            public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
+            {
+                // For the topmost struct, visit all children first, so we can append the new subtypes if needed
+                if (topStruct == null)
+                {
+                    topStruct = node;
+                    StructDeclarationSyntax newNode = (StructDeclarationSyntax)base.VisitStructDeclaration(node);
+                    if (PendingNodes.Count > 0 && !newNode.Ancestors().Any((ancestor) => ancestor.IsKind(SyntaxKind.StructDeclaration)))
+                    {
+                        newNode = newNode.InsertNodesAfter(newNode.ChildNodes().Last(), PendingNodes.Values.ToArray());
+                        PendingNodes.Clear();
+                    }
+                    var newStruct = base.VisitStructDeclaration(newNode);
+                    topStruct = null;
+                    return newStruct;
+                }
+                return base.VisitStructDeclaration(node);
+            }
+
+            public override SyntaxNode VisitTypeArgumentList(TypeArgumentListSyntax node)
+            {
+                var newNode = base.VisitTypeArgumentList(node);
+                if (newNode.ChildNodes().Count() == 0)
+                {
+                    return Visit(null);
+                }
+                return newNode;
+            }
+
+            public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+            {
+                switch (node.Identifier.ValueText)
+                {
+                    case "nint":
+                        return Visit(SyntaxFactory.ParseName("long"));
+                    case "hkaSkeleton":
+                    case "hkLoader":
+                    case "hkaSkeletonMapper":
+                        return Visit(SyntaxFactory.ParseName("void"));
+                    case "MathF":
+                        return Visit(SyntaxFactory.ParseName("System.Math"));
+                }
+
+                if (remapUsingAliases.ContainsKey(node.Identifier.ValueText))
+                {
+                    return Visit(SyntaxFactory.ParseName(remapUsingAliases[node.Identifier.ValueText]));
+                }
+                return base.VisitIdentifierName(node);
+            }
+
+            public override SyntaxNode VisitBaseList(BaseListSyntax node)
+            {
+                var types = node.Types.Where((type) => {
+                    switch (type.ToString().Split("<")[0])
+                    {
+                        case "IEquatable":
+                        case "IFormattable":
+                            return false;
+                    }
+                    return true;
+                }).ToArray();
+                if (types.Length != node.Types.Count)
+                {
+                    return Visit(SyntaxFactory.BaseList(node.ColonToken, SyntaxFactory.SeparatedList(types)));
+                }
+                if (node.Types.Count == 0)
+                {
+                    return null;
+                }
+                return base.VisitBaseList(node);
+            }
         }
     }
 }

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -284,7 +284,7 @@ namespace StripFFXIVClientStructs
                     Directory.CreateDirectory(Directory.GetParent(destFile).FullName);
                     // Call `NormalizeWhitespace()`, otherwise Roslyn will omit whitespace between nodes randomly 🤷🏼‍
                     // Also call `ToFullString()` because sometimes it'll use the wrong output. I never figured out why this is needed.
-                    // The documentation doesn't indicate why, but sometimes it randomly returned old node text instead of replaced/udpated text?
+                    // The documentation doesn't indicate why, but sometimes it randomly returned old node text instead of replaced/updated text?
                     File.WriteAllText(destFile, outTree.NormalizeWhitespace().ToFullString());
                 }
                 catch (Exception e)


### PR DESCRIPTION
Also updates the FFXIVClientStructs to the latest version, and changes the error to debug for the message so people stop complaining about it.

This is a pretty big rewrite of the code that handles the transformation from C# 10+ to C# 7.3 and might need a bit of comments added.