### PR TITLE
Location/Heading for ActorCast + ActionEffect

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -372,6 +372,44 @@ namespace RainbowMage.OverlayPlugin
             return machinaEpochToDateTimeWrapper(epoch).ToLocalTime();
         }
 
+        /**
+         * Convert a coordinate expressed as a uint16 to a float.
+         *
+         * See https://github.com/ravahn/FFXIV_ACT_Plugin/issues/298
+         */
+        public float ConvertUInt16Coordinate(ushort value)
+        {
+            return (value - 0x7FFF) / 32.767f;
+        }
+
+        /**
+         * Convert a packet heading to an in-game headiung.
+         * 
+         * When a heading is sent in certain packets, the heading is expressed as a uint16, where
+         * 0=north and each increment is 1/65536 of a turn in the CCW direction.
+         * 
+         * See https://github.com/ravahn/FFXIV_ACT_Plugin/issues/298
+         */
+        public double ConvertHeading(ushort heading)
+        {
+            return heading
+               // Normalize to turns
+               / 65536.0
+               // Normalize to radians
+               * 2 * Math.PI
+               // Flip from 0=north to 0=south like the game uses
+               - Math.PI;
+        }
+
+        /**
+         * Reinterpret a float as a UInt16. Some fields in Machina, such as Server_ActorCast.Rotation, are
+         * marked as floats when they really should be UInt16.
+         */
+        public ushort InterpretFloatAsUInt16(float value)
+        {
+            return BitConverter.ToUInt16(BitConverter.GetBytes(value), 0);
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal bool WriteLogLineImpl(uint ID, DateTime timestamp, string line)
         {

--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -24,6 +24,7 @@ namespace RainbowMage.OverlayPlugin
             container.Register(new LineCombatant(container));
             container.Register(new LineRSV(container));
             container.Register(new LineActorCastExtra(container));
+            container.Register(new LineAbilityExtra(container));
         }
     }
 

--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -23,6 +23,7 @@ namespace RainbowMage.OverlayPlugin
             container.Register(new LineInCombat(container));
             container.Register(new LineCombatant(container));
             container.Register(new LineRSV(container));
+            container.Register(new LineActorCastExtra(container));
         }
     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -24,15 +24,106 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private readonly int offsetMessageType;
         private readonly FFXIVRepository ffxiv;
 
-        private Type actionEffectHeaderType;
-        private Func<string, DateTime, bool> logWriter;
-        private Dictionary<int, ActionEffectTypeInfo> opcodeToType = new Dictionary<int, ActionEffectTypeInfo>();
-        private FieldInfo fieldR;
+        private readonly Type actionEffectHeaderType;
+        private readonly Func<string, DateTime, bool> logWriter;
+        private readonly Type headerType;
+
+        private readonly Dictionary<int, ActionEffectTypeInfo> opcodeToType =
+            new Dictionary<int, ActionEffectTypeInfo>();
+
+        private readonly FieldInfo fieldCastSourceId;
+        private readonly FieldInfo fieldGlobalEffectCounter;
+        private readonly FieldInfo fieldR;
 
         private class ActionEffectTypeInfo
         {
+            public int actionEffectSize;
             public int packetSize;
-            public Type machinaType;
+            public Type extraType;
+            public bool hasError = false;
+        }
+
+        interface IActionEffectExtra
+        {
+            ushort x { get; }
+            ushort y { get; }
+            ushort z { get; }
+        }
+
+        [StructLayout(LayoutKind.Explicit, Pack = 1, Size = 0x29C)]
+        private struct Server_ActionEffect8_Extra : IActionEffectExtra
+        {
+            [FieldOffset(0x290)]
+            private ushort _x;
+
+            [FieldOffset(0x292)]
+            private ushort _z;
+
+            [FieldOffset(0x294)]
+            private ushort _y;
+
+            public ushort x => _x;
+            public ushort y => _y;
+            public ushort z => _z;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Pack = 1, Size = 0x4DC)]
+        private struct Server_ActionEffect16_Extra : IActionEffectExtra
+        {
+            [FieldOffset(0x4D0)]
+            public ushort _x;
+
+            [FieldOffset(0x4D2)]
+            public ushort _z;
+
+            [FieldOffset(0x4D4)]
+            public ushort _y;
+
+            public ushort x => _x;
+            public ushort y => _y;
+            public ushort z => _z;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Pack = 1, Size = 0x71C)]
+        private struct Server_ActionEffect24_Extra : IActionEffectExtra
+        {
+            [FieldOffset(0x710)]
+            public ushort _x;
+
+            [FieldOffset(0x712)]
+            public ushort _z;
+
+            [FieldOffset(0x714)]
+            public ushort _y;
+
+            public ushort x => _x;
+            public ushort y => _y;
+            public ushort z => _z;
+        }
+
+        [StructLayout(LayoutKind.Explicit, Pack = 1, Size = 0x95C)]
+        private struct Server_ActionEffect32_Extra : IActionEffectExtra
+        {
+            [FieldOffset(0x950)]
+            public ushort _x;
+
+            [FieldOffset(0x952)]
+            public ushort _z;
+
+            [FieldOffset(0x954)]
+            public ushort _y;
+
+            public ushort x => _x;
+            public ushort y => _y;
+            public ushort z => _z;
+        }
+
+        // For possible future expansion.
+        private enum LineSubType
+        {
+            NO_DATA = 0,
+            DATA_PRESENT = 1,
+            ERROR = 256
         }
 
         public LineAbilityExtra(TinyIoCContainer container)
@@ -46,19 +137,54 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 var mach = Assembly.Load("Machina.FFXIV");
                 var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                fieldCastSourceId = headerType.GetField("ActorID");
+
                 actionEffectHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_ActionEffectHeader");
                 fieldR = actionEffectHeaderType.GetField("rotation");
+                fieldGlobalEffectCounter = actionEffectHeaderType.GetField("globalEffectCounter");
 
-                int[] sizes = {1, 8, 16, 24, 32};
+                int[] sizes = { 1, 8, 16, 24, 32 };
                 foreach (int size in sizes)
                 {
                     Type aeType = mach.GetType("Machina.FFXIV.Headers.Server_ActionEffect" + size);
+                    int machinaTypeSize = Marshal.SizeOf(aeType);
                     var actionEffectTypeInfo = new ActionEffectTypeInfo()
                     {
-                        machinaType = aeType,
-                        packetSize = Marshal.SizeOf(aeType)
+                        actionEffectSize = size,
+                        packetSize = machinaTypeSize,
                     };
-                    minSize = Math.Min(actionEffectTypeInfo.packetSize, minSize);
+                    minSize = Math.Min(machinaTypeSize, minSize);
+                    logger.Log(LogLevel.Debug, "ActionEffect Size {0} -> {1:X4}", size, actionEffectTypeInfo.packetSize);
+                    switch (size)
+                    {
+                        case 8:
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect8_Extra);
+                                break;
+                            }
+                        case 16:
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect16_Extra);
+                                break;
+                            }
+                        case 24:
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect24_Extra);
+                                break;
+                            }
+                        case 32:
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect32_Extra);
+                                break;
+                            }
+                    }
+                    int extraSize = Marshal.SizeOf(actionEffectTypeInfo.extraType);
+                    if (machinaTypeSize != extraSize)
+                    {
+                        logger.Log(LogLevel.Error, "ActionEffect size mismatch! {} -> {}", machinaTypeSize, extraSize);
+                        actionEffectTypeInfo.hasError = true;
+                    }
                     opcodeToType.Add(netHelper.GetOpcode("Ability" + size), actionEffectTypeInfo);
                 }
 
@@ -92,28 +218,51 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             fixed (byte* buffer = message)
             {
                 int opCode = *(ushort*)&buffer[offsetMessageType];
-                var info = opcodeToType[opCode];
-                if (info != null)
+                ActionEffectTypeInfo info;
+                bool result = opcodeToType.TryGetValue(opCode, out info);
+                if (result)
                 {
                     if (message.Length < info.packetSize)
                     {
                         return;
                     }
-                    object packet = Marshal.PtrToStructure(new IntPtr(buffer), actionEffectHeaderType);
+
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
-                    float x = (BitConverter.ToUInt16(message, message.Length - 12) - 0x7FFF) / 32.767f;
-                    float z = (BitConverter.ToUInt16(message, message.Length - 10) - 0x7FFF) / 32.767f;
-                    float y = (BitConverter.ToUInt16(message, message.Length - 8) - 0x7FFF) / 32.767f;
-                    double h = ((ushort)fieldR.GetValue(packet))
-                               // Normalize to turns
-                               / 65536.0
-                               // Normalize to radians
-                               * 2 * Math.PI
-                               // Flip from 0=north to 0=south like the game uses
-                               - Math.PI;
+
+                    object header = Marshal.PtrToStructure(new IntPtr(buffer), headerType);
+                    UInt32 sourceId = (UInt32)fieldCastSourceId.GetValue(header);
+
+                    object aeHeader = Marshal.PtrToStructure(new IntPtr(buffer), actionEffectHeaderType);
+                    UInt32 globalEffectCounter = (UInt32)fieldGlobalEffectCounter.GetValue(aeHeader);
+
+                    if (info.actionEffectSize == 1)
+                    {
+                        // AE1 is not useful. It does not contain this data. But we still need to write something
+                        // to indicate that a proper line will not be happening.
+                        logWriter(string.Format(CultureInfo.InvariantCulture,
+                            "{0:X8}|{1:X8}|{2}||||",
+                            sourceId, globalEffectCounter, (int)LineSubType.NO_DATA), serverTime);
+                        return;
+                    }
+
+                    if (info.hasError)
+                    {
+                        logWriter(string.Format(CultureInfo.InvariantCulture,
+                            "{0:X8}|{1:X8}|{2}||||",
+                            sourceId, globalEffectCounter, (int)LineSubType.ERROR), serverTime);
+                        return;
+                    }
+
+                    IActionEffectExtra aeExtra = (IActionEffectExtra)Marshal.PtrToStructure(new IntPtr(buffer), info.extraType);
+
+                    float x = ffxiv.ConvertUInt16Coordinate(aeExtra.x);
+                    float y = ffxiv.ConvertUInt16Coordinate(aeExtra.y);
+                    float z = ffxiv.ConvertUInt16Coordinate(aeExtra.z);
+
+                    double h = ffxiv.ConvertHeading((ushort)fieldR.GetValue(aeHeader));
                     string line = string.Format(CultureInfo.InvariantCulture,
-                        "{0:F3}|{1:F3}|{2:F3}|{3:F3}",
-                        x, y, z, h);
+                        "{0:X8}|{1:X8}|{2}|{3:F3}|{4:F3}|{5:F3}|{6:F3}",
+                        sourceId, globalEffectCounter, (int)LineSubType.DATA_PRESENT, x, y, z, h);
 
                     logWriter(line, serverTime);
                 }

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -12,23 +13,125 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     public class LineAbilityExtra
     {
         public const uint LogFileLineID = 264;
-        private ILogger logger;
-        private int minSize = Int32.MaxValue;
-        private readonly int offsetMessageType;
+        private readonly ILogger logger;
         private readonly FFXIVRepository ffxiv;
-
-        private readonly Type actionEffectHeaderType;
         private readonly Func<string, DateTime, bool> logWriter;
-        private readonly Type headerType;
+        private readonly NetworkParser netHelper;
 
-        private readonly Dictionary<int, ActionEffectTypeInfo> opcodeToType =
-            new Dictionary<int, ActionEffectTypeInfo>();
+        /**
+         * Holds information that may be specific to the current game region.
+         */
+        private RegionalizedInfo regionalized;
 
-        private readonly FieldInfo fieldCastSourceId;
-        private readonly FieldInfo fieldAbilityId;
-        private readonly FieldInfo fieldGlobalEffectCounter;
-        private readonly FieldInfo fieldR;
+        /**
+         * Holds information that may be specific to different game client regions
+         */
+        private class RegionalizedInfo
+        {
+            public readonly Dictionary<int, ActionEffectTypeInfo> opcodeToType =
+                new Dictionary<int, ActionEffectTypeInfo>();
 
+            public int minSize = Int32.MaxValue;
+            public readonly int offsetMessageType;
+            public readonly Type actionEffectHeaderType;
+            public readonly Type headerType;
+
+            public readonly FieldInfo fieldCastSourceId;
+            public readonly FieldInfo fieldAbilityId;
+            public readonly FieldInfo fieldGlobalEffectCounter;
+            public readonly FieldInfo fieldR;
+
+            public RegionalizedInfo(Assembly mach, GameRegion region, ILogger logger, NetworkParser netHelper)
+            {
+                Func<int, string> actionEffectTypesTemplate;
+                switch (region)
+                {
+                    case GameRegion.Global:
+                        headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                        actionEffectHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_ActionEffectHeader");
+                        actionEffectTypesTemplate = i => "Machina.FFXIV.Headers.Server_ActionEffect" + i;
+                        break;
+                    case GameRegion.Chinese:
+                        headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                        actionEffectHeaderType =
+                            mach.GetType("Machina.FFXIV.Headers.Chinese.Server_ActionEffectHeader");
+                        actionEffectTypesTemplate = i => "Machina.FFXIV.Headers.Chinese.Server_ActionEffect" + i;
+                        break;
+                    case GameRegion.Korean:
+                        headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                        actionEffectHeaderType = mach.GetType("Machina.FFXIV.Headers.Korean.Server_ActionEffectHeader");
+                        actionEffectTypesTemplate = i => "Machina.FFXIV.Headers.Korean.Server_ActionEffect" + i;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(region), region, null);
+                }
+
+                fieldCastSourceId = headerType.GetField("ActorID");
+                fieldAbilityId = actionEffectHeaderType.GetField("actionId");
+                fieldR = actionEffectHeaderType.GetField("rotation");
+                fieldGlobalEffectCounter = actionEffectHeaderType.GetField("globalEffectCounter");
+
+                int[] sizes = {1, 8, 16, 24, 32};
+                foreach (int size in sizes)
+                {
+                    Type aeType = mach.GetType(actionEffectTypesTemplate(size));
+                    int machinaTypeSize = Marshal.SizeOf(aeType);
+                    var actionEffectTypeInfo = new ActionEffectTypeInfo()
+                    {
+                        actionEffectSize = size,
+                        packetSize = machinaTypeSize,
+                    };
+                    minSize = Math.Min(machinaTypeSize, minSize);
+                    logger.Log(LogLevel.Debug, "ActionEffect Size {0} -> {1:X4}", size,
+                        actionEffectTypeInfo.packetSize);
+                    // Fortunately, these are currently identical between regions, so there is no need to have separate
+                    // CN/KR versions (yet). If that happens down the line, make copies of them for additional regions,
+                    // and change the switch/case statement to also consider these.
+                    switch (size)
+                    {
+                        case 8:
+                        {
+                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect8_Extra);
+                            break;
+                        }
+                        case 16:
+                        {
+                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect16_Extra);
+                            break;
+                        }
+                        case 24:
+                        {
+                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect24_Extra);
+                            break;
+                        }
+                        case 32:
+                        {
+                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect32_Extra);
+                            break;
+                        }
+                    }
+
+                    if (size != 1)
+                    {
+                        int extraSize = Marshal.SizeOf(actionEffectTypeInfo.extraType);
+                        if (machinaTypeSize != extraSize)
+                        {
+                            logger.Log(LogLevel.Error, "ActionEffect size mismatch! {} -> {}", machinaTypeSize,
+                                extraSize);
+                            actionEffectTypeInfo.hasError = true;
+                        }
+                    }
+
+                    opcodeToType.Add(netHelper.GetOpcode("Ability" + size), actionEffectTypeInfo);
+                }
+
+                offsetMessageType = netHelper.GetOffset(headerType, "MessageType");
+            }
+        }
+
+        /**
+         * Holds information specific to a particular 'size' of ActionEffect
+         */
         private class ActionEffectTypeInfo
         {
             public int actionEffectSize;
@@ -124,73 +227,33 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         {
             logger = container.Resolve<ILogger>();
             ffxiv = container.Resolve<FFXIVRepository>();
-            var netHelper = container.Resolve<NetworkParser>();
+            netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            ffxiv.RegisterNetworkParser(MessageReceived);
+            ffxiv.RegisterProcessChangedHandler(ProcessChanged);
+
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "ActorCastExtra",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        // Load regionalized data when the game region changes
+        private void ProcessChanged(Process process)
+        {
+            GameRegion region = ffxiv.GetMachinaRegion();
             if (!ffxiv.IsFFXIVPluginPresent())
                 return;
             try
             {
-                var mach = Assembly.Load("Machina.FFXIV");
-                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
-                headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
-                fieldCastSourceId = headerType.GetField("ActorID");
-
-                actionEffectHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_ActionEffectHeader");
-                fieldAbilityId = actionEffectHeaderType.GetField("actionId");
-                fieldR = actionEffectHeaderType.GetField("rotation");
-                fieldGlobalEffectCounter = actionEffectHeaderType.GetField("globalEffectCounter");
-
-                int[] sizes = { 1, 8, 16, 24, 32 };
-                foreach (int size in sizes)
-                {
-                    Type aeType = mach.GetType("Machina.FFXIV.Headers.Server_ActionEffect" + size);
-                    int machinaTypeSize = Marshal.SizeOf(aeType);
-                    var actionEffectTypeInfo = new ActionEffectTypeInfo()
-                    {
-                        actionEffectSize = size,
-                        packetSize = machinaTypeSize,
-                    };
-                    minSize = Math.Min(machinaTypeSize, minSize);
-                    logger.Log(LogLevel.Debug, "ActionEffect Size {0} -> {1:X4}", size,
-                        actionEffectTypeInfo.packetSize);
-                    switch (size)
-                    {
-                        case 8:
-                            {
-                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect8_Extra);
-                                break;
-                            }
-                        case 16:
-                            {
-                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect16_Extra);
-                                break;
-                            }
-                        case 24:
-                            {
-                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect24_Extra);
-                                break;
-                            }
-                        case 32:
-                            {
-                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect32_Extra);
-                                break;
-                            }
-                    }
-
-                    if (size != 1)
-                    {
-                        int extraSize = Marshal.SizeOf(actionEffectTypeInfo.extraType);
-                        if (machinaTypeSize != extraSize)
-                        {
-                            logger.Log(LogLevel.Error, "ActionEffect size mismatch! {} -> {}", machinaTypeSize,
-                                extraSize);
-                            actionEffectTypeInfo.hasError = true;
-                        }
-                    }
-                    opcodeToType.Add(netHelper.GetOpcode("Ability" + size), actionEffectTypeInfo);
-                }
-
-                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
-                ffxiv.RegisterNetworkParser(MessageReceived);
+                Assembly mach = Assembly.Load("Machina.FFXIV");
+                RegionalizedInfo info = new RegionalizedInfo(mach, region, logger, netHelper);
+                regionalized = info;
             }
             catch (System.IO.FileNotFoundException)
             {
@@ -200,27 +263,22 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
             }
-
-            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
-            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
-            {
-                Name = "ActorCastExtra",
-                Source = "OverlayPlugin",
-                ID = LogFileLineID,
-                Version = 1,
-            });
         }
 
         private unsafe void MessageReceived(string id, long epoch, byte[] message)
         {
-            if (message.Length < minSize)
+            RegionalizedInfo regInfo = regionalized;
+            if (regInfo == null)
+                return;
+
+            if (message.Length < regInfo.minSize)
                 return;
 
             fixed (byte* buffer = message)
             {
-                int opCode = *(ushort*)&buffer[offsetMessageType];
+                int opCode = *(ushort*)&buffer[regInfo.offsetMessageType];
                 ActionEffectTypeInfo info;
-                bool result = opcodeToType.TryGetValue(opCode, out info);
+                bool result = regInfo.opcodeToType.TryGetValue(opCode, out info);
                 if (result)
                 {
                     if (message.Length < info.packetSize)
@@ -230,14 +288,14 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
 
-                    object header = Marshal.PtrToStructure(new IntPtr(buffer), headerType);
-                    UInt32 sourceId = (UInt32)fieldCastSourceId.GetValue(header);
+                    object header = Marshal.PtrToStructure(new IntPtr(buffer), regInfo.headerType);
+                    UInt32 sourceId = (UInt32)regInfo.fieldCastSourceId.GetValue(header);
 
-                    object aeHeader = Marshal.PtrToStructure(new IntPtr(buffer), actionEffectHeaderType);
+                    object aeHeader = Marshal.PtrToStructure(new IntPtr(buffer), regInfo.actionEffectHeaderType);
                     // Ability ID is really 16-bit, so it is formatted as such, but we will get an
                     // exception if we try to prematurely cast it to UInt16
-                    UInt32 abilityId = (UInt32)fieldAbilityId.GetValue(aeHeader);
-                    UInt32 globalEffectCounter = (UInt32)fieldGlobalEffectCounter.GetValue(aeHeader);
+                    UInt32 abilityId = (UInt32)regInfo.fieldAbilityId.GetValue(aeHeader);
+                    UInt32 globalEffectCounter = (UInt32)regInfo.fieldGlobalEffectCounter.GetValue(aeHeader);
 
                     if (info.actionEffectSize == 1)
                     {
@@ -264,7 +322,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     float y = ffxiv.ConvertUInt16Coordinate(aeExtra.y);
                     float z = ffxiv.ConvertUInt16Coordinate(aeExtra.z);
 
-                    double h = ffxiv.ConvertHeading((ushort)fieldR.GetValue(aeHeader));
+                    double h = ffxiv.ConvertHeading((ushort)regInfo.fieldR.GetValue(aeHeader));
                     string line = string.Format(CultureInfo.InvariantCulture,
                         "{0:X8}|{1:X4}|{2:X8}|{3}|{4:F3}|{5:F3}|{6:F3}|{7:F3}",
                         sourceId, abilityId, globalEffectCounter, (int)LineSubType.DATA_PRESENT, x, y, z, h);

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -71,7 +71,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 fieldR = actionEffectHeaderType.GetField("rotation");
                 fieldGlobalEffectCounter = actionEffectHeaderType.GetField("globalEffectCounter");
 
-                int[] sizes = {1, 8, 16, 24, 32};
+                int[] sizes = { 1, 8, 16, 24, 32 };
                 foreach (int size in sizes)
                 {
                     Type aeType = mach.GetType(actionEffectTypesTemplate(size));
@@ -90,25 +90,25 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     switch (size)
                     {
                         case 8:
-                        {
-                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect8_Extra);
-                            break;
-                        }
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect8_Extra);
+                                break;
+                            }
                         case 16:
-                        {
-                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect16_Extra);
-                            break;
-                        }
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect16_Extra);
+                                break;
+                            }
                         case 24:
-                        {
-                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect24_Extra);
-                            break;
-                        }
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect24_Extra);
+                                break;
+                            }
                         case 32:
-                        {
-                            actionEffectTypeInfo.extraType = typeof(Server_ActionEffect32_Extra);
-                            break;
-                        }
+                            {
+                                actionEffectTypeInfo.extraType = typeof(Server_ActionEffect32_Extra);
+                                break;
+                            }
                     }
 
                     if (size != 1)

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    /**
+     * Class for position/angle info from ActionEffect (i.e. line 21/22).
+     *
+     * This one is implemented different than LineActorCast. ActionEffect has several variants with different
+     * sizes to support different maximum numbers of targets. They have a common header, which contains the angle of
+     * the cast. However, the x/y/z coordinates are *after* the variable-size portion, so those are accessed by negative
+     * indexing from the end of the packet rather than reflectively via Machina definitions.
+     *
+     * Despite this, we still need to pull out the types from Machina because we need to know the minimum sizes.
+     */
+    public class LineAbilityExtra
+    {
+        public const uint LogFileLineID = 264;
+        private ILogger logger;
+        private int minSize = Int32.MaxValue;
+        private readonly int offsetMessageType;
+        private readonly FFXIVRepository ffxiv;
+
+        private Type actionEffectHeaderType;
+        private Func<string, DateTime, bool> logWriter;
+        private Dictionary<int, ActionEffectTypeInfo> opcodeToType = new Dictionary<int, ActionEffectTypeInfo>();
+        private FieldInfo fieldR;
+
+        private class ActionEffectTypeInfo
+        {
+            public int packetSize;
+            public Type machinaType;
+        }
+
+        public LineAbilityExtra(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                actionEffectHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_ActionEffectHeader");
+                fieldR = actionEffectHeaderType.GetField("rotation");
+
+                int[] sizes = {1, 8, 16, 24, 32};
+                foreach (int size in sizes)
+                {
+                    Type aeType = mach.GetType("Machina.FFXIV.Headers.Server_ActionEffect" + size);
+                    var actionEffectTypeInfo = new ActionEffectTypeInfo()
+                    {
+                        machinaType = aeType,
+                        packetSize = Marshal.SizeOf(aeType)
+                    };
+                    minSize = Math.Min(actionEffectTypeInfo.packetSize, minSize);
+                    opcodeToType.Add(netHelper.GetOpcode("Ability" + size), actionEffectTypeInfo);
+                }
+
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "ActorCastExtra",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            if (message.Length < minSize)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                int opCode = *(ushort*)&buffer[offsetMessageType];
+                var info = opcodeToType[opCode];
+                if (info != null)
+                {
+                    if (message.Length < info.packetSize)
+                    {
+                        return;
+                    }
+                    object packet = Marshal.PtrToStructure(new IntPtr(buffer), actionEffectHeaderType);
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                    float x = (BitConverter.ToUInt16(message, message.Length - 12) - 0x7FFF) / 32.767f;
+                    float z = (BitConverter.ToUInt16(message, message.Length - 10) - 0x7FFF) / 32.767f;
+                    float y = (BitConverter.ToUInt16(message, message.Length - 8) - 0x7FFF) / 32.767f;
+                    double h = ((ushort)fieldR.GetValue(packet))
+                               // Normalize to turns
+                               / 65536.0
+                               // Normalize to radians
+                               * 2 * Math.PI
+                               // Flip from 0=north to 0=south like the game uses
+                               - Math.PI;
+                    string line = string.Format(CultureInfo.InvariantCulture,
+                        "{0:F3}|{1:F3}|{2:F3}|{3:F3}",
+                        x, y, z, h);
+
+                    logWriter(line, serverTime);
+                }
+            }
+        }
+    }
+}

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -8,13 +8,6 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
     /**
      * Class for position/angle info from ActionEffect (i.e. line 21/22).
-     *
-     * This one is implemented different than LineActorCast. ActionEffect has several variants with different
-     * sizes to support different maximum numbers of targets. They have a common header, which contains the angle of
-     * the cast. However, the x/y/z coordinates are *after* the variable-size portion, so those are accessed by negative
-     * indexing from the end of the packet rather than reflectively via Machina definitions.
-     *
-     * Despite this, we still need to pull out the types from Machina because we need to know the minimum sizes.
      */
     public class LineAbilityExtra
     {

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -9,12 +9,15 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     {
         public const uint LogFileLineID = 263;
         private ILogger logger;
-        private OverlayPluginLogLineConfig opcodeConfig;
         private readonly int packetSize;
         private readonly int packetOpcode;
         private readonly int offsetMessageType;
         private readonly FFXIVRepository ffxiv;
         private readonly Type actorCastType;
+        private readonly FieldInfo fieldX;
+        private readonly FieldInfo fieldY;
+        private readonly FieldInfo fieldZ;
+        private readonly FieldInfo fieldR;
 
         private Func<string, DateTime, bool> logWriter;
 
@@ -25,12 +28,15 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             var netHelper = container.Resolve<NetworkParser>();
             if (!ffxiv.IsFFXIVPluginPresent())
                 return;
-            opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
             try
             {
                 var mach = Assembly.Load("Machina.FFXIV");
                 var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
                 actorCastType = mach.GetType("Machina.FFXIV.Headers.Server_ActorCast");
+                fieldX = actorCastType.GetField("PosX");
+                fieldY = actorCastType.GetField("PosY");
+                fieldZ = actorCastType.GetField("PosZ");
+                fieldR = actorCastType.GetField("Rotation");
                 packetOpcode = netHelper.GetOpcode("ActorCast");
                 packetSize = Marshal.SizeOf(actorCastType);
                 offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
@@ -68,17 +74,17 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
                     // see https://github.com/ravahn/FFXIV_ACT_Plugin/issues/298
                     // for x/y/x, subtract 7FFF then divide by (2^15 - 1) / 100
-                    float x = ((UInt16)actorCastType.GetField("PosX").GetValue(packet) - 0x7FFF) / 32.767f;
+                    float x = ((UInt16)fieldX.GetValue(packet) - 0x7FFF) / 32.767f;
                     // In-game uses Y as elevation and Z as north-south, but ACT convention is to use
                     // Z as elevation and Y as north-south.
-                    float y = ((UInt16)actorCastType.GetField("PosZ").GetValue(packet) - 0x7FFF) / 32.767f;
-                    float z = ((UInt16)actorCastType.GetField("PosY").GetValue(packet) - 0x7FFF) / 32.767f;
+                    float y = ((UInt16)fieldZ.GetValue(packet) - 0x7FFF) / 32.767f;
+                    float z = ((UInt16)fieldY.GetValue(packet) - 0x7FFF) / 32.767f;
                     // for rotation, the packet uses '0' as north, and each increment is 1/65536 of a CCW turn, while
                     // in-game uses 0=south, pi/2=west, +/-pi=north
                     // Machina thinks this is a float but that appears to be incorrect, so we have to reinterpret as
                     // a UInt16
                     double h = BitConverter.ToUInt16(BitConverter.GetBytes(
-                                   (float)actorCastType.GetField("Rotation").GetValue(packet)), 0)
+                                   (float)fieldR.GetValue(packet)), 0)
                                // Normalize to turns
                                / 65536.0
                                // Normalize to radians

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -16,6 +16,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private readonly Type headerType;
         private readonly Type actorCastType;
         private readonly FieldInfo fieldCastSourceId;
+        private readonly FieldInfo fieldAbilityId;
         private readonly FieldInfo fieldX;
         private readonly FieldInfo fieldY;
         private readonly FieldInfo fieldZ;
@@ -37,6 +38,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
                 actorCastType = mach.GetType("Machina.FFXIV.Headers.Server_ActorCast");
                 fieldCastSourceId = headerType.GetField("ActorID");
+                fieldAbilityId = actorCastType.GetField("ActionID");
                 fieldX = actorCastType.GetField("PosX");
                 fieldY = actorCastType.GetField("PosY");
                 fieldZ = actorCastType.GetField("PosZ");
@@ -78,6 +80,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     UInt32 sourceId = (UInt32)fieldCastSourceId.GetValue(header);
 
                     object packet = Marshal.PtrToStructure(new IntPtr(buffer), actorCastType);
+                    UInt16 abilityId = (UInt16)fieldAbilityId.GetValue(packet);
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
                     // for x/y/x, subtract 7FFF then divide by (2^15 - 1) / 100
                     float x = ffxiv.ConvertUInt16Coordinate((UInt16)fieldX.GetValue(packet));
@@ -94,8 +97,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
 
                     string line = string.Format(CultureInfo.InvariantCulture,
-                        "{0:X8}|{1:F3}|{2:F3}|{3:F3}|{4:F3}",
-                        sourceId, x, y, z, h);
+                        "{0:X8}|{1:X4}|{2:F3}|{3:F3}|{4:F3}|{5:F3}",
+                        sourceId, abilityId, x, y, z, h);
 
                     logWriter(line, serverTime);
                 }

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -9,34 +10,26 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     {
         public const uint LogFileLineID = 263;
         private ILogger logger;
-        private readonly int packetSize;
-        private readonly int packetOpcode;
-        private readonly int offsetMessageType;
         private readonly FFXIVRepository ffxiv;
-        private readonly Type headerType;
-        private readonly Type actorCastType;
-        private readonly FieldInfo fieldCastSourceId;
-        private readonly FieldInfo fieldAbilityId;
-        private readonly FieldInfo fieldX;
-        private readonly FieldInfo fieldY;
-        private readonly FieldInfo fieldZ;
-        private readonly FieldInfo fieldR;
 
-        private readonly Func<string, DateTime, bool> logWriter;
-
-        public LineActorCastExtra(TinyIoCContainer container)
+        private class RegionalizedInfo
         {
-            logger = container.Resolve<ILogger>();
-            ffxiv = container.Resolve<FFXIVRepository>();
-            var netHelper = container.Resolve<NetworkParser>();
-            if (!ffxiv.IsFFXIVPluginPresent())
-                return;
-            try
+            public readonly int packetSize;
+            public readonly int packetOpcode;
+            public readonly int offsetMessageType;
+            public readonly Type headerType;
+            public readonly Type actorCastType;
+            public readonly FieldInfo fieldCastSourceId;
+            public readonly FieldInfo fieldAbilityId;
+            public readonly FieldInfo fieldX;
+            public readonly FieldInfo fieldY;
+            public readonly FieldInfo fieldZ;
+            public readonly FieldInfo fieldR;
+
+            public RegionalizedInfo(Type headerType, Type actorCastType, NetworkParser netHelper)
             {
-                var mach = Assembly.Load("Machina.FFXIV");
-                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
-                headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
-                actorCastType = mach.GetType("Machina.FFXIV.Headers.Server_ActorCast");
+                this.headerType = headerType;
+                this.actorCastType = actorCastType;
                 fieldCastSourceId = headerType.GetField("ActorID");
                 fieldAbilityId = actorCastType.GetField("ActionID");
                 fieldX = actorCastType.GetField("PosX");
@@ -45,8 +38,69 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 fieldR = actorCastType.GetField("Rotation");
                 packetOpcode = netHelper.GetOpcode("ActorCast");
                 packetSize = Marshal.SizeOf(actorCastType);
-                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
-                ffxiv.RegisterNetworkParser(MessageReceived);
+                offsetMessageType = netHelper.GetOffset(headerType, "MessageType");
+            }
+        }
+
+        private RegionalizedInfo regionalized;
+
+        private readonly Func<string, DateTime, bool> logWriter;
+        private readonly NetworkParser netHelper;
+
+        public LineActorCastExtra(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            netHelper = container.Resolve<NetworkParser>();
+            ffxiv.RegisterNetworkParser(MessageReceived);
+            ffxiv.RegisterProcessChangedHandler(ProcessChanged);
+
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "ActorCastExtra",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private void ProcessChanged(Process process)
+        {
+            GameRegion region = ffxiv.GetMachinaRegion();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            try
+            {
+                Assembly mach = Assembly.Load("Machina.FFXIV");
+                Type headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                string actorCastTypeStr;
+                switch (region)
+                {
+                    case GameRegion.Global:
+                    {
+                        actorCastTypeStr = "Machina.FFXIV.Headers.Server_ActorCast";
+                        break;
+                    }
+                    case GameRegion.Korean:
+                    {
+                        actorCastTypeStr = "Machina.FFXIV.Headers.Korean.Server_ActorCast";
+                        break;
+                    }
+                    case GameRegion.Chinese:
+                    {
+                        actorCastTypeStr = "Machina.FFXIV.Headers.Chinese.Server_ActorCast";
+                        break;
+                    }
+                    default:
+                    {
+                        return;
+                    }
+                }
+
+                Type actorCastType = mach.GetType(actorCastTypeStr);
+                RegionalizedInfo info = new RegionalizedInfo(headerType, actorCastType, netHelper);
+                regionalized = info;
             }
             catch (System.IO.FileNotFoundException)
             {
@@ -56,44 +110,38 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
             }
-
-            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
-            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
-            {
-                Name = "ActorCastExtra",
-                Source = "OverlayPlugin",
-                ID = LogFileLineID,
-                Version = 1,
-            });
         }
 
         private unsafe void MessageReceived(string id, long epoch, byte[] message)
         {
-            if (message.Length < packetSize)
+            RegionalizedInfo info = regionalized;
+            if (info == null)
+                return;
+
+            if (message.Length < info.packetSize)
                 return;
 
             fixed (byte* buffer = message)
             {
-                if (*(ushort*)&buffer[offsetMessageType] == packetOpcode)
+                if (*(ushort*)&buffer[info.offsetMessageType] == info.packetOpcode)
                 {
-                    object header = Marshal.PtrToStructure(new IntPtr(buffer), headerType);
-                    UInt32 sourceId = (UInt32)fieldCastSourceId.GetValue(header);
+                    object header = Marshal.PtrToStructure(new IntPtr(buffer), info.headerType);
+                    UInt32 sourceId = (UInt32)info.fieldCastSourceId.GetValue(header);
 
-                    object packet = Marshal.PtrToStructure(new IntPtr(buffer), actorCastType);
-                    UInt16 abilityId = (UInt16)fieldAbilityId.GetValue(packet);
+                    object packet = Marshal.PtrToStructure(new IntPtr(buffer), info.actorCastType);
+                    UInt16 abilityId = (UInt16)info.fieldAbilityId.GetValue(packet);
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
                     // for x/y/x, subtract 7FFF then divide by (2^15 - 1) / 100
-                    float x = ffxiv.ConvertUInt16Coordinate((UInt16)fieldX.GetValue(packet));
+                    float x = ffxiv.ConvertUInt16Coordinate((UInt16)info.fieldX.GetValue(packet));
                     // In-game uses Y as elevation and Z as north-south, but ACT convention is to use
                     // Z as elevation and Y as north-south.
-                    float y = ffxiv.ConvertUInt16Coordinate((UInt16)fieldZ.GetValue(packet));
-                    float z = ffxiv.ConvertUInt16Coordinate((UInt16)fieldY.GetValue(packet));
+                    float y = ffxiv.ConvertUInt16Coordinate((UInt16)info.fieldZ.GetValue(packet));
+                    float z = ffxiv.ConvertUInt16Coordinate((UInt16)info.fieldY.GetValue(packet));
                     // for rotation, the packet uses '0' as north, and each increment is 1/65536 of a CCW turn, while
                     // in-game uses 0=south, pi/2=west, +/-pi=north
                     // Machina thinks this is a float but that appears to be incorrect, so we have to reinterpret as
                     // a UInt16
-                    double h = ffxiv.ConvertHeading(ffxiv.InterpretFloatAsUInt16((float)fieldR.GetValue(packet)));
-
+                    double h = ffxiv.ConvertHeading(ffxiv.InterpretFloatAsUInt16((float)info.fieldR.GetValue(packet)));
 
 
                     string line = string.Format(CultureInfo.InvariantCulture,

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -13,13 +13,15 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         private readonly int packetOpcode;
         private readonly int offsetMessageType;
         private readonly FFXIVRepository ffxiv;
+        private readonly Type headerType;
         private readonly Type actorCastType;
+        private readonly FieldInfo fieldCastSourceId;
         private readonly FieldInfo fieldX;
         private readonly FieldInfo fieldY;
         private readonly FieldInfo fieldZ;
         private readonly FieldInfo fieldR;
 
-        private Func<string, DateTime, bool> logWriter;
+        private readonly Func<string, DateTime, bool> logWriter;
 
         public LineActorCastExtra(TinyIoCContainer container)
         {
@@ -32,7 +34,9 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 var mach = Assembly.Load("Machina.FFXIV");
                 var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                headerType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
                 actorCastType = mach.GetType("Machina.FFXIV.Headers.Server_ActorCast");
+                fieldCastSourceId = headerType.GetField("ActorID");
                 fieldX = actorCastType.GetField("PosX");
                 fieldY = actorCastType.GetField("PosY");
                 fieldZ = actorCastType.GetField("PosZ");
@@ -70,31 +74,28 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 if (*(ushort*)&buffer[offsetMessageType] == packetOpcode)
                 {
+                    object header = Marshal.PtrToStructure(new IntPtr(buffer), headerType);
+                    UInt32 sourceId = (UInt32)fieldCastSourceId.GetValue(header);
+
                     object packet = Marshal.PtrToStructure(new IntPtr(buffer), actorCastType);
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
-                    // see https://github.com/ravahn/FFXIV_ACT_Plugin/issues/298
                     // for x/y/x, subtract 7FFF then divide by (2^15 - 1) / 100
-                    float x = ((UInt16)fieldX.GetValue(packet) - 0x7FFF) / 32.767f;
+                    float x = ffxiv.ConvertUInt16Coordinate((UInt16)fieldX.GetValue(packet));
                     // In-game uses Y as elevation and Z as north-south, but ACT convention is to use
                     // Z as elevation and Y as north-south.
-                    float y = ((UInt16)fieldZ.GetValue(packet) - 0x7FFF) / 32.767f;
-                    float z = ((UInt16)fieldY.GetValue(packet) - 0x7FFF) / 32.767f;
+                    float y = ffxiv.ConvertUInt16Coordinate((UInt16)fieldZ.GetValue(packet));
+                    float z = ffxiv.ConvertUInt16Coordinate((UInt16)fieldY.GetValue(packet));
                     // for rotation, the packet uses '0' as north, and each increment is 1/65536 of a CCW turn, while
                     // in-game uses 0=south, pi/2=west, +/-pi=north
                     // Machina thinks this is a float but that appears to be incorrect, so we have to reinterpret as
                     // a UInt16
-                    double h = BitConverter.ToUInt16(BitConverter.GetBytes(
-                                   (float)fieldR.GetValue(packet)), 0)
-                               // Normalize to turns
-                               / 65536.0
-                               // Normalize to radians
-                               * 2 * Math.PI
-                               // Flip from 0=north to 0=south like the game uses
-                               - Math.PI;
+                    double h = ffxiv.ConvertHeading(ffxiv.InterpretFloatAsUInt16((float)fieldR.GetValue(packet)));
+
+
 
                     string line = string.Format(CultureInfo.InvariantCulture,
-                        "{0:F3}|{1:F3}|{2:F3}|{3:F3}",
-                        x, y, z, h);
+                        "{0:X8}|{1:F3}|{2:F3}|{3:F3}|{4:F3}",
+                        sourceId, x, y, z, h);
 
                     logWriter(line, serverTime);
                 }

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -78,24 +78,24 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 switch (region)
                 {
                     case GameRegion.Global:
-                    {
-                        actorCastTypeStr = "Machina.FFXIV.Headers.Server_ActorCast";
-                        break;
-                    }
+                        {
+                            actorCastTypeStr = "Machina.FFXIV.Headers.Server_ActorCast";
+                            break;
+                        }
                     case GameRegion.Korean:
-                    {
-                        actorCastTypeStr = "Machina.FFXIV.Headers.Korean.Server_ActorCast";
-                        break;
-                    }
+                        {
+                            actorCastTypeStr = "Machina.FFXIV.Headers.Korean.Server_ActorCast";
+                            break;
+                        }
                     case GameRegion.Chinese:
-                    {
-                        actorCastTypeStr = "Machina.FFXIV.Headers.Chinese.Server_ActorCast";
-                        break;
-                    }
+                        {
+                            actorCastTypeStr = "Machina.FFXIV.Headers.Chinese.Server_ActorCast";
+                            break;
+                        }
                     default:
-                    {
-                        return;
-                    }
+                        {
+                            return;
+                        }
                 }
 
                 Type actorCastType = mach.GetType(actorCastTypeStr);

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -43,6 +44,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
             }
+
             var customLogLines = container.Resolve<FFXIVCustomLogLines>();
             this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
             {
@@ -62,21 +64,35 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             {
                 if (*(ushort*)&buffer[offsetMessageType] == packetOpcode)
                 {
-                    object packet = actorCastType.GetConstructor(new Type[] { }).Invoke(new object[] { });
-                    Marshal.PtrToStructure(new IntPtr(buffer), packet);
+                    object packet = Marshal.PtrToStructure(new IntPtr(buffer), actorCastType);
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                    // see https://github.com/ravahn/FFXIV_ACT_Plugin/issues/298
+                    // for x/y/x, subtract 7FFF then divide by (2^15 - 1) / 100
+                    float x = ((UInt16)actorCastType.GetField("PosX").GetValue(packet) - 0x7FFF) / 32.767f;
+                    // In-game uses Y as elevation and Z as north-south, but ACT convention is to use
+                    // Z as elevation and Y as north-south.
+                    float y = ((UInt16)actorCastType.GetField("PosZ").GetValue(packet) - 0x7FFF) / 32.767f;
+                    float z = ((UInt16)actorCastType.GetField("PosY").GetValue(packet) - 0x7FFF) / 32.767f;
+                    // for rotation, the packet uses '0' as north, and each increment is 1/65536 of a CCW turn, while
+                    // in-game uses 0=south, pi/2=west, +/-pi=north
+                    // Machina thinks this is a float but that appears to be incorrect, so we have to reinterpret as
+                    // a UInt16
+                    double h = BitConverter.ToUInt16(BitConverter.GetBytes(
+                                   (float)actorCastType.GetField("Rotation").GetValue(packet)), 0)
+                               // Normalize to turns
+                               / 65536.0
+                               // Normalize to radians
+                               * 2 * Math.PI
+                               // Flip from 0=north to 0=south like the game uses
+                               - Math.PI;
 
-                    string someData = "";
+                    string line = string.Format(CultureInfo.InvariantCulture,
+                        "{0:F3}|{1:F3}|{2:F3}|{3:F3}",
+                        x, y, z, h);
 
-                    someData += actorCastType.GetField("PosX") + "|";
-                    someData += actorCastType.GetField("PosY") + "|";
-                    someData += actorCastType.GetField("PosZ") + "|";
-                    someData += actorCastType.GetField("Heading");
-
-                    logWriter(someData, serverTime);
+                    logWriter(line, serverTime);
                 }
             }
         }
-
     }
 }

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    public class LineActorCastExtra
+    {
+        public const uint LogFileLineID = 263;
+        private ILogger logger;
+        private OverlayPluginLogLineConfig opcodeConfig;
+        private readonly int packetSize;
+        private readonly int packetOpcode;
+        private readonly int offsetMessageType;
+        private readonly FFXIVRepository ffxiv;
+        private readonly Type actorCastType;
+
+        private Func<string, DateTime, bool> logWriter;
+
+        public LineActorCastExtra(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                actorCastType = mach.GetType("Machina.FFXIV.Headers.Server_ActorCast");
+                packetOpcode = netHelper.GetOpcode("ActorCast");
+                packetSize = Marshal.SizeOf(actorCastType);
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "ActorCastExtra",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            if (message.Length < packetSize)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                if (*(ushort*)&buffer[offsetMessageType] == packetOpcode)
+                {
+                    object packet = actorCastType.GetConstructor(new Type[] { }).Invoke(new object[] { });
+                    Marshal.PtrToStructure(new IntPtr(buffer), packet);
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+
+                    string someData = "";
+
+                    someData += actorCastType.GetField("PosX") + "|";
+                    someData += actorCastType.GetField("PosY") + "|";
+                    someData += actorCastType.GetField("PosZ") + "|";
+                    someData += actorCastType.GetField("Heading");
+
+                    logWriter(someData, serverTime);
+                }
+            }
+        }
+
+    }
+}

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -130,6 +130,7 @@
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory62.cs" />
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory.cs" />
     <Compile Include="NetworkProcessors\FateWatcher.cs" />
+    <Compile Include="NetworkProcessors\LineAbilityExtra.cs" />
     <Compile Include="NetworkProcessors\LineActorCastExtra.cs" />
     <Compile Include="NetworkProcessors\LineRSV.cs" />
     <Compile Include="NetworkProcessors\LineFateControl.cs" />

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -130,6 +130,7 @@
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory62.cs" />
     <Compile Include="MemoryProcessors\Combatant\CombatantMemory.cs" />
     <Compile Include="NetworkProcessors\FateWatcher.cs" />
+    <Compile Include="NetworkProcessors\LineActorCastExtra.cs" />
     <Compile Include="NetworkProcessors\LineRSV.cs" />
     <Compile Include="NetworkProcessors\LineFateControl.cs" />
     <Compile Include="NetworkProcessors\LineCEDirector.cs" />

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -56,24 +56,24 @@
         "Comment": "RSV Key/Value data"
     },
     {
-    "ID": 263,
-    "Name": "ActorCastExtra",
-    "Source": "OverlayPlugin",
-    "Version": 1,
-    "Comment": "Extra info from ActorCast packets"
-  },
-  {
-    "ID": 264,
-    "Name": "AbilityExtra",
-    "Source": "OverlayPlugin",
-    "Version": 1,
-    "Comment": "Extra info from ActionEffect packets"
-  },
-  {
-    "StartID": 265,
-    "EndID": 512,
-    "Source": "OverlayPlugin",
-    "Version": 0,
-    "Comment": "Reserved for future OverlayPlugin use"
-  }
+        "ID": 263,
+        "Name": "ActorCastExtra",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "Extra info from ActorCast packets"
+    },
+    {
+        "ID": 264,
+        "Name": "AbilityExtra",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "Extra info from ActionEffect packets"
+    },
+    {
+        "StartID": 265,
+        "EndID": 512,
+        "Source": "OverlayPlugin",
+        "Version": 0,
+        "Comment": "Reserved for future OverlayPlugin use"
+    }
 ]

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -63,7 +63,14 @@
     "Comment": "Extra info from ActorCast packets"
   },
   {
-    "StartID": 264,
+    "ID": 264,
+    "Name": "AbilityExtra",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "Extra info from ActionEffect packets"
+  },
+  {
+    "StartID": 265,
     "EndID": 512,
     "Source": "OverlayPlugin",
     "Version": 0,

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -1,65 +1,72 @@
 [
-    {
-        "StartID": 0,
-        "EndID": 255,
-        "Source": "FFXIV_ACT_Plugin",
-        "Version": 0,
-        "Comment": "Reserved for base FFXIV_ACT_Plugin use"
-    },
-    {
-        "ID": 256,
-        "Name":  "RegisterLogLine",
-        "Source": "OverlayPlugin",
-        "Version": 1,
-        "Comment": "Line to be emitted when a new log line is registered"
-    },
-    {
-        "ID": 257,
-        "Name":  "MapEffect",
-        "Source": "OverlayPlugin",
-        "Version": 1,
-        "Comment": "MapEffect data"
-    },
-    {
-        "ID": 258,
-        "Name":  "FateDirector",
-        "Source": "OverlayPlugin",
-        "Version": 1,
-        "Comment": "ActorControlSelf Fate data"
-    },
-    {
-        "ID": 259,
-        "Name":  "CEDirector",
-        "Source": "OverlayPlugin",
-        "Version": 1,
-        "Comment": "Critical Engagement data"
-    },
-    {
-        "ID": 260,
-        "Name":  "InCombat",
-        "Source": "OverlayPlugin",
-        "Version": 1,
-        "Comment": "Combat beginning / ending"
-    },
-    {
-        "ID": 261,
-        "Name":  "CombatantMemory",
-        "Source": "OverlayPlugin",
-        "Version": 1,
-        "Comment": "Combatant Memory Information"
-    },
-    {
-        "ID": 262,
-        "Name":  "RSVData",
-        "Source": "OverlayPlugin",
-        "Version": 1,
-        "Comment": "RSV Key/Value data"
-    },
-    {
-        "StartID": 263,
-        "EndID": 512,
-        "Source": "OverlayPlugin",
-        "Version": 0,
-        "Comment": "Reserved for future OverlayPlugin use"
-    }
+  {
+    "StartID": 0,
+    "EndID": 255,
+    "Source": "FFXIV_ACT_Plugin",
+    "Version": 0,
+    "Comment": "Reserved for base FFXIV_ACT_Plugin use"
+  },
+  {
+    "ID": 256,
+    "Name": "RegisterLogLine",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "Line to be emitted when a new log line is registered"
+  },
+  {
+    "ID": 257,
+    "Name": "MapEffect",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "MapEffect data"
+  },
+  {
+    "ID": 258,
+    "Name": "FateDirector",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "ActorControlSelf Fate data"
+  },
+  {
+    "ID": 259,
+    "Name": "CEDirector",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "Critical Engagement data"
+  },
+  {
+    "ID": 260,
+    "Name": "InCombat",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "Combat beginning / ending"
+  },
+  {
+    "ID": 261,
+    "Name": "CombatantMemory",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "Combatant Memory Information"
+  },
+  {
+    "ID": 262,
+    "Name": "RSVData",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "RSV Key/Value data"
+  },
+  {
+    "ID": 263,
+    "Name": "ActorCastExtra",
+    "Source": "OverlayPlugin",
+    "Version": 1,
+    "Comment": "Extra info from ActorCast packets"
+  },
+  {
+    "StartID": 264,
+    "EndID": 512,
+    "Source": "OverlayPlugin",
+    "Version": 0,
+    "Comment": "Reserved for future OverlayPlugin use"
+  }
 ]


### PR DESCRIPTION
Thanks to @valarnin for the initial legwork.

Adds two new lines - 263 which pairs with line 20, and 264 which pairs with 21/22 - that give you the actual location/heading of a cast. See https://github.com/ravahn/FFXIV_ACT_Plugin/issues/298 for an explanation of the data and where it lives.

You can test it with BLU skills. Aqua Breath or any other line/cone which doesn't require a target will give you the "heading" portion, and Bomb Toss will give you data for ground-targeting locations.

However, I think it still needs some additional testing, since I'd like to make sure that the 264-line works correctly for all the different ActionEffect variants (1, 8, 16, 24, 32), or at least the more common ones (32 probably requires BA/DRS/etc). 

Format for both lines is x|y|z|heading.

Example of bomb toss on self at (91.24, -0.34):

```
20|2023-10-16T22:07:24.8690000-07:00|1001ABCD|Player Name|2C84|Bomb Toss|E0000000||1.886|91.24|-0.34|16.00|-3.00|
263|2023-10-16T22:07:24.8690000-07:00|91.250|-0.336|15.992|-3.142|
21|2023-10-16T22:07:26.2480000-07:00|1001ABCD|Player Name|2C84|Bomb Toss|E0000000||0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|||||||||||25280|25280|10000|10000|||91.24|-0.34|16.00|-3.00|0000278B|0|0|
264|2023-10-16T22:07:26.2480000-07:00|91.250|-0.336|15.992|-2.996|
```

Example of bomb toss on a dummy at (80.91, -5.26):
```
20|2023-10-16T22:05:53.5360000-07:00|1001ABCD|Player Name|2C84|Bomb Toss|E0000000||1.886|89.84|0.50|16.00|-2.14|
263|2023-10-16T22:05:53.5360000-07:00|80.905|-5.249|16.999|-3.142|
22|2023-10-16T22:05:54.9210000-07:00|1001ABCD|Player Name|2C84|Bomb Toss|4000048E|Striking Dummy|152003|14900000|E|20000|1B|2C848000|0|0|0|0|0|0|0|0|0|0|2134350|2134350|0|10000|||80.91|-5.26|17.00|0.00|25280|25280|10000|10000|||89.84|0.50|16.00|-2.14|00002789|0|1|
264|2023-10-16T22:05:54.9210000-07:00|80.905|-5.249|16.999|-2.143|
```

Example of Aqua Breath at various angles:
```
20|2023-10-16T22:11:24.6210000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|1001ABCD|Player Name|1.886|96.76|-1.96|16.00|3.07|
263|2023-10-16T22:11:24.6210000-07:00|96.744|-1.953|15.992|3.073|
21|2023-10-16T22:11:26.0000000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|E0000000||0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|||||||||||25280|25280|10000|10000|||96.76|-1.96|16.00|3.07|0000278D|0|0|
264|2023-10-16T22:11:26.0000000-07:00|0.000|0.000|0.000|3.073|
20|2023-10-16T22:11:31.1180000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|1001ABCD|Player Name|1.886|96.92|-1.94|16.00|1.45|
263|2023-10-16T22:11:31.1180000-07:00|96.927|-1.953|15.992|1.448|
21|2023-10-16T22:11:32.4960000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|E0000000||0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|||||||||||25280|25280|10000|10000|||96.92|-1.94|16.00|1.45|0000278F|0|0|
264|2023-10-16T22:11:32.4960000-07:00|0.000|0.000|0.000|1.448|
20|2023-10-16T22:11:35.5670000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|1001ABCD|Player Name|1.886|96.78|-1.78|16.00|-0.71|
263|2023-10-16T22:11:35.5670000-07:00|96.774|-1.770|15.992|-0.713|
21|2023-10-16T22:11:36.9450000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|E0000000||0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|||||||||||25280|25280|10000|10000|||96.78|-1.78|16.00|-0.71|00002790|0|0|
264|2023-10-16T22:11:36.9450000-07:00|0.000|0.000|0.000|-0.713|
20|2023-10-16T22:11:39.8370000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|1001ABCD|Player Name|1.886|96.75|-1.87|16.00|-2.76|
263|2023-10-16T22:11:39.8370000-07:00|96.744|-1.862|15.992|-2.764|
21|2023-10-16T22:11:41.2160000-07:00|1001ABCD|Player Name|2C7E|Aqua Breath|E0000000||0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|||||||||||25280|25280|10000|10000|||96.75|-1.87|16.00|-2.76|00002791|0|0|
264|2023-10-16T22:11:41.2160000-07:00|0.000|0.000|0.000|-2.764|
```

In terms of future functionality, it would be nice to have a way of emitting these lines *before* the corresponding 20/21/22, but that doesn't seem to be possible currently. As it stands, they are always emitted even if they do not contain any useful data.

Update: going to leave in WIP state for now. I think I need to filter out ActionEffect1s, since they seem to not contain this data. Makes sense, since a ground AoE *shouldn't* be single-target. 