### PR TITLE
Copy Tech Support: Don't right-pad the last column

### DIFF
--- a/OverlayPlugin.Core/ClipboardTechSupport.cs
+++ b/OverlayPlugin.Core/ClipboardTechSupport.cs
@@ -192,7 +192,10 @@ namespace RainbowMage.OverlayPlugin
                     if (column != 0)
                         text += " ";
                     var elem = row.ElementAtOrDefault(column);
-                    text += String.Format($"{{0, {-lengths[column]}}}", elem);
+                    var padLength = -lengths[column];
+                    if (column == numColumns - 1)
+                        padLength = 0;
+                    text += String.Format($"{{0, {padLength}}}", elem);
                 }
                 text += "\n";
 


### PR DESCRIPTION
Removes 1015 characters from my output at least, from 3145 characters to 2130 characters.

Users with less overlays or plugins should be able to paste in Discord without having to upload as file.