### PR TITLE
Update aers/FFXIVClientStructs to latest version

### DIFF
--- a/DEPS.py
+++ b/DEPS.py
@@ -16,9 +16,9 @@ deps = {
         'hash': ['sha256', 'ed98fa01ec2c7ed2ac843fa8ea2eec1d66f86fad4c6864de4d73d5cfbf163dce'],
     },
     'FFXIVClientStructs': {
-        'url': 'https://github.com/aers/FFXIVClientStructs/archive/8d454fb6209b994c47d1338f7cfdb8d0cd64ee52.zip',
+        'url': 'https://github.com/aers/FFXIVClientStructs/archive/e02acce27a77f47c9076c19ad89609127fa36c30.zip',
         'dest': 'OverlayPlugin.Core/Thirdparty/FFXIVClientStructs/Base/Global',
         'strip': 1,
-        'hash': ['sha256', 'db7b3e1bc85769229b02d2e27dbae75a2bc84cfc43e6b934de95570f74ab958e'],
+        'hash': ['sha256', 'f9ec36ec8caa15047d13e18e1e1d2beee4d50e93b42d4d822e858931b92b5958'],
     },
 }

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -45,6 +45,7 @@ namespace StripFFXIVClientStructs
             "AssemblyConfiguration",
             "InfoProxy",
             "VTableAddress",
+            "FixedString",
         };
 
         // Files whose relative path start with an entry in this array are skipped for transformation
@@ -327,7 +328,7 @@ namespace StripFFXIVClientStructs
             private Dictionary<string, string> remapUsingAliases = new Dictionary<string, string>();
 
             /// <param name="ns">Top-level namespace, e.g. `Global`</param>
-            public SyntaxRewriter(string ns)
+            public SyntaxRewriter(string ns) : base(true)
             {
                 structsNS = ns;
             }
@@ -363,6 +364,16 @@ namespace StripFFXIVClientStructs
                 }
 
                 return base.Visit(node);
+            }
+
+            public override SyntaxNode VisitRegionDirectiveTrivia(RegionDirectiveTriviaSyntax node)
+            {
+                return SyntaxFactory.SkippedTokensTrivia();
+            }
+
+            public override SyntaxNode VisitEndRegionDirectiveTrivia(EndRegionDirectiveTriviaSyntax node)
+            {
+                return SyntaxFactory.SkippedTokensTrivia();
             }
 
             public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)


### PR DESCRIPTION
Strip out new `FixedString` attribute, strip out regions to prevent issues with trivia attached to removed nodes