### PR TITLE
Fix LineCombatant FP decimal separator being locale-dependent.

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -435,7 +436,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             // Format numbers to 4 decimal places, to prevent scientific notation
             if (info.FieldType == typeof(Single) || info.FieldType == typeof(Double))
             {
-                return $"|{info.Name}|{value:F4}";
+                return string.Format(CultureInfo.InvariantCulture, "|{0}|{1:F4}", info.Name, value);
             }
 
             return $"|{info.Name}|{value}";


### PR DESCRIPTION
Fixes #221 

This is not the only solution - another option is to set the whole thread's locale, I'm just not familiar enough with the threading model in C# to know the real impact of that.