### PR TITLE
Visual Studio fetch_deps and strip-clientstructs support

### DIFF
--- a/AddonExample/AddonExample.csproj
+++ b/AddonExample/AddonExample.csproj
@@ -31,7 +31,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" Private="False" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Core\OverlayPlugin.Core.csproj" />
   </ItemGroup>

--- a/AddonExample/AddonExample.csproj
+++ b/AddonExample/AddonExample.csproj
@@ -31,6 +31,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Core\OverlayPlugin.Core.csproj" />
   </ItemGroup>

--- a/OverlayPlugin.Common/OverlayPlugin.Common.csproj
+++ b/OverlayPlugin.Common/OverlayPlugin.Common.csproj
@@ -8,6 +8,9 @@
     <OutputPath>..\out\$(Configuration)\libs\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Advanced Combat Tracker">
       <HintPath>..\Thirdparty\ACT\Advanced Combat Tracker.exe</HintPath>
       <Private>False</Private>

--- a/OverlayPlugin.Common/OverlayPlugin.Common.csproj
+++ b/OverlayPlugin.Common/OverlayPlugin.Common.csproj
@@ -8,7 +8,7 @@
     <OutputPath>..\out\$(Configuration)\libs\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" Private="False" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Advanced Combat Tracker">

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -389,7 +389,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" Private="False" />
     <ProjectReference Include="..\HtmlRenderer\HtmlRenderer.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Updater\OverlayPlugin.Updater.csproj" />

--- a/OverlayPlugin.Core/OverlayPlugin.Core.csproj
+++ b/OverlayPlugin.Core/OverlayPlugin.Core.csproj
@@ -389,6 +389,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
     <ProjectReference Include="..\HtmlRenderer\HtmlRenderer.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Updater\OverlayPlugin.Updater.csproj" />

--- a/OverlayPlugin.Updater/OverlayPlugin.Updater.csproj
+++ b/OverlayPlugin.Updater/OverlayPlugin.Updater.csproj
@@ -107,7 +107,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" Private="False" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/OverlayPlugin.Updater/OverlayPlugin.Updater.csproj
+++ b/OverlayPlugin.Updater/OverlayPlugin.Updater.csproj
@@ -107,6 +107,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/OverlayPlugin.sln
+++ b/OverlayPlugin.sln
@@ -30,6 +30,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VSBuildDeps", "tools\VSBuildDeps\VSBuildDeps.csproj", "{6423EE85-3E94-4290-8699-BF403245501F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,14 @@ Global
 		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|x64.ActiveCfg = Release|Any CPU
 		{F826ED1A-187A-484F-ABE4-D794E5CE0F50}.Release|x64.Build.0 = Release|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Debug|x64.Build.0 = Debug|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Release|x64.ActiveCfg = Release|Any CPU
+		{6423EE85-3E94-4290-8699-BF403245501F}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OverlayPlugin/OverlayPlugin.csproj
+++ b/OverlayPlugin/OverlayPlugin.csproj
@@ -28,6 +28,7 @@ xcopy /Y /R "$(SolutionDir)LICENSE.txt" "$(MSBuildProjectDirectory)\$(OutputPath
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
     <ProjectReference Include="..\HtmlRenderer\HtmlRenderer.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Core\OverlayPlugin.Core.csproj" />

--- a/OverlayPlugin/OverlayPlugin.csproj
+++ b/OverlayPlugin/OverlayPlugin.csproj
@@ -28,7 +28,7 @@ xcopy /Y /R "$(SolutionDir)LICENSE.txt" "$(MSBuildProjectDirectory)\$(OutputPath
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" />
+    <ProjectReference Include="..\tools\VSBuildDeps\VSBuildDeps.csproj" Private="False" />
     <ProjectReference Include="..\HtmlRenderer\HtmlRenderer.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Common\OverlayPlugin.Common.csproj" />
     <ProjectReference Include="..\OverlayPlugin.Core\OverlayPlugin.Core.csproj" />

--- a/build.ps1
+++ b/build.ps1
@@ -2,19 +2,6 @@ param (
     [switch]$ci = $false
 )
 
-function Try-Fetch-Deps {
-    param ([String]$description)
-    echo "Dependency '$description' was not found, running ``tools/fetch_deps.ps1` to fetch any missing dependencies"
-    .\tools\fetch_deps.ps1
-    if ($LASTEXITCODE -ne 0) {
-        echo 'Error running fetch_deps.ps1'
-        exit 1
-    }
-    else {
-        echo 'Fetched deps successfully'
-    }
-}
-
 try {
     # This assumes Visual Studio 2022 is installed in C:. You might have to change this depending on your system.
     $DEFAULT_VS_PATH = "C:\Program Files\Microsoft Visual Studio\2022\Community"
@@ -31,25 +18,10 @@ try {
         $VS_PATH = & "$DEFAULT_VSWHERE_PATH" -latest -property installationPath
     }
 
-    if ( -not (Test-Path "Thirdparty\ACT\Advanced Combat Tracker.exe" )) {
-        Try-Fetch-Deps -description "Advanced Combat Tracker.exe"
-    }
-
-
-    if ( -not (Test-Path "Thirdparty\FFXIV_ACT_Plugin\SDK\FFXIV_ACT_Plugin.Common.dll" )) {
-        Try-Fetch-Deps -description "FFXIV_ACT_Plugin.Common.dll"
-    }
-
-    if ( -not (Test-Path "OverlayPlugin.Core\Thirdparty\FFXIVClientStructs\Base\Global" )) {
-        Try-Fetch-Deps -description "FFXIVClientStructs"
-    }
-
     $ENV:PATH = "$VS_PATH\MSBuild\Current\Bin;${ENV:PATH}";
     if (Test-Path "C:\Program Files\7-Zip\7z.exe") {
         $ENV:PATH = "C:\Program Files\7-Zip;${ENV:PATH}";
     }
-
-    .\tools\strip-clientstructs.ps1
 
     if ($ci) {
         echo "==> Continuous integration flag set. Building Debug..."

--- a/build.ps1
+++ b/build.ps1
@@ -25,14 +25,14 @@ try {
 
     if ($ci) {
         echo "==> Continuous integration flag set. Building Debug..."
-        dotnet publish -v quiet -c debug
+        dotnet publish -c debug
         
         if (-not $?) { exit 1 }
     }
 
     echo "==> Building..."
 
-    dotnet publish -v quiet -c release
+    dotnet publish -c release
     
     if (-not $?) { exit 1 }
 

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -341,7 +341,6 @@ namespace StripFFXIVClientStructs
             /// Technically this isn't required for `return null` cases, but in any situation where that doesn't result
             /// in an NPE it should be done as well.
             /// </summary>
-            [return: NotNullIfNotNull("node")]
             public override SyntaxNode Visit(SyntaxNode node)
             {
                 if (node == null)
@@ -632,7 +631,7 @@ namespace StripFFXIVClientStructs
                 // Strip off base types that don't exist on older language versions
                 var types = node.Types.Where((type) =>
                 {
-                    switch (type.ToString().Split("<")[0])
+                    switch (type.ToString().Split('<')[0])
                     {
                         case "IEquatable":
                         case "IFormattable":

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <ProjectGuid>{F826ED1A-187A-484F-ABE4-D794E5CE0F50}</ProjectGuid>
     <AssemblyTitle>StripFFXIVClientStructs</AssemblyTitle>
     <Product>StripFFXIVClientStructs</Product>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.csproj
@@ -1,9 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <ProjectGuid>{F826ED1A-187A-484F-ABE4-D794E5CE0F50}</ProjectGuid>
+    <AssemblyTitle>StripFFXIVClientStructs</AssemblyTitle>
+    <Product>StripFFXIVClientStructs</Product>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 </Project>

--- a/tools/VSBuildDeps/VSBuildDeps.csproj
+++ b/tools/VSBuildDeps/VSBuildDeps.csproj
@@ -10,11 +10,15 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
   <Target Name="FetchDeps" Condition=" '$(FetchDeps)'!='false' " BeforeTargets="PrepareForBuild">
-    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\fetch_deps.ps1&apos;} &quot;" />
+    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;'..\fetch_deps.ps1'} &quot;" />
   </Target>
   <Target Name="StripClientStructs" Condition=" '$(StripClientStructs)'!='false' " BeforeTargets="PrepareForBuild">
-    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\strip-clientstructs.ps1&apos;} &quot;" />
+    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;'..\strip-clientstructs.ps1'} &quot;" />
   </Target>
+  <ItemGroup>
+    <None Include="..\fetch_deps.ps1" Link="fetch_deps.ps1" />
+    <None Include="..\strip-clientstructs.ps1" Link="strip-clientstructs.ps1" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/tools/VSBuildDeps/VSBuildDeps.csproj
+++ b/tools/VSBuildDeps/VSBuildDeps.csproj
@@ -5,16 +5,10 @@
     <Product>OverlayPlugin.VSBuildDeps</Product>
   </PropertyGroup>
   <Target Name="FetchDeps" Condition=" '$(FetchDeps)'!='false' " BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
-    </PropertyGroup>
-    <Exec Command="$(PowerShellExe) -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\fetch_deps.ps1&apos;} &quot;" />
+    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\fetch_deps.ps1&apos;} &quot;" />
   </Target>
   <Target Name="StripClientStructs" Condition=" '$(StripClientStructs)'!='false' " BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
-    </PropertyGroup>
-    <Exec Command="$(PowerShellExe) -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\strip-clientstructs.ps1&apos;} &quot;" />
+    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\strip-clientstructs.ps1&apos;} &quot;" />
   </Target>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/tools/VSBuildDeps/VSBuildDeps.csproj
+++ b/tools/VSBuildDeps/VSBuildDeps.csproj
@@ -13,7 +13,7 @@
     <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;'..\fetch_deps.ps1'} &quot;" />
   </Target>
   <Target Name="StripClientStructs" Condition=" '$(StripClientStructs)'!='false' " BeforeTargets="PrepareForBuild">
-    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;'..\strip-clientstructs.ps1'} &quot;" />
+    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;'..\strip-clientstructs.ps1' '$(SolutionDir)tools\StripFFXIVClientStructs\StripFFXIVClientStructs\bin\$(Configuration)\StripFFXIVClientStructs.exe'} &quot;" />
   </Target>
   <ItemGroup>
     <None Include="..\fetch_deps.ps1" Link="fetch_deps.ps1" />
@@ -21,5 +21,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\StripFFXIVClientStructs\StripFFXIVClientStructs\StripFFXIVClientStructs.csproj" Private="False" />
   </ItemGroup>
 </Project>

--- a/tools/VSBuildDeps/VSBuildDeps.csproj
+++ b/tools/VSBuildDeps/VSBuildDeps.csproj
@@ -4,6 +4,11 @@
     <AssemblyTitle>OverlayPlugin.VSBuildDeps</AssemblyTitle>
     <Product>OverlayPlugin.VSBuildDeps</Product>
   </PropertyGroup>
+  <Target Name="CoreCompile" />
+  <PropertyGroup>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
   <Target Name="FetchDeps" Condition=" '$(FetchDeps)'!='false' " BeforeTargets="PrepareForBuild">
     <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\fetch_deps.ps1&apos;} &quot;" />
   </Target>

--- a/tools/VSBuildDeps/VSBuildDeps.csproj
+++ b/tools/VSBuildDeps/VSBuildDeps.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{6423EE85-3E94-4290-8699-BF403245501F}</ProjectGuid>
+    <AssemblyTitle>OverlayPlugin.VSBuildDeps</AssemblyTitle>
+    <Product>OverlayPlugin.VSBuildDeps</Product>
+  </PropertyGroup>
+  <Target Name="FetchDeps" Condition=" '$(FetchDeps)'!='false' " BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
+    </PropertyGroup>
+    <Exec Command="$(PowerShellExe) -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\fetch_deps.ps1&apos;} &quot;" />
+  </Target>
+  <Target Name="StripClientStructs" Condition=" '$(StripClientStructs)'!='false' " BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <PowerShellExe Condition=" '$(PowerShellExe)'=='' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellExe>
+    </PropertyGroup>
+    <Exec Command="$(PowerShellExe) -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;..\strip-clientstructs.ps1&apos;} &quot;" />
+  </Target>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>

--- a/tools/VSBuildDeps/VSBuildDepsNewtonsoftJson.csproj
+++ b/tools/VSBuildDeps/VSBuildDepsNewtonsoftJson.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{6AF411B1-CD1C-4A96-8CC1-E33EB06ADE2A}</ProjectGuid>
+    <AssemblyTitle>OverlayPlugin.VSBuildDepsNewtonsoftJson</AssemblyTitle>
+    <Product>OverlayPlugin.VSBuildDepsNewtonsoftJson</Product>
+  </PropertyGroup>
+  <Target Name="CoreCompile" />
+  <PropertyGroup>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>

--- a/tools/strip-clientstructs.ps1
+++ b/tools/strip-clientstructs.ps1
@@ -1,3 +1,21 @@
+param(
+    [Parameter(Mandatory=$false)]
+    [Alias('p')]
+    [ValidateScript({
+        if (-not ($_ | Test-Path)) {
+            throw "`$exePath does not exist: $_"
+        }
+        if (-not ($_ | Test-Path -PathType Leaf)) {
+            throw "`$exePath must be a file"
+        }
+        if ($_ -notmatch "\.exe") {
+            throw "`$exePath must be an exe file"
+        }
+        return $true 
+    })]
+    [System.IO.FileInfo]$exePath
+)
+
 # cd to project root if we're not already there
 $base = (Get-Item $PSCommandPath).Directory.Parent.FullName
 Push-Location $base
@@ -5,12 +23,21 @@ Push-Location $base
 if (Test-Path "OverlayPlugin.Core\Thirdparty\FFXIVClientStructs\Base") {
     echo "==> Preparing FFXIVClientStructs..."
     
-    echo "==> Building StripFFXIVClientStructs..."
-    # There's probably a better way to target just StripFFXIVClientStructs for build but `dotnet` was insisting on
-    # building all associated projects even when passing the `-t:StripFFXIVClientStructs` flag through to msbuild
-    dotnet publish -v quiet -c release -a x64 ".\tools\StripFFXIVClientStructs\StripFFXIVClientStructs\StripFFXIVClientStructs.csproj"
+    if ($exePath -eq $null) {
+        echo "==> Building StripFFXIVClientStructs..."
+        # There's probably a better way to target just StripFFXIVClientStructs for build but `dotnet` was insisting on
+        # building all associated projects even when passing the `-t:StripFFXIVClientStructs` flag through to msbuild
+        dotnet publish -v quiet -c release -a x64 ".\tools\StripFFXIVClientStructs\StripFFXIVClientStructs\StripFFXIVClientStructs.csproj"
+    }
 
     cd OverlayPlugin.Core\Thirdparty\FFXIVClientStructs\Base
+    
+    if ($exePath -eq $null) {
+        $exePath = (Join-Path $base "tools\StripFFXIVClientStructs\StripFFXIVClientStructs\bin\Release\StripFFXIVClientStructs.exe")
+    }
+
+    # Reassign here to force relative paths to resolve, otherwise `Invoke-Expression` is unhappy
+    $exePath = $exePath.FullName
 
     # Fix code to compile against .NET 4.8, remove partial funcs and helper funcs, we only want the struct layouts themselves
     gci * | foreach-object {
@@ -18,7 +45,7 @@ if (Test-Path "OverlayPlugin.Core\Thirdparty\FFXIVClientStructs\Base") {
 
         echo "==> Stripping FFXIVClientStructs for namespace $ns..."
 
-        ..\..\..\..\tools\StripFFXIVClientStructs\StripFFXIVClientStructs\bin\Release\StripFFXIVClientStructs.exe $ns .\$ns ..\Transformed\$ns
+        Invoke-Expression "$exePath $ns .\$ns ..\Transformed\$ns"
     }
 
     cd ..\..\..\..


### PR DESCRIPTION
~~This is based on the other two powershell PRs. Only commits starting with 3834c31be3a0dfbd465e3ae4dc237fabaeaf6250 (one at the time of this PR being created) are part of this PR. I will rebase to `main` when the dependent PRs are merged.~~

Rebased after parent PRs were merged.

The logic here is pretty simple:
1. Create a dummy `VSBuildDeps` project
2. Have that project require `Newtonsoft.Json` for dependency reasons
3. Have that project run the associated powershell scripts
4. Require that project as a `ProjectReference` wherever we're using a dependency that's loaded via `fetch_deps.ps1`

Outstanding thoughts/TODOs:
1. ~~Should we make the two powershell scripts exist as part of this project so they're easily visible in VS?~~
2. ~~Somehow stop this from generating a pointless dll file~~