### PR TITLE
Various LineCombatant fixes

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -231,10 +231,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 {
                     var now = DateTime.Now;
 
-                    if (inCombat)
-                    {
-                        CheckCombatants(now);
-                    }
+                    CheckCombatants(now);
 
                     // Wait for next poll
                     var delay = CombatantChangeCriteria.PollingRate - (int)Math.Ceiling((DateTime.Now - now).TotalMilliseconds);
@@ -334,7 +331,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 {
                     foreach (var fi in criteria.CheckFieldDelay)
                     {
-                        if (fi.Value <= lastUpdatedDiff && ValueNotEqual(fi.Key, oldCombatant, combatant))
+                        if (fi.Value <= lastUpdatedDiff && !ValueEqual(fi.Key, oldCombatant, combatant))
                         {
                             changed.Add(fi.Key);
                         }
@@ -351,7 +348,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                         {
                             continue;
                         }
-                        if (ValueNotEqual(fi, oldCombatant, combatant))
+                        if (!ValueEqual(fi, oldCombatant, combatant))
                         {
                             changed.Add(fi);
                         }
@@ -385,7 +382,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             }
         }
 
-        private bool ValueNotEqual(FieldInfo fi, Combatant oldCombatant, Combatant combatant)
+        private bool ValueEqual(FieldInfo fi, Combatant oldCombatant, Combatant combatant)
         {
             var oldVal = fi.GetValue(oldCombatant);
             var newVal = fi.GetValue(combatant);
@@ -396,6 +393,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 {
                     return false;
                 }
+                return true;
             }
             if (!oldVal.Equals(newVal))
             {


### PR DESCRIPTION
- Fix LineCombatant not checking out of combat during polling thread
- Fix missing early out in equality check
- Rename ValueNotEqual to ValueEqual to match what it's actually doing
- Fix inverted logic elsewhere

Noticed that my log file from TOP last night was excessively large, seems like the equals/not equals logic got inverted at some point.

Did some minor cleanup and fixed an issue with adding back in the out-of-combat checks while I was at it.