### PR TITLE
Update opcodes for Global 6.4

### DIFF
--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -321,7 +321,7 @@
         // Region: Global
         // Version: 6.40
         "MapEffect": {
-            "opcode": 502,
+            "opcode": 264,
             "size": 11
         },
         "CEDirector": {

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -316,5 +316,21 @@
             "opcode": 642,
             "size": 1080
         }
+    },
+    "2023.05.18.0000.0000": {
+        // Region: Global
+        // Version: 6.40
+        "MapEffect": {
+            "opcode": 502,
+            "size": 11
+        },
+        "CEDirector": {
+            "opcode": 474,
+            "size": 16
+        },
+        "RSVData": {
+            "opcode": 477,
+            "size": 1080
+        }
     }
 }


### PR DESCRIPTION
Warning: my tools broke so I had to find these manually. We should make sure to test these first.

They removed RSV from TOP and added it to the new savages instead; however, if the other two are correct then I have confidence that RSV is correct as well.