### PR TITLE
OnPartyChanged event rewrite

### DIFF
--- a/DEPS.py
+++ b/DEPS.py
@@ -16,9 +16,9 @@ deps = {
         'hash': ['sha256', 'ed98fa01ec2c7ed2ac843fa8ea2eec1d66f86fad4c6864de4d73d5cfbf163dce'],
     },
     'FFXIVClientStructs': {
-        'url': 'https://github.com/aers/FFXIVClientStructs/archive/e02acce27a77f47c9076c19ad89609127fa36c30.zip',
+        'url': 'https://github.com/aers/FFXIVClientStructs/archive/22eb9598a3fc6572c44ce1fd1ad38b5545e35b66.zip',
         'dest': 'OverlayPlugin.Core/Thirdparty/FFXIVClientStructs/Base/Global',
         'strip': 1,
-        'hash': ['sha256', 'f9ec36ec8caa15047d13e18e1e1d2beee4d50e93b42d4d822e858931b92b5958'],
+        'hash': ['sha256', '912c565503d5af4cd037e39f147fc2abb987dbe925a10a6611bcca987e558de6'],
     },
 }

--- a/DEPS.py
+++ b/DEPS.py
@@ -16,9 +16,9 @@ deps = {
         'hash': ['sha256', 'ed98fa01ec2c7ed2ac843fa8ea2eec1d66f86fad4c6864de4d73d5cfbf163dce'],
     },
     'FFXIVClientStructs': {
-        'url': 'https://github.com/aers/FFXIVClientStructs/archive/22eb9598a3fc6572c44ce1fd1ad38b5545e35b66.zip',
+        'url': 'https://github.com/aers/FFXIVClientStructs/archive/39b39c12a62f17925a38863ccdc54fb43809f915.zip',
         'dest': 'OverlayPlugin.Core/Thirdparty/FFXIVClientStructs/Base/Global',
         'strip': 1,
-        'hash': ['sha256', '912c565503d5af4cd037e39f147fc2abb987dbe925a10a6611bcca987e558de6'],
+        'hash': ['sha256', 'de6eb9fdae1951012dfe39a4e61be53aab871b8735b16d831e6733e194f479a6'],
     },
 }

--- a/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
@@ -222,6 +222,18 @@ namespace RainbowMage.OverlayPlugin.EventSources
             return filteredCombatants;
         }
 
+        public enum PartyType
+        {
+            Solo,
+            Party,
+            AllianceA,
+            AllianceB,
+            AllianceC,
+            AllianceD,
+            AllianceE,
+            AllianceF,
+        }
+
         struct PartyMember
         {
             // Player id in hex (for ease in matching logs).
@@ -265,25 +277,25 @@ namespace RainbowMage.OverlayPlugin.EventSources
             // TODO: We know how to detect alliance A/B/C. Need to verify alliance D/E/F
             List<PartyMember> result = new List<PartyMember>(24);
 
-            List<string> remainingAlliances = new List<string>() {
-                "Alliance A",
-                "Alliance B",
-                "Alliance C",
-                "Alliance D",
-                "Alliance E",
-                "Alliance F",
+            List<PartyType> remainingAlliances = new List<PartyType>() {
+                PartyType.AllianceA,
+                PartyType.AllianceB,
+                PartyType.AllianceC,
+                PartyType.AllianceD,
+                PartyType.AllianceE,
+                PartyType.AllianceF,
             };
 
-            string currentAlliance;
+            PartyType currentAlliance;
             if ((cachedPartyList.allianceFlags & 0x1) == 0)
             {
                 if (cachedPartyList.memberCount <= 1)
                 {
-                    currentAlliance = "Solo";
+                    currentAlliance = PartyType.Solo;
                 }
                 else
                 {
-                    currentAlliance = "Party";
+                    currentAlliance = PartyType.Party;
                 }
             }
             else if ((cachedPartyList.currentPartyFlags & 0x100) == 0x100)
@@ -337,7 +349,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
             }));
         }
 
-        private void BuildPartyMemberResults(List<PartyMember> result, PartyListEntry[] members, string currentAlliance, bool inParty)
+        private void BuildPartyMemberResults(List<PartyMember> result, PartyListEntry[] members, PartyType partyType, bool inParty)
         {
             foreach (var member in members)
             {
@@ -358,7 +370,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     flags = member.flags,
                     objectId = member.objectId,
                     territoryType = member.territoryType,
-                    partyType = currentAlliance,
+                    partyType = partyType.ToString(),
                 });
             }
         }

--- a/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
@@ -383,6 +383,11 @@ namespace RainbowMage.OverlayPlugin.EventSources
         public override void LoadConfig(IPluginConfig config)
         {
             this.Config = container.Resolve<BuiltinEventConfig>();
+
+            this.Config.UpdateIntervalChanged += (o, e) =>
+            {
+                this.Start();
+            };
         }
 
         public override void SaveConfig(IPluginConfig config)
@@ -392,7 +397,9 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         public override void Start()
         {
-            this.timer.Change(0, 10);
+            // Use the config update interval, but clamp an upper limit at 5000ms
+            var updateInterval = Math.Min(5000, this.Config.UpdateInterval * 1000);
+            this.timer.Change(0, updateInterval);
         }
 
         protected override void Update()

--- a/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
@@ -292,6 +292,11 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 currentAlliance = remainingAlliances[1];
                 remainingAlliances.RemoveAt(1);
             }
+            else if ((cachedPartyList.Unk_3D40 & 0x10000) == 0x10000)
+            {
+                currentAlliance = remainingAlliances[2];
+                remainingAlliances.RemoveAt(2);
+            }
             else
             {
                 currentAlliance = remainingAlliances[2];
@@ -322,6 +327,9 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
                     cachedPartyList.Unk_3D40,
                 },
+#if DEBUG
+                debugPartyStruct = cachedPartyList,
+#endif
             }));
         }
 

--- a/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
@@ -233,13 +233,13 @@ namespace RainbowMage.OverlayPlugin.EventSources
             public int level;
             // @deprecated, please use partyType
             public bool inParty;
-            public long contentID;
+            public long contentId;
             // 0x1 = valid/present
             // 0x2 = unknown but set for some alliance members?
             // 0x4 = unknown but always set for current party and alliance members?
             // 0x8 = unknown but always set for current party?
             public byte flags;
-            public uint objectID;
+            public uint objectId;
             public ushort territoryType;
             public string partyType;
         }
@@ -286,17 +286,17 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     currentAlliance = "Party";
                 }
             }
-            else if ((cachedPartyList.Unk_3D40 & 0x100) == 0x100)
+            else if ((cachedPartyList.currentPartyFlags & 0x100) == 0x100)
             {
                 currentAlliance = remainingAlliances[0];
                 remainingAlliances.RemoveAt(0);
             }
-            else if ((cachedPartyList.Unk_3D40 & 0x1) == 0x1)
+            else if ((cachedPartyList.currentPartyFlags & 0x1) == 0x1)
             {
                 currentAlliance = remainingAlliances[1];
                 remainingAlliances.RemoveAt(1);
             }
-            else if ((cachedPartyList.Unk_3D40 & 0x10000) == 0x10000)
+            else if ((cachedPartyList.currentPartyFlags & 0x10000) == 0x10000)
             {
                 currentAlliance = remainingAlliances[2];
                 remainingAlliances.RemoveAt(2);
@@ -305,7 +305,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
             {
                 currentAlliance = remainingAlliances[2];
                 remainingAlliances.RemoveAt(2);
-                Log(LogLevel.Warning, $"Could not detect player alliance, value {cachedPartyList.Unk_3D40:X8}");
+                Log(LogLevel.Warning, $"Could not detect player alliance, value {cachedPartyList.currentPartyFlags:X8}");
             }
 
             BuildPartyMemberResults(result, cachedPartyList.partyMembers, currentAlliance, true);
@@ -329,7 +329,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     cachedPartyList.partyId_2,
                     cachedPartyList.partyLeaderIndex,
 
-                    cachedPartyList.Unk_3D40,
+                    cachedPartyList.currentPartyFlags,
                 },
 #if DEBUG
                 debugPartyStruct = cachedPartyList,
@@ -348,15 +348,15 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
                 result.Add(new PartyMember
                 {
-                    id = $"{member.objectID:X}",
+                    id = $"{member.objectId:X}",
                     name = member.name,
                     worldId = member.homeWorld,
                     job = member.classJob,
                     level = member.level,
                     inParty = inParty,
-                    contentID = member.contentID,
+                    contentId = member.contentId,
                     flags = member.flags,
-                    objectID = member.objectID,
+                    objectId = member.objectId,
                     territoryType = member.territoryType,
                     partyType = currentAlliance,
                 });
@@ -413,7 +413,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                         x = currentPlayer.PosX,
                         y = currentPlayer.PosY,
                         z = currentPlayer.PosZ,
-                        objectID = currentPlayer.ID,
+                        objectId = currentPlayer.ID,
                         currentHP = (uint) currentPlayer.CurrentHP,
                         maxHP = (uint) currentPlayer.MaxHP,
                         currentMP = (ushort) currentPlayer.CurrentMP,
@@ -492,7 +492,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
                     }
                 }
                 // If the party list is in a different order, dispatch the event
-                if (newMember.objectID != oldMember.objectID)
+                if (newMember.objectId != oldMember.objectId)
                 {
                     return true;
                 }

--- a/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVRequiredEventSource.cs
@@ -234,6 +234,10 @@ namespace RainbowMage.OverlayPlugin.EventSources
             // @deprecated, please use partyType
             public bool inParty;
             public long contentID;
+            // 0x1 = valid/present
+            // 0x2 = unknown but set for some alliance members?
+            // 0x4 = unknown but always set for current party and alliance members?
+            // 0x8 = unknown but always set for current party?
             public byte flags;
             public uint objectID;
             public ushort territoryType;
@@ -258,7 +262,7 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         private void DispatchPartyChangeEvent()
         {
-            // TODO: We know how to detect alliance A/B. Need to verify alliance C/D/E/F
+            // TODO: We know how to detect alliance A/B/C. Need to verify alliance D/E/F
             List<PartyMember> result = new List<PartyMember>(24);
 
             List<string> remainingAlliances = new List<string>() {
@@ -305,11 +309,11 @@ namespace RainbowMage.OverlayPlugin.EventSources
             }
 
             BuildPartyMemberResults(result, cachedPartyList.partyMembers, currentAlliance, true);
-            BuildPartyMemberResults(result, cachedPartyList.allianceAMembers, remainingAlliances[0], true);
-            BuildPartyMemberResults(result, cachedPartyList.allianceBMembers, remainingAlliances[1], true);
-            BuildPartyMemberResults(result, cachedPartyList.allianceCMembers, remainingAlliances[2], true);
-            BuildPartyMemberResults(result, cachedPartyList.allianceDMembers, remainingAlliances[3], true);
-            BuildPartyMemberResults(result, cachedPartyList.allianceEMembers, remainingAlliances[4], true);
+            BuildPartyMemberResults(result, cachedPartyList.alliance1Members, remainingAlliances[0], true);
+            BuildPartyMemberResults(result, cachedPartyList.alliance2Members, remainingAlliances[1], true);
+            BuildPartyMemberResults(result, cachedPartyList.alliance3Members, remainingAlliances[2], true);
+            BuildPartyMemberResults(result, cachedPartyList.alliance4Members, remainingAlliances[3], true);
+            BuildPartyMemberResults(result, cachedPartyList.alliance5Members, remainingAlliances[4], true);
 
             Log(LogLevel.Debug, "party list: {0}", JObject.FromObject(new { party = result }).ToString());
 
@@ -418,10 +422,6 @@ namespace RainbowMage.OverlayPlugin.EventSources
                         name = currentPlayer.Name,
                         classJob = currentPlayer.Job,
                         level = currentPlayer.Level,
-                        // 0x1 = valid/present
-                        // 0x2 = unknown but set for some alliance members?
-                        // 0x4 = unknown but always set for current party and alliance members?
-                        // 0x8 = unknown but always set for current party?
                         flags = 0x13,
                     },
                 };
@@ -434,30 +434,30 @@ namespace RainbowMage.OverlayPlugin.EventSources
             {
                 dispatchEvent = true;
             }
-            // Check each of party and alliances A/B/C/D/E
+            // Check each of party and alliances 1-5
             if (!dispatchEvent)
             {
                 dispatchEvent = HasPartyCompChanged(cachedPartyList.partyMembers, newParty.partyMembers);
             }
             if (!dispatchEvent)
             {
-                dispatchEvent = HasPartyCompChanged(cachedPartyList.allianceAMembers, newParty.allianceAMembers);
+                dispatchEvent = HasPartyCompChanged(cachedPartyList.alliance1Members, newParty.alliance1Members);
             }
             if (!dispatchEvent)
             {
-                dispatchEvent = HasPartyCompChanged(cachedPartyList.allianceBMembers, newParty.allianceBMembers);
+                dispatchEvent = HasPartyCompChanged(cachedPartyList.alliance2Members, newParty.alliance2Members);
             }
             if (!dispatchEvent)
             {
-                dispatchEvent = HasPartyCompChanged(cachedPartyList.allianceCMembers, newParty.allianceCMembers);
+                dispatchEvent = HasPartyCompChanged(cachedPartyList.alliance3Members, newParty.alliance3Members);
             }
             if (!dispatchEvent)
             {
-                dispatchEvent = HasPartyCompChanged(cachedPartyList.allianceDMembers, newParty.allianceDMembers);
+                dispatchEvent = HasPartyCompChanged(cachedPartyList.alliance4Members, newParty.alliance4Members);
             }
             if (!dispatchEvent)
             {
-                dispatchEvent = HasPartyCompChanged(cachedPartyList.allianceEMembers, newParty.allianceEMembers);
+                dispatchEvent = HasPartyCompChanged(cachedPartyList.alliance5Members, newParty.alliance5Members);
             }
             cachedPartyList = newParty;
             if (dispatchEvent)

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/Data.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/Data.cs
@@ -33,7 +33,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs
 
         // @TODO: At some point the runtime checks in this function should be moved to a compile-time test instead
         // and this function can return `long` instead of `long?`
-        public long? GetClassInstanceAddress(DataNamespace ns, string targetClass)
+        public long? GetClassInstanceAddress(DataNamespace ns, string targetClass, int index = 0)
         {
             var curObj = GetBaseObject(ns);
             if (curObj == null)
@@ -54,7 +54,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs
                 return null;
             }
 
-            return instances[0].ea - DataBaseOffset;
+            return instances[index].ea - DataBaseOffset;
         }
 
         public ClientStructsData GetBaseObject(DataNamespace ns)

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
@@ -35,11 +35,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         public uint Unk_3D40;
 
         public PartyListEntry[] partyMembers;
-        public PartyListEntry[] allianceAMembers;
-        public PartyListEntry[] allianceBMembers;
-        public PartyListEntry[] allianceCMembers;
-        public PartyListEntry[] allianceDMembers;
-        public PartyListEntry[] allianceEMembers;
+        public PartyListEntry[] alliance1Members;
+        public PartyListEntry[] alliance2Members;
+        public PartyListEntry[] alliance3Members;
+        public PartyListEntry[] alliance4Members;
+        public PartyListEntry[] alliance5Members;
     }
 
     public abstract class PartyMemory

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
+{
+    public class PartyListEntry
+    {
+        public float x;
+        public float y;
+        public float z;
+        public long contentID;
+        public uint objectID;
+        public uint currentHP;
+        public uint maxHP;
+        public ushort currentMP;
+        public ushort maxMP;
+        public ushort territoryType;
+        public ushort homeWorld;
+        public string name;
+        public byte sex;
+        public byte classJob;
+        public byte level;
+        public byte flags;
+    }
+
+    public class PartyListsStruct
+    {
+        public long partyId;
+        public long partyId_2;
+        public uint partyLeaderIndex;
+        public byte memberCount;
+        public byte allianceFlags;
+
+        public PartyListEntry[] partyMembers;
+        public PartyListEntry[] allianceAMembers;
+        public PartyListEntry[] allianceBMembers;
+        public PartyListEntry[] allianceCMembers;
+        public PartyListEntry[] allianceDMembers;
+        public PartyListEntry[] allianceEMembers;
+    }
+
+    public abstract class PartyMemory
+    {
+        protected FFXIVMemory memory;
+        protected ILogger logger;
+
+        protected IntPtr party1InstanceAddress = IntPtr.Zero;
+        protected IntPtr party2InstanceAddress = IntPtr.Zero;
+
+        private long partySingletonAddressInstance1;
+        private long partySingletonAddressInstance2;
+
+        public PartyMemory(TinyIoCContainer container, long partySingletonAddressInstance1, long partySingletonAddressInstance2)
+        {
+            this.partySingletonAddressInstance1 = partySingletonAddressInstance1;
+            this.partySingletonAddressInstance2 = partySingletonAddressInstance2;
+            logger = container.Resolve<ILogger>();
+            memory = container.Resolve<FFXIVMemory>();
+        }
+
+        private void ResetPointers()
+        {
+            party1InstanceAddress = IntPtr.Zero;
+        }
+
+        private bool HasValidPointers()
+        {
+            if (party1InstanceAddress == IntPtr.Zero)
+                return false;
+            if (party2InstanceAddress == IntPtr.Zero)
+                return false;
+            return true;
+        }
+
+        public bool IsValid()
+        {
+            if (!memory.IsValid())
+                return false;
+
+            if (!HasValidPointers())
+                return false;
+
+            return true;
+        }
+
+        public void ScanPointers()
+        {
+            ResetPointers();
+            if (!memory.IsValid())
+                return;
+
+            List<string> fail = new List<string>();
+
+            // These addresses aren't pointers, they're static memory structures. Therefore we don't need to resolve nested pointers.
+            long instanceAddress = memory.GetBaseAddress().ToInt64() + partySingletonAddressInstance1;
+
+            if (instanceAddress != 0)
+            {
+                party1InstanceAddress = new IntPtr(instanceAddress);
+            }
+            else
+            {
+                party1InstanceAddress = IntPtr.Zero;
+                fail.Add(nameof(party1InstanceAddress));
+            }
+
+            instanceAddress = memory.GetBaseAddress().ToInt64() + partySingletonAddressInstance2;
+
+            if (instanceAddress != 0)
+            {
+                party2InstanceAddress = new IntPtr(instanceAddress);
+            }
+            else
+            {
+                party2InstanceAddress = IntPtr.Zero;
+                fail.Add(nameof(party2InstanceAddress));
+            }
+
+            logger.Log(LogLevel.Debug, "party1InstanceAddress: 0x{0:X}", party1InstanceAddress.ToInt64());
+            logger.Log(LogLevel.Debug, "party2InstanceAddress: 0x{0:X}", party2InstanceAddress.ToInt64());
+
+            if (fail.Count == 0)
+            {
+                logger.Log(LogLevel.Info, $"Found party memory via {GetType().Name}.");
+                return;
+            }
+
+            // @TODO: Change this from Debug to Error once we're actually using party
+            logger.Log(LogLevel.Debug, $"Failed to find party memory via {GetType().Name}: {string.Join(", ", fail)}.");
+            return;
+        }
+
+        public abstract Version GetVersion();
+
+        public IntPtr GetPointer()
+        {
+            if (!IsValid())
+                return IntPtr.Zero;
+            return party1InstanceAddress;
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
@@ -9,8 +9,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         public float x;
         public float y;
         public float z;
-        public long contentID;
-        public uint objectID;
+        public long contentId;
+        public uint objectId;
         public uint currentHP;
         public uint maxHP;
         public ushort currentMP;
@@ -32,7 +32,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         public byte memberCount;
         public byte allianceFlags;
 
-        public uint Unk_3D40;
+        public uint currentPartyFlags;
 
         public PartyListEntry[] partyMembers;
         public PartyListEntry[] alliance1Members;

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
@@ -32,6 +32,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         public byte memberCount;
         public byte allianceFlags;
 
+        public uint Unk_3D40;
+
         public PartyListEntry[] partyMembers;
         public PartyListEntry[] allianceAMembers;
         public PartyListEntry[] allianceBMembers;

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
@@ -60,7 +60,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
                 memberCount = groupManager1.MemberCount,
                 allianceFlags = groupManager1.AllianceFlags,
 
-                Unk_3D40 = groupManager1.Unk_3D40,
+                currentPartyFlags = groupManager1.Unk_3D40,
 
                 partyMembers = partyMembers,
                 alliance1Members = alliance1Members,
@@ -99,8 +99,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
                     x = member.X,
                     y = member.Y,
                     z = member.Z,
-                    contentID = member.ContentID,
-                    objectID = member.ObjectID,
+                    contentId = member.ContentID,
+                    objectId = member.ObjectID,
                     currentHP = member.CurrentHP,
                     maxHP = member.MaxHP,
                     currentMP = member.CurrentMP,

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using FFXIVClientStructs.Global.FFXIV.Client.Game.Group;
-using FFXIVClientStructs.Global.FFXIV.Component.GUI;
 using RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
@@ -60,6 +59,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
                 partyLeaderIndex = groupManager1.PartyLeaderIndex,
                 memberCount = groupManager1.MemberCount,
                 allianceFlags = groupManager1.AllianceFlags,
+
+                Unk_3D40 = groupManager1.Unk_3D40,
 
                 partyMembers = partyMembers,
                 allianceAMembers = allianceAMembers,

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
@@ -45,12 +45,12 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
 
             // `AllianceMembers` is a fixed-position array, with removed elements being mostly zero'd out
             // Easiest way to check if an entry is still active is to check for `Flags != 0`
-            var allianceAMembers = extractAllianceMembers(groupManager1.AllianceMembers, 20, 0, 8);
-            var allianceBMembers = extractAllianceMembers(groupManager1.AllianceMembers, 20, 8, 8);
-            // TOOD: Actually verify C/D/E alliance info?
-            var allianceCMembers = extractAllianceMembers(groupManager2.PartyMembers, 8, 0, 8);
-            var allianceDMembers = extractAllianceMembers(groupManager2.AllianceMembers, 20, 0, 8);
-            var allianceEMembers = extractAllianceMembers(groupManager2.AllianceMembers, 20, 8, 8);
+            var alliance1Members = extractAllianceMembers(groupManager1.AllianceMembers, 20, 0, 8);
+            var alliance2Members = extractAllianceMembers(groupManager1.AllianceMembers, 20, 8, 8);
+            // TOOD: Actually verify D/E/F alliance info?
+            var alliance3Members = extractAllianceMembers(groupManager2.PartyMembers, 8, 0, 8);
+            var alliance4Members = extractAllianceMembers(groupManager2.AllianceMembers, 20, 0, 8);
+            var alliance5Members = extractAllianceMembers(groupManager2.AllianceMembers, 20, 8, 8);
 
             return new PartyListsStruct()
             {
@@ -63,11 +63,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
                 Unk_3D40 = groupManager1.Unk_3D40,
 
                 partyMembers = partyMembers,
-                allianceAMembers = allianceAMembers,
-                allianceBMembers = allianceBMembers,
-                allianceCMembers = allianceCMembers,
-                allianceDMembers = allianceDMembers,
-                allianceEMembers = allianceEMembers,
+                alliance1Members = alliance1Members,
+                alliance2Members = alliance2Members,
+                alliance3Members = alliance3Members,
+                alliance4Members = alliance4Members,
+                alliance5Members = alliance5Members,
             };
         }
 

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using FFXIVClientStructs.Global.FFXIV.Client.Game.Group;
+using FFXIVClientStructs.Global.FFXIV.Component.GUI;
+using RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
+{
+    interface IPartyMemory64 : IPartyMemory { }
+
+    class PartyMemory64 : PartyMemory, IPartyMemory64
+    {
+        private static long GetPartySingletonAddress(TinyIoCContainer container, int instance)
+        {
+            var data = container.Resolve<Data>();
+            return (long)data.GetClassInstanceAddress(DataNamespace.Global, "Client::Game::Group::GroupManager", instance);
+        }
+
+        public PartyMemory64(TinyIoCContainer container) : base(container, GetPartySingletonAddress(container, 0), GetPartySingletonAddress(container, 1)) { }
+
+        public override Version GetVersion()
+        {
+            return new Version(6, 4);
+        }
+
+
+        public unsafe PartyListsStruct GetPartyLists()
+        {
+            if (!IsValid())
+            {
+                return new PartyListsStruct();
+            }
+
+            if (party1InstanceAddress.ToInt64() == 0)
+            {
+                return new PartyListsStruct();
+            }
+            var groupManager1 = ManagedType<GroupManager>.GetManagedTypeFromIntPtr(party1InstanceAddress, memory).ToType();
+            var groupManager2 = ManagedType<GroupManager>.GetManagedTypeFromIntPtr(party2InstanceAddress, memory).ToType();
+
+            // `PartyMembers` is a standard array, members are moved up/down as they're added/removed.
+            // As such, limit extracting members to the current count to avoid "ghost" members
+            var partyMembers = extractPartyMembers(groupManager1.PartyMembers, Math.Min((int)groupManager1.MemberCount, 8));
+
+            // `AllianceMembers` is a fixed-position array, with removed elements being mostly zero'd out
+            // Easiest way to check if an entry is still active is to check for `Flags != 0`
+            var allianceAMembers = extractAllianceMembers(groupManager1.AllianceMembers, 20, 0, 8);
+            var allianceBMembers = extractAllianceMembers(groupManager1.AllianceMembers, 20, 8, 8);
+            // TOOD: Actually verify C/D/E alliance info?
+            var allianceCMembers = extractAllianceMembers(groupManager2.PartyMembers, 8, 0, 8);
+            var allianceDMembers = extractAllianceMembers(groupManager2.AllianceMembers, 20, 0, 8);
+            var allianceEMembers = extractAllianceMembers(groupManager2.AllianceMembers, 20, 8, 8);
+
+            return new PartyListsStruct()
+            {
+                partyId = groupManager1.PartyId,
+                partyId_2 = groupManager1.PartyId_2,
+                partyLeaderIndex = groupManager1.PartyLeaderIndex,
+                memberCount = groupManager1.MemberCount,
+                allianceFlags = groupManager1.AllianceFlags,
+
+                partyMembers = partyMembers,
+                allianceAMembers = allianceAMembers,
+                allianceBMembers = allianceBMembers,
+                allianceCMembers = allianceCMembers,
+                allianceDMembers = allianceDMembers,
+                allianceEMembers = allianceEMembers,
+            };
+        }
+
+        private unsafe PartyListEntry[] extractAllianceMembers(byte* allianceMembers, int elementCount, int start, int count)
+        {
+            var allMembers = extractPartyMembers(allianceMembers, elementCount);
+            var retMembers = new PartyListEntry[count];
+            for (var i = start; i < start + count && i < allMembers.Length; ++i)
+            {
+                var member = allMembers[i];
+                if (member.flags == 0)
+                {
+                    continue;
+                }
+
+                retMembers[i - start] = member;
+            }
+            return retMembers;
+        }
+
+        private unsafe PartyListEntry[] extractPartyMembers(byte* ptr, int count)
+        {
+            var ret = new PartyListEntry[count];
+            for (int i = 0; i < count; ++i)
+            {
+                var member = Marshal.PtrToStructure<PartyMember>(new IntPtr(ptr + (i * sizeof(PartyMember))));
+                ret[i] = new PartyListEntry()
+                {
+                    x = member.X,
+                    y = member.Y,
+                    z = member.Z,
+                    contentID = member.ContentID,
+                    objectID = member.ObjectID,
+                    currentHP = member.CurrentHP,
+                    maxHP = member.MaxHP,
+                    currentMP = member.CurrentMP,
+                    maxMP = member.MaxMP,
+                    territoryType = member.TerritoryType,
+                    homeWorld = member.HomeWorld,
+                    name = FFXIVMemory.GetStringFromBytes(member.Name, 0x40),
+                    sex = member.Sex,
+                    classJob = member.ClassJob,
+                    level = member.Level,
+                    flags = member.Flags,
+                };
+            }
+            return ret;
+        }
+
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory65.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory65.cs
@@ -7,109 +7,111 @@ using RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
 {
-    interface IPartyMemory64 : IPartyMemory { }
+    interface IPartyMemory65 : IPartyMemory { }
 
-    public class PartyMemory64 : PartyMemory, IPartyMemory64
+    public class PartyMemory65 : PartyMemory, IPartyMemory65
     {
         // Due to lack of multi-version support in FFXIVClientStructs, we need to duplicate these structures here per-version
         // We use FFXIVClientStructs versions of the structs because they have more required details than FFXIV_ACT_Plugin's struct definitions
         #region FFXIVClientStructs structs
-        [StructLayout(LayoutKind.Explicit, Size = 0x188)]
+        [StructLayout(LayoutKind.Explicit, Size = 0x2F0)]
         public unsafe partial struct StatusManager
         {
             [FieldOffset(0x0)]
             public void* Owner;
             [FieldOffset(0x8)]
-            public fixed byte Status[0xC * 30]; // Client::Game::Status array
-            [FieldOffset(0x170)]
-            public uint Unk_170;
-            [FieldOffset(0x174)]
-            public ushort Unk_174;
-            [FieldOffset(0x178)]
+            public fixed byte Status[0xC * 60]; // Client::Game::Status array
+            [FieldOffset(0x2D8)]
+            public uint Flags1;
+            [FieldOffset(0x2DC)]
+            public ushort Flags2;
+            [FieldOffset(0x2E0)]
             public long Unk_178;
-            [FieldOffset(0x180)]
-            public byte Unk_180;
+            [FieldOffset(0x2E8)]
+            public byte NumValidStatuses;
         }
-        [StructLayout(LayoutKind.Explicit, Size = 0x230)]
+        [StructLayout(LayoutKind.Explicit, Size = 0x390)]
         public unsafe struct PartyMember
         {
             [FieldOffset(0x0)]
             public StatusManager StatusManager;
-            [FieldOffset(0x190)]
+            [FieldOffset(0x2F0)]
             public float X;
-            [FieldOffset(0x194)]
+            [FieldOffset(0x2F4)]
             public float Y;
-            [FieldOffset(0x198)]
+            [FieldOffset(0x2F8)]
             public float Z;
-            [FieldOffset(0x1A0)]
+            [FieldOffset(0x300)]
             public long ContentID;
-            [FieldOffset(0x1A8)]
+            [FieldOffset(0x308)]
             public uint ObjectID;
-            [FieldOffset(0x1AC)]
+            [FieldOffset(0x30C)]
             public uint Unk_ObjectID_1;
-            [FieldOffset(0x1B0)]
+            [FieldOffset(0x310)]
             public uint Unk_ObjectID_2;
-            [FieldOffset(0x1B4)]
+            [FieldOffset(0x314)]
             public uint CurrentHP;
-            [FieldOffset(0x1B8)]
+            [FieldOffset(0x318)]
             public uint MaxHP;
-            [FieldOffset(0x1BC)]
+            [FieldOffset(0x31C)]
             public ushort CurrentMP;
-            [FieldOffset(0x1BE)]
+            [FieldOffset(0x31E)]
             public ushort MaxMP;
-            [FieldOffset(0x1C0)]
+            [FieldOffset(0x320)]
             public ushort TerritoryType;
-            [FieldOffset(0x1C2)]
+            [FieldOffset(0x322)]
             public ushort HomeWorld;
-            [FieldOffset(0x1C4)]
+            [FieldOffset(0x324)]
             public fixed byte Name[0x40];
-            [FieldOffset(0x204)]
+            [FieldOffset(0x364)]
             public byte Sex;
-            [FieldOffset(0x205)]
+            [FieldOffset(0x365)]
             public byte ClassJob;
-            [FieldOffset(0x206)]
+            [FieldOffset(0x366)]
             public byte Level;
-            [FieldOffset(0x208)]
+            [FieldOffset(0x367)]
+            public byte DamageShield;
+            [FieldOffset(0x368)]
             public byte Unk_Struct_208__0;
-            [FieldOffset(0x20C)]
+            [FieldOffset(0x36C)]
             public uint Unk_Struct_208__4;
-            [FieldOffset(0x210)]
+            [FieldOffset(0x370)]
             public ushort Unk_Struct_208__8;
-            [FieldOffset(0x214)]
+            [FieldOffset(0x374)]
             public uint Unk_Struct_208__C;
-            [FieldOffset(0x218)]
+            [FieldOffset(0x378)]
             public ushort Unk_Struct_208__10;
-            [FieldOffset(0x21A)]
+            [FieldOffset(0x37A)]
             public ushort Unk_Struct_208__14;
-            [FieldOffset(0x220)]
+            [FieldOffset(0x380)]
             public byte Flags; // 0x01 == set for valid alliance members
         }
-        [StructLayout(LayoutKind.Explicit, Size = 0x3D70)]
+        [StructLayout(LayoutKind.Explicit, Size = 0x63F0)]
         public unsafe partial struct GroupManager
         {
             [FieldOffset(0x0)]
-            public fixed byte PartyMembers[0x230 * 8]; // PartyMember type
-            [FieldOffset(0x1180)]
-            public fixed byte AllianceMembers[0x230 * 20]; // PartyMember type
-            [FieldOffset(0x3D40)]
+            public fixed byte PartyMembers[0x390 * 8]; // PartyMember type
+            [FieldOffset(0x1C80)]
+            public fixed byte AllianceMembers[0x390 * 20]; // PartyMember type
+            [FieldOffset(0x63C0)]
             public uint Unk_3D40;
-            [FieldOffset(0x3D44)]
+            [FieldOffset(0x63C4)]
             public ushort Unk_3D44;
-            [FieldOffset(0x3D48)]
+            [FieldOffset(0x63C8)]
             public long PartyId; // both seem to be unique per party and replicated to every member
-            [FieldOffset(0x3D50)]
+            [FieldOffset(0x63D0)]
             public long PartyId_2;
-            [FieldOffset(0x3D58)]
+            [FieldOffset(0x63D8)]
             public uint PartyLeaderIndex; // index of party leader in array
-            [FieldOffset(0x3D5C)]
+            [FieldOffset(0x63DC)]
             public byte MemberCount;
-            [FieldOffset(0x3D5D)]
+            [FieldOffset(0x63DD)]
             public byte Unk_3D5D;
-            [FieldOffset(0x3D5F)]
+            [FieldOffset(0x63DF)]
             public byte Unk_3D5F; // some sort of count
-            [FieldOffset(0x3D60)]
+            [FieldOffset(0x63E0)]
             public byte Unk_3D60;
-            [FieldOffset(0x3D61)]
+            [FieldOffset(0x63E1)]
             public byte AllianceFlags; // 0x01 == is alliance; 0x02 == alliance with 5 4-man groups rather than 2 8-man
         }
         #endregion
@@ -120,11 +122,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
             public GroupManager groupManager2;
         }
 
-        public PartyMemory64(TinyIoCContainer container) : base(container) { }
+        public PartyMemory65(TinyIoCContainer container) : base(container) { }
 
         public override Version GetVersion()
         {
-            return new Version(6, 4);
+            return new Version(6, 5);
         }
 
 

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
+{
+    public interface IPartyMemory : IVersionedMemory
+    {
+        PartyListsStruct GetPartyLists();
+    }
+
+    class PartyMemoryManager : IPartyMemory
+    {
+        private readonly TinyIoCContainer container;
+        private readonly FFXIVRepository repository;
+        private IPartyMemory memory = null;
+
+        public PartyMemoryManager(TinyIoCContainer container)
+        {
+            this.container = container;
+            container.Register<IPartyMemory64, PartyMemory64>();
+            repository = container.Resolve<FFXIVRepository>();
+
+            var memory = container.Resolve<FFXIVMemory>();
+            memory.RegisterOnProcessChangeHandler(FindMemory);
+        }
+
+        private void FindMemory(object sender, Process p)
+        {
+            memory = null;
+            if (p == null)
+            {
+                return;
+            }
+            ScanPointers();
+        }
+
+        public void ScanPointers()
+        {
+            List<IPartyMemory> candidates = new List<IPartyMemory>();
+            candidates.Add(container.Resolve<IPartyMemory64>());
+            memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
+        }
+
+        public bool IsValid()
+        {
+            if (memory == null || !memory.IsValid())
+            {
+                return false;
+            }
+            return true;
+        }
+
+        Version IVersionedMemory.GetVersion()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
+        }
+
+        public PartyListsStruct GetPartyLists()
+        {
+            if (!IsValid())
+            {
+                return new PartyListsStruct();
+            }
+            return memory.GetPartyLists();
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
@@ -19,6 +19,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         {
             this.container = container;
             container.Register<IPartyMemory64, PartyMemory64>();
+            container.Register<IPartyMemory65, PartyMemory65>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();
@@ -39,6 +40,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         {
             List<IPartyMemory> candidates = new List<IPartyMemory>();
             candidates.Add(container.Resolve<IPartyMemory64>());
+            candidates.Add(container.Resolve<IPartyMemory65>());
             memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
         }
 

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -123,6 +123,7 @@
     <Compile Include="MemoryProcessors\InCombat\InCombatMemoryManager.cs" />
     <Compile Include="MemoryProcessors\InCombat\LineInCombat.cs" />
     <Compile Include="MemoryProcessors\Party\PartyMemory.cs" />
+    <Compile Include="MemoryProcessors\Party\PartyMemory65.cs" />
     <Compile Include="MemoryProcessors\Party\PartyMemory64.cs" />
     <Compile Include="MemoryProcessors\Party\PartyMemoryManager.cs" />
     <Compile Include="MemoryProcessors\Target\TargetMemory63.cs" />

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -122,6 +122,9 @@
     <Compile Include="MemoryProcessors\InCombat\InCombatMemory61.cs" />
     <Compile Include="MemoryProcessors\InCombat\InCombatMemoryManager.cs" />
     <Compile Include="MemoryProcessors\InCombat\LineInCombat.cs" />
+    <Compile Include="MemoryProcessors\Party\PartyMemory.cs" />
+    <Compile Include="MemoryProcessors\Party\PartyMemory64.cs" />
+    <Compile Include="MemoryProcessors\Party\PartyMemoryManager.cs" />
     <Compile Include="MemoryProcessors\Target\TargetMemory63.cs" />
     <Compile Include="MemoryProcessors\Target\TargetMemoryManager.cs" />
     <Compile Include="MemoryProcessors\Target\TargetMemory.cs" />

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -19,6 +19,7 @@ using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Enmity;
 using RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud;
 using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
+using RainbowMage.OverlayPlugin.MemoryProcessors.Party;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Target;
 using RainbowMage.OverlayPlugin.NetworkProcessors;
 using RainbowMage.OverlayPlugin.Overlays;
@@ -272,6 +273,7 @@ namespace RainbowMage.OverlayPlugin
                                 _container.Register<IEnmityHudMemory, EnmityHudMemoryManager>();
                                 _container.Register<IInCombatMemory, InCombatMemoryManager>();
                                 _container.Register<IAtkStageMemory, AtkStageMemoryManager>();
+                                _container.Register<IPartyMemory, PartyMemoryManager>();
 
                                 _container.Register(new OverlayPluginLogLines(_container));
                             }


### PR DESCRIPTION
This still requires some additional testing and some adjusted handling for whatever edge case causes multiple 4-man parties instead of 8-man parties, as well as some cleanup of the emitted event.

I wanted to get this open as a PR instead of continuing discussion in DMs since it'll be easier to discuss when everyone can reference the code.

I'm still trying to track down the flag that determines what alliance the current player is in, after that I'll be able to better distinguish A/B/C alliance info.

I'm not sure exactly what content this is referring to:
```cs
        [FieldOffset(0x3D61)]
        public byte AllianceFlags; // 0x01 == is alliance; 0x02 == alliance with 5 4-man groups rather than 2 8-man
```

~~Here's an anonymized example of the event emitted during an alliance raid~~:

Removed json since it's no longer relevant.