### PR TITLE
Add combatant memory info line

### DIFF
--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
 using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
 using RainbowMage.OverlayPlugin.NetworkProcessors;
 using RainbowMage.OverlayPlugin.Updater;
@@ -20,6 +21,7 @@ namespace RainbowMage.OverlayPlugin
             container.Register(new LineFateControl(container));
             container.Register(new LineCEDirector(container));
             container.Register(new LineInCombat(container));
+            container.Register(new LineCombatant(container));
         }
     }
 

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -315,7 +315,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
         private string FormatFieldChange(FieldInfo info, Combatant combatant)
         {
-            if (info.Name == "PCTargetID" || info.Name == "NPCTargetID" || info.Name == "BNpcNameID" || info.Name == "BNpcID" || info.Name == "TargetID" || info.Name == "OwnerID")
+            if (info.Name == "PCTargetID" || info.Name == "NPCTargetID" || info.Name == "BNpcNameID" || info.Name == "BNpcID" || info.Name == "TargetID" || info.Name == "OwnerID" || info.Name == "CastTargetID")
             {
                 return $"|{info.Name}|0x{info.GetValue(combatant):X}";
             }

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Reflection;
-using System.Linq;
-using RainbowMage.OverlayPlugin.NetworkProcessors;
-using System.Collections.Generic;
 using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
-using System.Collections.ObjectModel;
+using RainbowMage.OverlayPlugin.NetworkProcessors;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
@@ -24,7 +24,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         int offsetHeaderLoginUserID;
 
         // Only emit a log line when this information changes every X milliseconds
-        private struct CombatantChangeCriteria {
+        private struct CombatantChangeCriteria
+        {
             // in milliseconds
             public const int PollingRate = 20;
 
@@ -92,7 +93,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 return null;
             }
 
-            public static readonly ReadOnlyDictionary<Type, object> DefaultValues = 
+            public static readonly ReadOnlyDictionary<Type, object> DefaultValues =
                 new ReadOnlyDictionary<Type, object>(
                     AllFields.Select((fi) => fi.FieldType).Distinct().ToDictionary((t) => t, (t) => GetDefault(t)));
         }

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -72,6 +72,20 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 nameof(Combatant.RawEffectiveDistance),
                 // Excluded due to being included in many, many other lines
                 nameof(Combatant.CurrentHP),
+
+                // These are not currently written to but exclude them in case they're updated upstream properly in the future
+                nameof(Combatant.Distance),
+                nameof(Combatant.EffectiveDistance),
+
+                // These fields are calculated and can be determined downstream by consumers if needed
+                nameof(Combatant.TargetID),
+                nameof(Combatant.IsTargetable),
+
+                // CP and GP are pointless since this is currently restricted to combat-only.
+                nameof(Combatant.CurrentCP),
+                nameof(Combatant.MaxCP),
+                nameof(Combatant.CurrentGP),
+                nameof(Combatant.MaxGP),
             };
 
             // Fields that should be written out for add or full list of changes
@@ -373,6 +387,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             {
                 return $"|{info.Name}|{Convert.ChangeType(value, Enum.GetUnderlyingType(info.FieldType))}";
             }
+
+            // Format numbers to 4 decimal places, to prevent scientific notation
+            if (info.FieldType == typeof(Single) || info.FieldType == typeof(Double))
+            {
+                return $"|{info.Name}|{value:F4}";
+            }
+
             return $"|{info.Name}|{value}";
         }
 

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
+using System.Reflection;
+using System.Linq;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
+{
+    public class LineCombatant
+    {
+        public const uint LogFileLineID = 261;
+        private ILogger logger;
+        private readonly FFXIVRepository ffxiv;
+        private ICombatantMemory combatantMemoryManager;
+        private ConcurrentDictionary<uint, CombatantStateInfo> combatantStateMap = new ConcurrentDictionary<uint, CombatantStateInfo>();
+
+        // Only emit a log line when this information changes every X milliseconds
+        private struct CombatantChangeCriteria {
+            // in milliseconds
+            public const int PollingRate = 20;
+
+            // in milliseconds
+            public const uint DelayDefault = 1000; // If any property has changed in this timeframe, a line will be written
+
+            public const uint DelayNameID = 0;
+            public const uint DelayPosition = 250;
+            public const uint DelayTransformationID = 0;
+            public const uint DelayWeaponID = 0;
+            public const uint DelayTargetID = 0;
+
+            // in in-game distance
+            public const float DistancePosition = 5F;
+
+            // in radians
+            public const float DistanceHeading = (float)(45 * (Math.PI / 180)); // 45º turns
+
+            // Check these fields for changes to determine if we should dump a full line
+            public static readonly FieldInfo[] defaultCheckFields = new FieldInfo[] {
+                // This is just every field except Effects, Distances, and specifically checked values for now, can remove as needed
+                typeof(Combatant).GetField("ID"),
+                typeof(Combatant).GetField("OwnerID"),
+                typeof(Combatant).GetField("Type"),
+                typeof(Combatant).GetField("MonsterType"),
+                typeof(Combatant).GetField("Status"),
+                typeof(Combatant).GetField("ModelStatus"),
+                typeof(Combatant).GetField("AggressionStatus"),
+                typeof(Combatant).GetField("IsTargetable"),
+                typeof(Combatant).GetField("Job"),
+                typeof(Combatant).GetField("Name"),
+                typeof(Combatant).GetField("CurrentHP"),
+                typeof(Combatant).GetField("MaxHP"),
+                typeof(Combatant).GetField("Radius"),
+                typeof(Combatant).GetField("BNpcID"),
+                typeof(Combatant).GetField("CurrentMP"),
+                typeof(Combatant).GetField("MaxMP"),
+                typeof(Combatant).GetField("Level"),
+                typeof(Combatant).GetField("WorldID"),
+                typeof(Combatant).GetField("CurrentWorldID"),
+                typeof(Combatant).GetField("NPCTargetID"),
+                typeof(Combatant).GetField("CurrentGP"),
+                typeof(Combatant).GetField("MaxGP"),
+                typeof(Combatant).GetField("CurrentCP"),
+                typeof(Combatant).GetField("MaxCP"),
+                typeof(Combatant).GetField("PCTargetID"),
+                typeof(Combatant).GetField("IsCasting1"),
+                typeof(Combatant).GetField("IsCasting2"),
+                typeof(Combatant).GetField("CastBuffID"),
+                typeof(Combatant).GetField("CastTargetID"),
+                typeof(Combatant).GetField("CastDurationCurrent"),
+                typeof(Combatant).GetField("CastDurationMax"),
+            };
+        }
+
+        private class CombatantStateInfo
+        {
+            public DateTime lastUpdated;
+            public Combatant combatant;
+        }
+
+        private Func<string, DateTime, bool> logWriter;
+
+        private CancellationTokenSource cancellationToken;
+
+        public LineCombatant(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            combatantMemoryManager = container.Resolve<ICombatantMemory>();
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "CombatantMemory",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+
+            cancellationToken = new CancellationTokenSource();
+
+            Task.Run(PollCombatants, cancellationToken.Token);
+        }
+
+        ~LineCombatant()
+        {
+            if (cancellationToken != null)
+            {
+                cancellationToken.Cancel();
+            }
+        }
+
+        private void PollCombatants()
+        {
+            try {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var now = DateTime.Now;
+
+                    var combatants = combatantMemoryManager.GetCombatantList();
+
+                    // Check combatants currently in memory first
+                    foreach (var combatant in combatants)
+                    {
+                        // If this is a new combatant, always write a line for it
+                        if (!combatantStateMap.ContainsKey(combatant.ID))
+                        {
+                            combatantStateMap[combatant.ID] = new CombatantStateInfo(){
+                                lastUpdated = now,
+                                combatant = combatant,
+                            };
+                            WriteLine(CombatantMemoryChangeType.Add, combatant.ID, JObject.FromObject(combatant).ToString(Newtonsoft.Json.Formatting.None));
+                            continue;
+                        }
+
+                        var oldCombatant = combatantStateMap[combatant.ID].combatant;
+                        var lastUpdatedDiff = (now - combatantStateMap[combatant.ID].lastUpdated).TotalMilliseconds;
+
+                        if (lastUpdatedDiff > CombatantChangeCriteria.DelayDefault)
+                        {
+                            var changed = false;
+                            foreach(var fi in CombatantChangeCriteria.defaultCheckFields)
+                            {
+                                var oldVal = fi.GetValue(oldCombatant);
+                                var newVal = fi.GetValue(combatant);
+                                // There's some weird behavior with just using `==` or `.Equals` here, where two UInt32 values that are the same somehow aren't.
+                                if (oldVal is IComparable)
+                                {
+                                    if (((IComparable)oldVal).CompareTo(newVal) != 0)
+                                    {
+                                        changed = true;
+                                        break;
+                                    }
+                                }
+                                if (!oldVal.Equals(newVal))
+                                {
+                                    changed = true;
+                                    break;
+                                }
+                            }
+                            if (changed)
+                            {
+                                combatantStateMap[combatant.ID] = new CombatantStateInfo()
+                                {
+                                    lastUpdated = now,
+                                    combatant = combatant,
+                                };
+                                WriteLine(CombatantMemoryChangeType.PartialChange, combatant.ID, JObject.FromObject(combatant).ToString(Newtonsoft.Json.Formatting.None));
+                            }
+                        }
+
+                        // Check for partial change lines at the end
+                        // Batch these partial changes
+                        var obj = new JObject();
+                        if (lastUpdatedDiff > CombatantChangeCriteria.DelayNameID && combatant.BNpcNameID != oldCombatant.BNpcNameID)
+                        {
+                            obj["BNpcNameID"] = combatant.BNpcNameID;
+                        }
+                        if (lastUpdatedDiff > CombatantChangeCriteria.DelayTransformationID && combatant.TransformationId != oldCombatant.TransformationId)
+                        {
+                            obj["TransformationId"] = combatant.TransformationId;
+                        }
+                        if (lastUpdatedDiff > CombatantChangeCriteria.DelayWeaponID && combatant.WeaponId != oldCombatant.WeaponId)
+                        {
+                            obj["WeaponId"] = combatant.WeaponId;
+                        }
+                        if (lastUpdatedDiff > CombatantChangeCriteria.DelayTargetID && combatant.TargetID != oldCombatant.TargetID)
+                        {
+                            obj["TargetID"] = combatant.TargetID;
+                        }
+                        if (lastUpdatedDiff > CombatantChangeCriteria.DelayPosition)
+                        {
+                            if (
+                                (combatant.PosX != oldCombatant.PosX || combatant.PosY != oldCombatant.PosY || combatant.PosZ != oldCombatant.PosZ)
+                                && Math.Sqrt(Math.Pow(combatant.PosX, 2) + Math.Pow(combatant.PosY, 2) + Math.Pow(combatant.PosZ, 2)) > CombatantChangeCriteria.DistancePosition)
+                            {
+                                obj["PosX"] = combatant.PosX;
+                                obj["PosY"] = combatant.PosY;
+                                obj["PosZ"] = combatant.PosZ;
+                            } else if (
+                                combatant.Heading != oldCombatant.Heading
+                                && Math.Abs((combatant.Heading + Math.PI) - (oldCombatant.Heading + Math.PI)) > CombatantChangeCriteria.DistanceHeading)
+                            {
+                                obj["Heading"] = combatant.Heading;
+                            }
+                        }
+                        if (obj.Count > 0)
+                        {
+                            combatantStateMap[combatant.ID] = new CombatantStateInfo()
+                            {
+                                lastUpdated = now,
+                                combatant = combatant,
+                            };
+                            WriteLine(CombatantMemoryChangeType.FullChange, combatant.ID, obj.ToString(Newtonsoft.Json.Formatting.None));
+                        }
+                    }
+
+                    // Any combatants no longer in memory, signify that they were removed
+                    foreach (var ID in combatantStateMap.Keys)
+                    {
+                        if (!combatants.Any((c) => c.ID == ID))
+                        {
+                            combatantStateMap.TryRemove(ID, out var _);
+                            WriteLine(CombatantMemoryChangeType.Remove, ID, "");
+                        }
+                    }
+
+                    // Wait for next poll
+                    var delay = CombatantChangeCriteria.PollingRate - (int)Math.Ceiling((DateTime.Now - now).TotalMilliseconds);
+                    if (delay > 0)
+                    {
+                        Thread.Sleep(delay);
+                    }
+                    else
+                    {
+                        // If we're lagging enough to not have a sleep duration, delay by PollingRate to reduce lag
+                        Thread.Sleep(CombatantChangeCriteria.PollingRate);
+                    }
+                }
+            } catch (Exception e) {
+                logger.Log(LogLevel.Debug, $"LineCombatant: Exception: {e}");
+            }
+        }
+
+        private void WriteLine(CombatantMemoryChangeType type, uint combatantID, string info)
+        {
+            var line = $"{type}|{combatantID:X8}|{info}";
+            logWriter(line, ffxiv.GetServerTimestamp());
+        }
+
+        private enum CombatantMemoryChangeType
+        {
+            Add,
+            Remove,
+            FullChange,
+            PartialChange,
+        }
+    }
+}

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -103,6 +103,7 @@
     <Compile Include="MemoryProcessors\AtkStage\AtkStageMemoryManager.cs" />
     <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\Data.cs" />
     <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\ManagedType.cs" />
+    <Compile Include="MemoryProcessors\Combatant\LineCombatant.cs" />
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory63.cs" />
     <Compile Include="MemoryProcessors\Combatant\Common.cs" />
     <Compile Include="MemoryProcessors\EnmityHud\Common.cs" />

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -42,7 +42,14 @@
         "Comment": "Combat beginning / ending"
     },
     {
-        "StartID": 261,
+        "ID": 261,
+        "Name":  "CombatantMemory",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "Combatant Memory Information"
+    },
+    {
+        "StartID": 262,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
This PR adds a new log line for combatant memory information.

Effort was made to reduce the potential overhead and load of this new line as much as possible. As such, lines are emitted:
1. When a combatant is added
  i. New combatant lines omit any values that are default values
2. When specific values pass a specific threshold
3. If a value has changed within a certain timeout
4. When a combatant is removed

Additionally, thresholds and timeouts are longer when out of combat.

Further optimizations to reduce the amount of data and lines were omitted to reduce code complexity, but can be added if it's felt that these lines are still too "chatty":
1. Player timeouts and thresholds are kept the same as enemy values.
2. The `Add` lines contain overlapping data with the default ACT `03` lines
3. The `Remove` lines could be batched together
4. A `RemoveAll` line could be added
5. Triggers for combatant data updates based on network lines could be dumped onto a separate thread to reduce blocking of the network thread

Some quick statistics:
  | Size (without 261) | Lines (without 261) | Size (with 261) | Lines (with 261) | 261 Lines | Add Lines | Change Lines | Remove Lines
-- | -- | -- | -- | -- | -- | -- | -- | --
p8s p1 | 5,267,398 | 30,078 | 5,592,558 | 33,192 | 3,114 | 114 | 2,922 | 78
p8s p2 | 6,405,673 | 35,489 | 6,697,643 | 38,313 | 2,824 | 91 | 2,646 | 87

Anonymized log files that these statistics were pulled from:
[p8s p1 str.log](https://github.com/OverlayPlugin/OverlayPlugin/files/10972451/p8s.p1.str.log)
[p8s p2 str.log](https://github.com/OverlayPlugin/OverlayPlugin/files/10972452/p8s.p2.str.log)

I would request that those with a less powerful PC test these changes as well to ensure there's not any issues with additional load.