### PR TITLE
Shared overlay: ngrok update

### DIFF
--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -505,6 +505,7 @@ version: 2
                         if (ev.Data != null)
                         {
                             simpLogBox.AppendText(ev.Data.Replace("\n", "\r\n") + "\r\n");
+                            // From https://ngrok.com/docs/errors/
                             // ERR_NGROK_120  Your ngrok agent version "<VERSION>" is no longer supported.
                             // ERR_NGROK_121  Your ngrok agent version "<VERSION>" is too old.
                             if (Regex.IsMatch(ev.Data, "\\bERR_NGROK_12[01]\\b"))
@@ -657,12 +658,12 @@ version: 2
                 var match = Regex.Match(ngrokScript, "^\\s*" + urlKey + "\\s*=\\s*'(https://[^']+)'\\s*$", RegexOptions.Multiline);
                 if (match == Match.Empty)
                 {
-                    simpLogBox.AppendText("Failed to find download URL in the install script! Please notify OverlayPlugin devs.\r\n");
+                    simpLogBox.AppendText("Failed to find download URL in ngrok install script! Please notify OverlayPlugin devs.\r\n");
                     return false;
                 }
                 var ngrokUrl = match.Groups[1].Captures[0].Value;
 
-                simpLogBox.AppendText("Downloading ngrok client...\r\n");
+                simpLogBox.AppendText(string.Format("Downloading ngrok client from {0}\r\n", ngrokUrl));
                 try
                 {
                     HttpClientWrapper.Get(ngrokUrl, new Dictionary<string, string>(), ngrokPath + ".zip", NgrokProgressCallback, false);

--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -435,7 +435,11 @@ namespace RainbowMage.OverlayPlugin
                     var fetchedNgrok = false; // Used to prevent infinite recursion in case ngrok reports too old version but redownloading doesn't fix it
                     if (!File.Exists(ngrokPath))
                     {
-                        if (!FetchNgrok(ngrokPath)) return;
+                        if (!FetchNgrok(ngrokPath))
+                        {
+                            UpdateTunnelStatus(TunnelStatus.Error);
+                            return;
+                        }
                         fetchedNgrok = true;
                     }
 

--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -418,6 +418,19 @@ namespace RainbowMage.OverlayPlugin
                 try
                 {
                     var ngrokPath = Path.Combine(ActGlobals.oFormActMain.AppDataFolder.FullName, "ngrok-" + (Environment.Is64BitOperatingSystem ? "x64" : "x86") + ".exe");
+                    var ngrokConfigPath = Path.Combine(ActGlobals.oFormActMain.AppDataFolder.FullName, "ngrok.yml");
+
+                    if (File.Exists(ngrokConfigPath))
+                    {
+                        var oldConfig = File.ReadAllText(ngrokConfigPath);
+                        if (!Regex.IsMatch(oldConfig, "^version: 2$", RegexOptions.Multiline))
+                        {
+                            simpLogBox.AppendText("Old config file found. Updating ngrok...\r\n");
+                            File.Delete(ngrokPath);
+                            File.Delete(ngrokConfigPath);
+                        }
+                    }
+
                     if (!File.Exists(ngrokPath))
                     {
                         if (!FetchNgrok(ngrokPath)) return;
@@ -471,9 +484,10 @@ tunnels:
         proto: http
         addr: 127.0.0.1:" + _config.WSServerPort + @"
         inspect: false
-        bind_tls: true
-    ";
-                    var ngrokConfigPath = Path.Combine(ActGlobals.oFormActMain.AppDataFolder.FullName, "ngrok.yml");
+        schemes:
+            - https
+version: 2
+";
                     File.WriteAllText(ngrokConfigPath, config);
 
                     var p = new Process();


### PR DESCRIPTION
Ngrok servers no longer accept v2 clients. Update OverlayPlugin to work with with ngrok v3, and to automatically update ngrok for users with old versions.

Tested cases:
1. Old version of `ngrok.yml` config file present, with or without `ngrok-(x86|x64).exe`.
    * Assume the exe is old too, delete both and proceed with download.
2. No `ngrok-(x86|x64).exe` present.
    * Successfully download the version specified for [ngrok chocolatey package](https://github.com/ngrok/choco-ngrok/blob/main/tools/chocolateyinstall.ps1)
3. Old `ngrok-(x86|x64).exe` present without old version config file.
    * Attempt to launch, detect "too old" error code in output, delete exe and automatically retry.