### PR TITLE
Fix class scoping on classes required for custom log lines

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace RainbowMage.OverlayPlugin
 {
-    class FFXIVCustomLogLines
+    public class FFXIVCustomLogLines
     {
         private ILogger logger;
         private FFXIVRepository repository;
@@ -142,7 +142,7 @@ namespace RainbowMage.OverlayPlugin
         }
     }
 
-    interface ILogLineRegistryEntry
+    public interface ILogLineRegistryEntry
     {
         uint ID { get; }
         string Name { get; }
@@ -150,7 +150,7 @@ namespace RainbowMage.OverlayPlugin
         uint Version { get; }
     }
 
-    class LogLineRegistryEntry : ILogLineRegistryEntry
+    public class LogLineRegistryEntry : ILogLineRegistryEntry
     {
         public uint ID { get; set; }
         public string Name { get; set; }

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -71,7 +71,7 @@ namespace RainbowMage.OverlayPlugin
         Korean = 3
     }
 
-    class FFXIVRepository
+    public class FFXIVRepository
     {
         private readonly ILogger logger;
         private IDataRepository repository;


### PR DESCRIPTION
The original intent of the custom log lines class was to allow for use by both OverlayPlugin and downstream plugins.

Having finally gotten around to implementing a downstream plugin (for personal use), I found that a few classes/interfaces weren't scoped properly and therefore weren't available outside the assembly.

These adjustments are sufficient for my downstream project to work, but other adjustments might also make sense?