### PR TITLE
Fix race condition with locking `Logs` due to invocation on UI thread

### DIFF
--- a/OverlayPlugin.Core/Logger.cs
+++ b/OverlayPlugin.Core/Logger.cs
@@ -38,14 +38,13 @@ namespace RainbowMage.OverlayPlugin
 
             var entry = new LogEntry(level, DateTime.Now, message);
 
-            lock (Logs)
+            if (listener != null)
             {
-
-                if (listener != null)
-                {
-                    listener(entry);
-                }
-                else
+                listener(entry);
+            }
+            else
+            {
+                lock (Logs)
                 {
                     Logs.Add(entry);
                 }


### PR DESCRIPTION
Of course this race condition didn't happen the three times that I restarted ACT to test the change, but has happened almost every time since then. 🙃 

Basically what's happening is that the invoke on UI thread is getting delayed due to something else already running on the UI thread, and then that something else also tries to log, leading to the lock already being contended.

Since the lock is only required to prevent concurrent write to the `Logs` array, only wrap that in the lock.