### PR TITLE
Remove unused `OnLog` event

### DIFF
--- a/OverlayPlugin.Common/IOverlay.cs
+++ b/OverlayPlugin.Common/IOverlay.cs
@@ -31,11 +31,6 @@ namespace RainbowMage.OverlayPlugin
         Control CreateConfigControl();
 
         /// <summary>
-        /// オーバーレイがログを出力したときに発生します。
-        /// </summary>
-        event EventHandler<LogEventArgs> OnLog;
-
-        /// <summary>
         /// オーバーレイの更新を開始します。
         /// </summary>
         void Start();

--- a/OverlayPlugin.Core/OverlayBase.cs
+++ b/OverlayPlugin.Core/OverlayBase.cs
@@ -23,10 +23,6 @@ namespace RainbowMage.OverlayPlugin
         private readonly EventDispatcher dispatcher;
 
         protected System.Timers.Timer timer;
-        /// <summary>
-        /// オーバーレイがログを出力したときに発生します。
-        /// </summary>
-        public event EventHandler<LogEventArgs> OnLog;
 
         /// <summary>
         /// ユーザーが設定したオーバーレイの名前を取得します。

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -395,7 +395,6 @@ namespace RainbowMage.OverlayPlugin
         /// <param name="overlay"></param>
         internal void RegisterOverlay(IOverlay overlay)
         {
-            overlay.OnLog += (o, e) => _logger.Log(e.Level, e.Message);
             overlay.Start();
             this.Overlays.Add(overlay);
 


### PR DESCRIPTION
This event is never used (and isn't exposed to actual overlays browser-side). I looked through git history related to the field, applying google translate as I went, and this was added 9 years ago or so and never actually used. It was superseded by `EventSourceBase.Log`, which is actually used.