### PR TITLE
Minor optimization to LogLineHandler

### DIFF
--- a/OverlayPlugin.Core/EventSources/FFXIVOptionalEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVOptionalEventSource.cs
@@ -60,23 +60,21 @@ namespace RainbowMage.OverlayPlugin.EventSources
             {
                 try
                 {
-                    // @TODO: Should this be a customizable setting so that it can be changed per game, or somehow allow
-                    // downstream plugins to override it to change it per game?
-                    var line = args.originalLogLine.Split('|');
+                    LogMessageType lineType = (LogMessageType)args.detectedType;
 
-                    if (int.TryParse(line[0], out int lineTypeInt))
+                    // If an imported log has split the encounter, also split it while importing.
+                    // TODO: should we also consider the current user's wipe config option here for splitting,
+                    // even if the original log writer did not have it set to true?
+                    if (lineType == LogMessageType.InCombat)
                     {
-                        // If an imported log has split the encounter, also split it while importing.
-                        // TODO: should we also consider the current user's wipe config option here for splitting,
-                        // even if the original log writer did not have it set to true?
-                        LogMessageType lineType = (LogMessageType)lineTypeInt;
-                        if (lineType == LogMessageType.InCombat)
+                        // @TODO: Should this be a customizable setting so that it can be changed per game, or somehow allow
+                        // downstream plugins to override it to change it per game?
+                        var line = args.originalLogLine.Split('|');
+
+                        var inACTCombat = Convert.ToUInt32(line[2]);
+                        if (inACTCombat == 0)
                         {
-                            var inACTCombat = Convert.ToUInt32(line[2]);
-                            if (inACTCombat == 0)
-                            {
-                                StopACTCombat();
-                            }
+                            StopACTCombat();
                         }
                     }
                 }
@@ -90,22 +88,8 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             try
             {
-                LogMessageType lineType;
+                LogMessageType lineType = (LogMessageType)args.detectedType;
                 var line = args.originalLogLine.Split('|');
-
-                if (!int.TryParse(line[0], out int lineTypeInt))
-                {
-                    return;
-                }
-
-                try
-                {
-                    lineType = (LogMessageType)lineTypeInt;
-                }
-                catch
-                {
-                    return;
-                }
 
                 switch (lineType)
                 {


### PR DESCRIPTION
`FFXIV_ACT_Plugin` is already parsing out the line type and storing it on `detectedType`, so we don't need to re-parse it.

This has a knock-on effect during import, we don't need to split the line unless it's an `InCombat` line, significantly improving the speed for importing logs.

I verified that this works properly in the following scenarios during both normal gameplay and import:

1. Standard `FFXIV_ACT_Plugin` log line - `lineType` gets correct value as expected
2. `OverlayPlugin` custom log line - `lineType` gets correct value as expected
3. Completely unknown log line (tested with a value of 300) - Casting to `LogMessageType` still works, no errors thrown, line is successfully passed to overlay as expected