### PR TITLE
Move FFXIVClientStructs helpers to their own folder

### DIFF
--- a/OverlayPlugin.Core/EventSources/FFXIVClientStructsEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVClientStructsEventSource.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using Newtonsoft.Json.Linq;
 using RainbowMage.OverlayPlugin.MemoryProcessors;
-using RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs;
 using RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage;
 
 namespace RainbowMage.OverlayPlugin.EventSources

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory62.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using FFXIVClientStructs.Global.FFXIV.Component.GUI;
-using RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs;
+using RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
 {
@@ -14,8 +14,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
     {
         private static long GetAtkStageSingletonAddress(TinyIoCContainer container)
         {
-            var data = container.Resolve<FFXIVClientStructs.Data>();
-            return (long)data.GetClassInstanceAddress(FFXIVClientStructs.DataNamespace.Global, "Component::GUI::AtkStage");
+            var data = container.Resolve<Data>();
+            return (long)data.GetClassInstanceAddress(DataNamespace.Global, "Component::GUI::AtkStage");
         }
 
         public AtkStageMemory62(TinyIoCContainer container) : base(container, GetAtkStageSingletonAddress(container)) { }

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemoryManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
 {

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/Data.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/Data.cs
@@ -5,7 +5,7 @@ using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage.FFXIVClientStructs
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs
 {
     public enum DataNamespace
     {

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/ManagedType.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/ManagedType.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using Newtonsoft.Json.Linq;
 
-namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs
 {
     /// <summary>
     /// This class acts as a proxy to FFXIV process memory, based on a struct.
@@ -348,7 +348,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs
                     var array = Array.CreateInstance(fixedBuffer.ElementType, elementCount);
                     fixed (void* tPtr = &rawObject)
                     {
-                        byte* fixedPtr = ((byte*)tPtr) + offset;
+                        byte* fixedPtr = (byte*)tPtr + offset;
                         for (int i = 0; i < elementCount; ++i)
                         {
                             // Cast this pointer to the correct type and add it to the array at the correct position
@@ -361,7 +361,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs
                 {
                     object str = field.GetValue(rawObject);
                     long strPtr = (long)Pointer.Unbox(str.GetType().GetField("StringPtr").GetValue(str));
-                    long strLen = ((long)str.GetType().GetField("BufUsed").GetValue(str)) - 1;
+                    long strLen = (long)str.GetType().GetField("BufUsed").GetValue(str) - 1;
                     var bytes = memory.GetByteArray(new IntPtr(strPtr), (int)strLen);
                     valMap[field.Name] = System.Text.Encoding.UTF8.GetString(bytes);
                 }
@@ -397,33 +397,33 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs
             switch (elementType.Name)
             {
                 case "Boolean":
-                    return *(Boolean*)v;
+                    return *(bool*)v;
                 case "Byte":
-                    return *(Byte*)v;
+                    return *v;
                 case "SByte":
-                    return *(SByte*)v;
+                    return *(sbyte*)v;
                 case "Int16":
-                    return *(Int16*)v;
+                    return *(short*)v;
                 case "UInt16":
-                    return *(UInt16*)v;
+                    return *(ushort*)v;
                 case "Int32":
-                    return *(Int32*)v;
+                    return *(int*)v;
                 case "UInt32":
-                    return *(UInt32*)v;
+                    return *(uint*)v;
                 case "Int64":
-                    return *(Int64*)v;
+                    return *(long*)v;
                 case "UInt64":
-                    return *(UInt64*)v;
+                    return *(ulong*)v;
                 case "IntPtr":
                     return *(IntPtr*)v;
                 case "UIntPtr":
                     return *(UIntPtr*)v;
                 case "Char":
-                    return *(Char*)v;
+                    return *(char*)v;
                 case "Double":
-                    return *(Double*)v;
+                    return *(double*)v;
                 case "Single":
-                    return *(Single*)v;
+                    return *(float*)v;
                 default:
                     // Should be impossible
                     return null;
@@ -476,7 +476,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs
                 ReadBaseObjFromMemory();
             }
 
-            return (T)rawObject;
+            return rawObject;
         }
 
         [IgnoreDataMember]
@@ -585,7 +585,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkGui.FFXIVClientStructs
 
             for (int i = 0; i < count; ++i)
             {
-                IntPtr objPtr = new IntPtr(((long)firstPtr) + (objSize * i));
+                IntPtr objPtr = new IntPtr((long)firstPtr + objSize * i);
                 dynamic obj = ManagedType<int>.GetDynamicManagedTypeFromIntPtr(objPtr, memory, objType, readPtrMap);
                 list.Add(obj.ToType());
             }

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -101,8 +101,8 @@
     <Compile Include="MemoryProcessors\AtkStage\AtkStageMemory.cs" />
     <Compile Include="MemoryProcessors\AtkStage\AtkStageMemory62.cs" />
     <Compile Include="MemoryProcessors\AtkStage\AtkStageMemoryManager.cs" />
-    <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\Data.cs" />
-    <Compile Include="MemoryProcessors\AtkStage\FFXIVClientStructs\ManagedType.cs" />
+    <Compile Include="MemoryProcessors\FFXIVClientStructs\Data.cs" />
+    <Compile Include="MemoryProcessors\FFXIVClientStructs\ManagedType.cs" />
     <Compile Include="MemoryProcessors\Combatant\LineCombatant.cs" />
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory63.cs" />
     <Compile Include="MemoryProcessors\Combatant\Common.cs" />

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -257,7 +257,7 @@ namespace RainbowMage.OverlayPlugin
                                 _container.Register(new NetworkParser(_container));
                                 _container.Register(new TriggIntegration(_container));
                                 _container.Register(new FFXIVCustomLogLines(_container));
-                                _container.Register(new MemoryProcessors.AtkStage.FFXIVClientStructs.Data(_container));
+                                _container.Register(new MemoryProcessors.FFXIVClientStructs.Data(_container));
 
                                 // Register FFXIV memory reading subcomponents.
                                 // Must be done before loading addons.


### PR DESCRIPTION
Moving these two classes in preparation for using ClientStructs stuff for other purposes aside from AtkStage.

Visual Studio insisted on formatting/cleaning up `ManagedType`. Rather than fight with it, I just let it reformat the class so it won't try to do so again next time, that's why there's spurious changes in the file.