### PR TITLE
Add triple backticks to tech support button

### DIFF
--- a/OverlayPlugin.Core/ClipboardTechSupport.cs
+++ b/OverlayPlugin.Core/ClipboardTechSupport.cs
@@ -135,7 +135,7 @@ namespace RainbowMage.OverlayPlugin
 
         public void CopyToClipboard()
         {
-            string text = "";
+            string text = "```\n";
             if (warnings.Count > 1)
             {
                 text += TableToString(warnings);
@@ -147,6 +147,7 @@ namespace RainbowMage.OverlayPlugin
             text += TableToString(overlays);
             text += "\n\n";
             text += TableToString(settings);
+            text += "```\n";
 
             Clipboard.SetText(text);
         }


### PR DESCRIPTION
This will make pasting in discord easier to read.