### PR TITLE
Fix missing escape logic in RSV line

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -26,8 +26,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 return
                     $"|" +
                     $"{unknown1:X8}|" +
-                    $"{FFXIVMemory.GetStringFromBytes(key, keySize)}|" +
-                    $"{FFXIVMemory.GetStringFromBytes(value, valueSize)}";
+                    $"{FFXIVMemory.GetStringFromBytes(key, keySize).Replace("\r", "\\r").Replace("\n", "\\n")}|" +
+                    $"{FFXIVMemory.GetStringFromBytes(value, valueSize).Replace("\r", "\\r").Replace("\n", "\\n")}";
             }
         }
 


### PR DESCRIPTION
Noticed this while reviewing changes during merging into a local branch. No impact currently but probably shouldn't leave a potential bug as a future surprise.