### PR TITLE
Improvement about the 260 ACT/game InCombat log line

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/LineInCombat.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/LineInCombat.cs
@@ -66,16 +66,24 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
             // always set this to true if lastEventArgs == null so that if ACT is started while out of combat,
             // the overlays are hidden/shown appropriately.
             bool inGameCombatChanged = lastEventArgs == null ? inGameCombat : lastEventArgs.InGameCombat != inGameCombat;
+
+            // Add two boolean variables into the logline to indicate exactly which part was changed.
+            // Useful if a plugin only cares about the change of in-game or ACT combat state to trigger other events.
+            bool isACTChanged = lastEventArgs != null && lastEventArgs.InACTCombat != inACTCombat;
+            bool isGameChanged = lastEventArgs != null && lastEventArgs.InGameCombat != inGameCombat;
+
             lastEventArgs = new InCombatArgs(inACTCombat, inGameCombat, inGameCombatChanged);
-            WriteLine(inACTCombat, inGameCombat);
+            WriteLine(inACTCombat, inGameCombat, isACTChanged, isGameChanged);
             OnInCombatChanged?.Invoke(this, lastEventArgs);
         }
 
-        public void WriteLine(bool inACTCombat, bool inGameCombat)
+        public void WriteLine(bool inACTCombat, bool inGameCombat, bool isACTChanged, bool isGameChanged)
         {
             var inACTCombatDecimal = inACTCombat ? 1 : 0;
             var inGameCombatDecimal = inGameCombat ? 1 : 0;
-            var line = $"{inACTCombatDecimal}|{inGameCombatDecimal}";
+            var isACTChangedDecimal = isACTChanged ? 1 : 0;
+            var isGameChangedDecimal = isGameChanged ? 1 : 0;
+            var line = $"{inACTCombatDecimal}|{inGameCombatDecimal}|Changed|{isACTChangedDecimal}|{isGameChangedDecimal}";
             logWriter(line, ffxiv.GetServerTimestamp());
         }
     }

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/LineInCombat.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/LineInCombat.cs
@@ -83,7 +83,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
             var inGameCombatDecimal = inGameCombat ? 1 : 0;
             var isACTChangedDecimal = isACTChanged ? 1 : 0;
             var isGameChangedDecimal = isGameChanged ? 1 : 0;
-            var line = $"{inACTCombatDecimal}|{inGameCombatDecimal}|Changed|{isACTChangedDecimal}|{isGameChangedDecimal}";
+            var line = $"{inACTCombatDecimal}|{inGameCombatDecimal}|{isACTChangedDecimal}|{isGameChangedDecimal}";
             logWriter(line, ffxiv.GetServerTimestamp());
         }
     }


### PR DESCRIPTION
Added two new fields to `0x104` log lines indicating which source was changed.  
  
Format:  

    260|timestamp|{ACTState}|{GameState}|Changed|{ACTIsChanged}|{GameIsChanged}
    [time] 260 104:{ACTState}:{GameState}:Changed:{ACTIsChanged}:{GameIsChanged}
  
_e.g._  `ACT InCombat` = `1` (unchanged), `GameInCombat` = `0`  → `1` (changed):
| Original log line | `260 104:1:1`|
|:---:|:---:|
| **Updated new log line**  | **`260 104:1:1:Changed:0:1`**  |
 

  
Useful for other plugins which only care about the change of in-game / ACT state to trigger other events.    
_e.g._ Using `104:.:1:Changed:.:1` to detect the start of a raid, while using the previous version `104:1:1` could be infected by custom ACT configurations.
  
Related discussion: [Discord](https://discord.com/channels/551474815727304704/594899820976668673/1068678252958318712)