### PR TITLE
Change CombatantMemory63 to use FFXIVClientStructs struct setup

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Extensions/FFXIV/Client/Game/Character/Character.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Extensions/FFXIV/Client/Game/Character/Character.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using FFXIVClientStructs.Global.FFXIV.Client.Game.Object;
+
+namespace FFXIVClientStructs.Global.FFXIV.Client.Game.Character
+{
+    // Size = 0x1B20
+    public unsafe partial struct Character
+    {
+        // TODO: this is incorrect in 6.3, please fix
+        [FieldOffset(0x19C3)]
+        public byte MonsterType;
+
+        // TODO: this is incorrect in 6.3, please fix
+        [FieldOffset(0x19DF)]
+        public byte AggressionStatus;
+
+        // FFXIVClientStructs has this struct defined but doesn't use it for some reason :shrug:
+        [FieldOffset(0x1A88)]
+        public GameObjectID TargetObject;
+
+        // New field
+        [FieldOffset(0x1B0A)]
+        public byte WeaponId;
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Extensions/FFXIV/Client/Game/Object/GameObject.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/FFXIVClientStructs/Extensions/FFXIV/Client/Game/Object/GameObject.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace FFXIVClientStructs.Global.FFXIV.Client.Game.Object
+{
+    // Size = 0x1A0
+    public unsafe partial struct GameObject
+    {
+        // `Name` already present, size is 4 bytes smaller (64 bytes)
+        public const int NameBytes = 64;
+
+        // New field
+        [FieldOffset(0x94)]
+        public byte Status;
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using FFXIVClientStructs.Global.FFXIV.Client.Game;
+using FFXIVClientStructs.Global.FFXIV.Client.Game.Character;
+using FFXIVClientStructs.Global.FFXIV.Client.Game.Object;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
@@ -11,7 +14,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         private const string charmapSignature = "488B5720B8000000E0483BD00F84????????488D0D";
 
         public CombatantMemory63(TinyIoCContainer container)
-            : base(container, charmapSignature, CombatantMemory.Size, EffectMemory.Size)
+            : base(container, charmapSignature, Marshal.SizeOf<BattleChara>(), EffectMemory.Size)
         {
 
         }
@@ -26,9 +29,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         {
             fixed (byte* p = source)
             {
-                CombatantMemory mem = *(CombatantMemory*)&p[0];
-                ObjectType type = (ObjectType)mem.Type;
-                if (mem.ID == 0 || mem.ID == emptyID)
+                BattleChara mem = *(BattleChara*)&p[0];
+                if (mem.Character.GameObject.ObjectID == 0 || mem.Character.GameObject.ObjectID == emptyID)
                     return null;
             }
             return GetCombatantFromByteArray(source, mycharID, false);
@@ -40,63 +42,63 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         {
             fixed (byte* p = source)
             {
-                CombatantMemory mem = *(CombatantMemory*)&p[0];
+                BattleChara mem = *(BattleChara*)&p[0];
 
                 if (isPlayer)
                 {
-                    mycharID = mem.ID;
+                    mycharID = mem.Character.GameObject.ObjectID;
                 }
 
                 Combatant combatant = new Combatant()
                 {
-                    Name = FFXIVMemory.GetStringFromBytes(mem.Name, CombatantMemory.NameBytes),
-                    Job = mem.Job,
-                    ID = mem.ID,
-                    OwnerID = mem.OwnerID == emptyID ? 0 : mem.OwnerID,
-                    Type = (ObjectType)mem.Type,
-                    MonsterType = (MonsterType)mem.MonsterType,
-                    Status = (ObjectStatus)mem.Status,
-                    ModelStatus = (ModelStatus)mem.ModelStatus,
+                    Name = FFXIVMemory.GetStringFromBytes(mem.Character.GameObject.Name, GameObject.NameBytes),
+                    Job = mem.Character.ClassJob,
+                    ID = mem.Character.GameObject.ObjectID,
+                    OwnerID = mem.Character.GameObject.OwnerID == emptyID ? 0 : mem.Character.GameObject.OwnerID,
+                    Type = (ObjectType)mem.Character.GameObject.ObjectKind,
+                    MonsterType = (MonsterType)mem.Character.MonsterType,
+                    Status = (ObjectStatus)mem.Character.GameObject.Status,
+                    ModelStatus = (ModelStatus)mem.Character.GameObject.RenderFlags,
                     // Normalize all possible aggression statuses into the basic 4 ones.
-                    AggressionStatus = (AggressionStatus)(mem.AggressionStatus - (mem.AggressionStatus / 4) * 4),
-                    NPCTargetID = mem.NPCTargetID,
-                    RawEffectiveDistance = mem.EffectiveDistance,
-                    PosX = mem.PosX,
+                    AggressionStatus = (AggressionStatus)(mem.Character.AggressionStatus - (mem.Character.AggressionStatus / 4) * 4),
+                    NPCTargetID = mem.Character.TargetObject.ObjectID,
+                    RawEffectiveDistance = mem.Character.GameObject.YalmDistanceFromPlayerZ,
+                    PosX = mem.Character.GameObject.Position.X,
                     // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
-                    PosY = mem.PosZ,
-                    PosZ = mem.PosY,
-                    Heading = mem.Heading,
-                    Radius = mem.Radius,
+                    PosY = mem.Character.GameObject.Position.Z,
+                    PosZ = mem.Character.GameObject.Position.Y,
+                    Heading = mem.Character.GameObject.Rotation,
+                    Radius = mem.Character.GameObject.HitboxRadius,
                     // In-memory there are separate values for PC's current target and NPC's current target
-                    TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
-                    CurrentHP = mem.CurrentHP,
-                    MaxHP = mem.MaxHP,
-                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+                    TargetID = (ObjectType)mem.Character.GameObject.ObjectKind == ObjectType.PC ? mem.Character.PlayerTargetObjectID : mem.Character.TargetObject.ObjectID,
+                    CurrentHP = (int)mem.Character.Health,
+                    MaxHP = (int)mem.Character.MaxHealth,
+                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.StatusManager.Status, (ObjectType)mem.Character.GameObject.ObjectKind, mycharID),
 
-                    BNpcID = mem.BNpcID,
-                    CurrentMP = mem.CurrentMP,
-                    MaxMP = mem.MaxMP,
-                    CurrentGP = mem.CurrentGP,
-                    MaxGP = mem.MaxGP,
-                    CurrentCP = mem.CurrentCP,
-                    MaxCP = mem.MaxCP,
-                    Level = mem.Level,
-                    PCTargetID = mem.PCTargetID,
+                    BNpcID = mem.Character.GameObject.DataID,
+                    CurrentMP = (int)mem.Character.Mana,
+                    MaxMP = (int)mem.Character.MaxMana,
+                    CurrentGP = mem.Character.GatheringPoints,
+                    MaxGP = mem.Character.MaxGatheringPoints,
+                    CurrentCP = mem.Character.CraftingPoints,
+                    MaxCP = mem.Character.MaxCraftingPoints,
+                    Level = mem.Character.Level,
+                    PCTargetID = mem.Character.PlayerTargetObjectID,
 
-                    BNpcNameID = mem.BNpcNameID,
+                    BNpcNameID = mem.Character.NameID,
 
-                    WorldID = mem.WorldID,
-                    CurrentWorldID = mem.CurrentWorldID,
+                    WorldID = mem.Character.HomeWorld,
+                    CurrentWorldID = mem.Character.CurrentWorld,
 
-                    IsCasting1 = mem.IsCasting1,
-                    IsCasting2 = mem.IsCasting2,
-                    CastBuffID = mem.CastBuffID,
-                    CastTargetID = mem.CastTargetID,
-                    CastDurationCurrent = mem.CastDurationCurrent,
-                    CastDurationMax = mem.CastDurationMax,
+                    IsCasting1 = mem.SpellCastInfo.IsCasting,
+                    IsCasting2 = (byte)mem.SpellCastInfo.ActionType,
+                    CastBuffID = mem.SpellCastInfo.ActionID,
+                    CastTargetID = mem.SpellCastInfo.CastTargetID,
+                    CastDurationCurrent = mem.SpellCastInfo.CurrentCastTime,
+                    CastDurationMax = mem.SpellCastInfo.TotalCastTime,
 
-                    TransformationId = mem.TransformationId,
-                    WeaponId = mem.WeaponId
+                    TransformationId = mem.Character.TransformationId,
+                    WeaponId = mem.Character.WeaponId
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
@@ -109,138 +111,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 }
                 return combatant;
             }
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        private unsafe struct CombatantMemory
-        {
-            public static int Size => Marshal.SizeOf(typeof(CombatantMemory));
-
-            // Unknown size, but this is the bytes up to the next field.
-            public const int NameBytes = 68;
-
-            public const int EffectCount = 60;
-            public const int EffectBytes = EffectMemory.Size * EffectCount;
-
-            [FieldOffset(0x30)]
-            public fixed byte Name[NameBytes];
-
-            [FieldOffset(0x74)]
-            public uint ID;
-
-            [FieldOffset(0x80)]
-            public uint BNpcID;
-
-            [FieldOffset(0x84)]
-            public uint OwnerID;
-
-            [FieldOffset(0x8C)]
-            public byte Type;
-
-            [FieldOffset(0x92)]
-            public byte EffectiveDistance;
-
-            [FieldOffset(0x94)]
-            public byte Status;
-
-            [FieldOffset(0xB0)]
-            public Single PosX;
-
-            [FieldOffset(0xB4)]
-            public Single PosY;
-
-            [FieldOffset(0xB8)]
-            public Single PosZ;
-
-            [FieldOffset(0xC0)]
-            public Single Heading;
-
-            [FieldOffset(0xD0)]
-            public Single Radius;
-
-            [FieldOffset(0x114)]
-            public int ModelStatus;
-
-            [FieldOffset(0x1C4)]
-            public int CurrentHP;
-
-            [FieldOffset(0x1C8)]
-            public int MaxHP;
-
-            [FieldOffset(0x1CC)]
-            public int CurrentMP;
-
-            [FieldOffset(0x1D0)]
-            public int MaxMP;
-
-            [FieldOffset(0x1D4)]
-            public ushort CurrentGP;
-
-            [FieldOffset(0x1D6)]
-            public ushort MaxGP;
-
-            [FieldOffset(0x1D8)]
-            public ushort CurrentCP;
-
-            [FieldOffset(0x1DA)]
-            public ushort MaxCP;
-
-            [FieldOffset(0x1DC)]
-            public short TransformationId;
-
-            [FieldOffset(0x1E0)]
-            public byte Job;
-
-            [FieldOffset(0x1E1)]
-            public byte Level;
-
-            [FieldOffset(0xC80)]
-            public uint PCTargetID;
-
-            // TODO: this is incorrect in 6.3, please fix
-            [FieldOffset(0x19C3)]
-            public byte MonsterType;
-
-            // TODO: this is incorrect in 6.3, please fix
-            [FieldOffset(0x19DF)]
-            public byte AggressionStatus;
-
-            [FieldOffset(0x1A88)]
-            public uint NPCTargetID;
-
-            [FieldOffset(0x1AD8)]
-            public uint BNpcNameID;
-
-            [FieldOffset(0x1AF4)]
-            public ushort CurrentWorldID;
-
-            [FieldOffset(0x1AF6)]
-            public ushort WorldID;
-
-            [FieldOffset(0x1B0A)]
-            public byte WeaponId;
-
-            [FieldOffset(0x1B68)]
-            public fixed byte Effects[EffectBytes];
-
-            [FieldOffset(0x1CF0)]
-            public byte IsCasting1;
-
-            [FieldOffset(0x1CF2)]
-            public byte IsCasting2;
-
-            [FieldOffset(0x1CF4)]
-            public uint CastBuffID;
-
-            [FieldOffset(0x1CF0)]
-            public uint CastTargetID;
-
-            [FieldOffset(0x1DF4)]
-            public float CastDurationCurrent;
-
-            [FieldOffset(0x1DF8)]
-            public float CastDurationMax;
-            // Missing PartyType
         }
     }
 }

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -101,6 +101,8 @@
     <Compile Include="MemoryProcessors\AtkStage\AtkStageMemory.cs" />
     <Compile Include="MemoryProcessors\AtkStage\AtkStageMemory62.cs" />
     <Compile Include="MemoryProcessors\AtkStage\AtkStageMemoryManager.cs" />
+    <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\Extensions\FFXIV\Client\Game\Character\Character.cs" />
+    <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\Extensions\FFXIV\Client\Game\Object\GameObject.cs" />
     <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\Data.cs" />
     <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\ManagedType.cs" />
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory63.cs" />

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -523,6 +523,13 @@ namespace StripFFXIVClientStructs
 
             public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
             {
+                // Add `partial` modifier to all structs to allow extending them with new fields
+                if (!node.Modifiers.Any(SyntaxKind.PartialKeyword))
+                {
+                    node = node.AddModifiers(SyntaxFactory.Token(SyntaxKind.PartialKeyword));
+                    return Visit(node);
+                }
+
                 // For the topmost struct, visit all children first, so we can append the new subtypes if needed
                 if (topStruct == null)
                 {


### PR DESCRIPTION
This PR is in preparation for adding a new log line for combatant memory information.

- StripFFXIVClientStructs was adjusted to add the `partial` keyword to structs to allow extending
- Missing fields were added to extension structs
- Existing fields that were named differently were adjusted in CombatantMemory63 itself

After this PR is merged, I plan to adjust the file/folder/namespace structure for these to not live in the `AtkStage` folder anymore, since that doesn't really make sense. I could include that change in this PR, but that would make this PR a bit bigger.