### PR TITLE
Fix ngrok API header

### DIFF
--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -507,7 +507,7 @@ tunnels:
                     var apiUrl = "http://127.0.0.1:" + (_config.WSServerPort + 1) + "/api/tunnels";
                     var headers = new Dictionary<string, string>()
                     {
-                        { "Content-Type", "application/json" },
+                        { "Accept", "application/json" },
                     };
 
                     string data = null;


### PR DESCRIPTION
We're fetching tunnel metadata from the local ngrok client's HTTP API. `Content-Type` was always wrong, but we previously used cURL which did not validate headers, unlike .NET HttpClient. It simply worked by the API responding with JSON by default.