### PR TITLE
Update StripFFXIVClientStructs to run on .NET 6.0

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -68,7 +68,7 @@ try {
 
             echo "==> Stripping FFXIVClientStructs for namespace $ns..."
 
-            ..\..\..\..\tools\StripFFXIVClientStructs\StripFFXIVClientStructs\bin\Release\netcoreapp3.1\StripFFXIVClientStructs.exe $ns .\$ns ..\Transformed\$ns
+            ..\..\..\..\tools\StripFFXIVClientStructs\StripFFXIVClientStructs\bin\Release\net6.0\StripFFXIVClientStructs.exe $ns .\$ns ..\Transformed\$ns
         }
 
         cd ..\..\..\..

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This branch was done from the OverlayPlugin/OverlayPlugin repo instead of my fork to force the github-side build to run in the same environment with the same dependency cache resolution.