### PR TITLE
Add ContentFinderSettings log line

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -179,6 +179,26 @@ namespace RainbowMage.OverlayPlugin
             }
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private uint? GetCurrentTerritoryIDImpl()
+        {
+            return GetRepository()?.GetCurrentTerritoryID();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public uint? GetCurrentTerritoryID()
+        {
+            try
+            {
+                return GetCurrentTerritoryIDImpl();
+            }
+            catch (FileNotFoundException)
+            {
+                // The FFXIV plugin isn't loaded
+                return null;
+            }
+        }
+
         public Version GetOverlayPluginVersion()
         {
             return Assembly.GetExecutingAssembly().GetName().Version;

--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
+using RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings;
 using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
 using RainbowMage.OverlayPlugin.NetworkProcessors;
 using RainbowMage.OverlayPlugin.Updater;
@@ -25,6 +26,7 @@ namespace RainbowMage.OverlayPlugin
             container.Register(new LineRSV(container));
             container.Register(new LineActorCastExtra(container));
             container.Register(new LineAbilityExtra(container));
+            container.Register(new LineContentFinderSettings(container));
         }
     }
 

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings.cs
@@ -20,8 +20,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             public byte explorerMode { get; set; }
 
             public byte levelSync { get; set; }
-
-            public ushort ilvlSync { get; set; }
         }
 
         private FFXIVMemory memory;
@@ -159,85 +157,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             settings.silenceEcho = bytes[3];
             settings.explorerMode = bytes[4];
             settings.levelSync = bytes[2];
-            var directorPtr = memory.GetInt64(contentDirectorAddress);
 
-            // Wrap the ilvlSync in a try/catch, because I'm not sure if this code will persist very well across major game updates
-            // Should work fine for 6.51 and 6.51-hotfix, but I don't really have a good way to check older versions for this logic
-            try
-            {
-                // Technically, the InstanceContentDirector is 0x1CB2 in length, but grab the minimal length required here.
-                var directorBytes = memory.GetByteArray(new IntPtr(directorPtr), 0x1CA7);
-                // Offsets and logic in `GetItemLevelSync` are based on
-                // https://github.com/Kouzukii/ffxiv-characterstatus-refined/blob/master/CharacterPanelRefined/IlvlSync.cs
-                var ilvlSyncValue1 = (ushort)(directorBytes[0x524] + (directorBytes[0x525] << 8)); // 1316
-                var ilvlSyncValue2 = (ushort)(directorBytes[0x526] + (directorBytes[0x527] << 8)); // 1318
-                var flags1 = directorBytes[0xCE4]; // 3300
-                var flags2 = directorBytes[0x33C]; // 828
-                var minIlvlFlags1 = directorBytes[0x1CA6]; // 7334
-                settings.ilvlSync = GetItemLevelSync(ilvlSyncValue1, ilvlSyncValue2, flags1, flags2, minIlvlFlags1, settings.levelSync, settings.inContentFinderContent);
-            }
-            catch (Exception e)
-            {
-                logger.Log(LogLevel.Error, $"Failed to get memory info for ilvlSync calculations: " + e.ToString());
-            }
             return settings;
-        }
-
-        private ushort GetItemLevelSync(ushort ilvlSyncValue1, ushort ilvlSyncValue2, byte flags1, byte flags2, byte minIlvlFlags1, byte levelSync, bool inContentFinderContent)
-        {
-            if (inContentFinderContent)
-            {
-                if (flags1 != 8 && (flags2 & 1) == 0)
-                {
-                    // min ilvl
-                    if (minIlvlFlags1 >= 0x80 && ilvlSyncValue1 > 0)
-                    {
-                        return ilvlSyncValue1;
-                    }
-
-                    // duty is sync'd
-                    if (((minIlvlFlags1 & 0x40) == 0 || levelSync == 1) && ilvlSyncValue2 > 0)
-                    {
-                        return ilvlSyncValue2;
-                    }
-                }
-            }
-
-            if (levelSync == 1)
-            {
-                var syncedLevel = combatantMemoryManager.GetSelfCombatant().Level;
-                ushort ilvl;
-                if (syncedLevel == 90)
-                    ilvl = 660;
-                else if (syncedLevel >= 83)
-                    ilvl = (ushort)(530 + (syncedLevel - 83) * 3);
-                else if (syncedLevel >= 81)
-                    ilvl = (ushort)(520 + (syncedLevel - 81) * 5);
-                else if (syncedLevel == 80)
-                    ilvl = 530;
-                else if (syncedLevel >= 73)
-                    ilvl = (ushort)(400 + (syncedLevel - 73) * 3);
-                else if (syncedLevel >= 71)
-                    ilvl = (ushort)(390 + (syncedLevel - 71) * 5);
-                else if (syncedLevel == 70)
-                    ilvl = 400;
-                else if (syncedLevel >= 63)
-                    ilvl = (ushort)(270 + (syncedLevel - 63) * 3);
-                else if (syncedLevel >= 61)
-                    ilvl = (ushort)(260 + (syncedLevel - 61) * 5);
-                else if (syncedLevel == 60)
-                    ilvl = 270;
-                else if (syncedLevel >= 53)
-                    ilvl = (ushort)(130 + (syncedLevel - 53) * 3);
-                else if (syncedLevel >= 51)
-                    ilvl = (ushort)(120 + (syncedLevel - 51) * 5);
-                else if (syncedLevel == 50)
-                    ilvl = 130;
-                else
-                    ilvl = syncedLevel;
-                return ilvl;
-            }
-            return 0;
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
+{
+    public abstract class ContentFinderSettingsMemory : IContentFinderSettingsMemory
+    {
+        private struct ContentFinderSettingsImpl : ContentFinderSettings
+        {
+            public byte unrestrictedParty { get; set; }
+
+            public byte minimalItemLevel { get; set; }
+
+            public byte silenceEcho { get; set; }
+
+            public byte explorerMode { get; set; }
+
+            public byte levelSync { get; set; }
+        }
+
+        private FFXIVMemory memory;
+        private ILogger logger;
+
+        private IntPtr settingsAddress = IntPtr.Zero;
+        private IntPtr inContentFinderAddress = IntPtr.Zero;
+
+        private string settingsSignature;
+        private string inContentFinderSignature;
+        private int inContentSettingsOffset;
+
+        public ContentFinderSettingsMemory(TinyIoCContainer container, string settingsSignature, string inContentFinderSignature, int inContentSettingsOffset)
+        {
+            this.settingsSignature = settingsSignature;
+            this.inContentFinderSignature = inContentFinderSignature;
+            this.inContentSettingsOffset = inContentSettingsOffset;
+            logger = container.Resolve<ILogger>();
+            memory = container.Resolve<FFXIVMemory>();
+        }
+
+        private void ResetPointers()
+        {
+            settingsAddress = IntPtr.Zero;
+            inContentFinderAddress = IntPtr.Zero;
+        }
+
+        private bool HasValidPointers()
+        {
+            if (settingsAddress == IntPtr.Zero)
+                return false;
+            if (inContentFinderAddress == IntPtr.Zero)
+                return false;
+            return true;
+        }
+
+        public bool IsValid()
+        {
+            if (!memory.IsValid())
+                return false;
+
+            if (!HasValidPointers())
+                return false;
+
+            return true;
+        }
+
+        public void ScanPointers()
+        {
+            ResetPointers();
+            if (!memory.IsValid())
+                return;
+
+            List<string> fail = new List<string>();
+
+            List<IntPtr> list = memory.SigScan(settingsSignature, -35, true);
+            if (list != null && list.Count > 0)
+            {
+                settingsAddress = list[0] + inContentSettingsOffset;
+            }
+            else
+            {
+                settingsAddress = IntPtr.Zero;
+                fail.Add(nameof(settingsAddress));
+            }
+
+            logger.Log(LogLevel.Debug, "settingsAddress: 0x{0:X}", settingsAddress.ToInt64());
+
+            list = memory.SigScan(inContentFinderSignature, -34, true, 1);
+            if (list != null && list.Count > 0)
+            {
+                inContentFinderAddress = list[0];
+            }
+            else
+            {
+                inContentFinderAddress = IntPtr.Zero;
+                fail.Add(nameof(inContentFinderAddress));
+            }
+
+            logger.Log(LogLevel.Debug, "inContentFinderAddress: 0x{0:X}", inContentFinderAddress.ToInt64());
+
+            if (fail.Count == 0)
+            {
+                logger.Log(LogLevel.Info, $"Found content finder settings memory via {GetType().Name}.");
+                return;
+            }
+
+            logger.Log(LogLevel.Error, $"Failed to find content finder settings memory via {GetType().Name}: {string.Join(", ", fail)}.");
+            return;
+        }
+
+        public abstract Version GetVersion();
+
+        public bool GetInContentFinderContent()
+        {
+            var bytes = memory.GetByteArray(inContentFinderAddress, 1);
+            return bytes[0] != 0;
+        }
+
+        public ContentFinderSettings GetContentFinderSettings()
+        {
+            var bytes = memory.GetByteArray(settingsAddress, 5);
+            var settings = new ContentFinderSettingsImpl();
+            settings.unrestrictedParty = bytes[0];
+            settings.minimalItemLevel = bytes[1];
+            settings.silenceEcho = bytes[3];
+            settings.explorerMode = bytes[4];
+            settings.levelSync = bytes[2];
+            return settings;
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 {
@@ -24,33 +22,27 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 
         private FFXIVMemory memory;
         private ILogger logger;
-        private ICombatantMemory combatantMemoryManager;
 
         private IntPtr settingsAddress = IntPtr.Zero;
         private IntPtr inContentFinderAddress = IntPtr.Zero;
-        private IntPtr contentDirectorAddress = IntPtr.Zero;
 
         private string settingsSignature;
         private string inContentFinderSignature;
-        private string contentDirectorSignature;
         private int inContentSettingsOffset;
 
-        public ContentFinderSettingsMemory(TinyIoCContainer container, string settingsSignature, string inContentFinderSignature, string contentDirectorSignature, int inContentSettingsOffset)
+        public ContentFinderSettingsMemory(TinyIoCContainer container, string settingsSignature, string inContentFinderSignature, int inContentSettingsOffset)
         {
             this.settingsSignature = settingsSignature;
             this.inContentFinderSignature = inContentFinderSignature;
             this.inContentSettingsOffset = inContentSettingsOffset;
-            this.contentDirectorSignature = contentDirectorSignature;
             logger = container.Resolve<ILogger>();
             memory = container.Resolve<FFXIVMemory>();
-            combatantMemoryManager = container.Resolve<ICombatantMemory>();
         }
 
         private void ResetPointers()
         {
             settingsAddress = IntPtr.Zero;
             inContentFinderAddress = IntPtr.Zero;
-            contentDirectorAddress = IntPtr.Zero;
         }
 
         private bool HasValidPointers()
@@ -58,8 +50,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             if (settingsAddress == IntPtr.Zero)
                 return false;
             if (inContentFinderAddress == IntPtr.Zero)
-                return false;
-            if (contentDirectorAddress == IntPtr.Zero)
                 return false;
             return true;
         }
@@ -108,19 +98,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             }
 
             logger.Log(LogLevel.Debug, "inContentFinderAddress: 0x{0:X}", inContentFinderAddress.ToInt64());
-
-            list = memory.SigScan(contentDirectorSignature, -32, true, 1);
-            if (list != null && list.Count > 0)
-            {
-                contentDirectorAddress = list[0];
-            }
-            else
-            {
-                contentDirectorAddress = IntPtr.Zero;
-                fail.Add(nameof(contentDirectorAddress));
-            }
-
-            logger.Log(LogLevel.Debug, "contentDirectorAddress: 0x{0:X}", contentDirectorAddress.ToInt64());
 
             if (fail.Count == 0)
             {

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
+{
+    interface IContentFinderSettingsMemory651 : IContentFinderSettingsMemory { }
+
+    class ContentFinderSettingsMemory651 : ContentFinderSettingsMemory, IContentFinderSettingsMemory651
+    {
+        // FUN_140985ee0:140985fae
+        private const string settingsSignature = "0FB63D????????EB??488B0D????????BA????????4883C1??E8????????8378????410F97C6";
+
+        // FUN_1400aa840:1400aa862
+        // IsLocalPlayerInParty:1400aa862 (after rename)
+        private const string inContentFinderSignature = "803D??????????0F85????????33D2488D0D????????E8????????80B8??????????0F87";
+
+        // Client::Game::InstanceContent::PublicContentDirector.HandleEnterContentInfoPacket, call to FUN_140988430 with static address 0x14220de08
+        // Static address = settingsSignature resolved address - 0x18, probably a full struct that hasn't been deconstructed yet
+        // FUN_140988430 returns address + 0x20 = 0x14220de28, so settingsSignature + 0x8
+        // HandleEnterContentInfoPacket calls to FUN_140987600 with resolved static address as first param
+        // param_9 = unrestricted party flag
+        // param_10 = min item level flag
+        // param_11 = silence echo flag
+        // param_12 = explorer mode flag
+        // param_13 = level sync flag
+        // FUN_140987600 directly sets memory based on static address passed in, the five flags we're interested in are at address + 0x88
+        // So 0x8 + 0x88 = 0x90
+        // There didn't seem to be a good signature to find the base address (passed into FUN_140988430) that would resolve across both
+        // 6.51 and 6.51-hotfix versions, so we're using the sig for the duty finder settings holder instead.
+        private const int inContentSettingsOffset = 0x90;
+
+        public ContentFinderSettingsMemory651(TinyIoCContainer container)
+            : base(container, settingsSignature, inContentFinderSignature, inContentSettingsOffset)
+        { }
+
+        public override Version GetVersion()
+        {
+            return new Version(6, 5, 1);
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
@@ -13,9 +13,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         // IsLocalPlayerInParty:1400aa862 (after rename)
         private const string inContentFinderSignature = "803D??????????0F85????????33D2488D0D????????E8????????80B8??????????0F87";
 
-        // FUN_140829150:140829208
-        private const string contentDirectorSignature = "48833D??????????74??803D??????????74??488D0D????????E8????????488B5C24";
-
         // Client::Game::InstanceContent::PublicContentDirector.HandleEnterContentInfoPacket, call to FUN_140988430 with static address 0x14220de08
         // Static address = settingsSignature resolved address - 0x18, probably a full struct that hasn't been deconstructed yet
         // FUN_140988430 returns address + 0x20 = 0x14220de28, so settingsSignature + 0x8
@@ -32,7 +29,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         private const int inContentSettingsOffset = 0x90;
 
         public ContentFinderSettingsMemory651(TinyIoCContainer container)
-            : base(container, settingsSignature, inContentFinderSignature, contentDirectorSignature, inContentSettingsOffset)
+            : base(container, settingsSignature, inContentFinderSignature, inContentSettingsOffset)
         { }
 
         public override Version GetVersion()

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
@@ -13,6 +13,9 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         // IsLocalPlayerInParty:1400aa862 (after rename)
         private const string inContentFinderSignature = "803D??????????0F85????????33D2488D0D????????E8????????80B8??????????0F87";
 
+        // FUN_140829150:140829208
+        private const string contentDirectorSignature = "48833D??????????74??803D??????????74??488D0D????????E8????????488B5C24";
+
         // Client::Game::InstanceContent::PublicContentDirector.HandleEnterContentInfoPacket, call to FUN_140988430 with static address 0x14220de08
         // Static address = settingsSignature resolved address - 0x18, probably a full struct that hasn't been deconstructed yet
         // FUN_140988430 returns address + 0x20 = 0x14220de28, so settingsSignature + 0x8
@@ -29,7 +32,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         private const int inContentSettingsOffset = 0x90;
 
         public ContentFinderSettingsMemory651(TinyIoCContainer container)
-            : base(container, settingsSignature, inContentFinderSignature, inContentSettingsOffset)
+            : base(container, settingsSignature, inContentFinderSignature, contentDirectorSignature, inContentSettingsOffset)
         { }
 
         public override Version GetVersion()

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
+{
+    public interface ContentFinderSettings
+    {
+        byte unrestrictedParty { get; }
+        byte minimalItemLevel { get; }
+        byte silenceEcho { get; }
+        byte explorerMode { get; }
+        byte levelSync { get; }
+        // TODO: Maybe we can track these down if they're ever actually needed?
+        // byte lootRules { get; }
+        // byte limitedLevelingRoulette { get; }
+    }
+
+    public interface IContentFinderSettingsMemory : IVersionedMemory
+    {
+        bool GetInContentFinderContent();
+
+        ContentFinderSettings GetContentFinderSettings();
+    }
+
+    class ContentFinderSettingsMemoryManager : IContentFinderSettingsMemory
+    {
+        private readonly TinyIoCContainer container;
+        private readonly FFXIVRepository repository;
+        private IContentFinderSettingsMemory memory = null;
+
+        public ContentFinderSettingsMemoryManager(TinyIoCContainer container)
+        {
+            this.container = container;
+            container.Register<IContentFinderSettingsMemory651, ContentFinderSettingsMemory651>();
+            repository = container.Resolve<FFXIVRepository>();
+
+            var memory = container.Resolve<FFXIVMemory>();
+            memory.RegisterOnProcessChangeHandler(FindMemory);
+        }
+
+        private void FindMemory(object sender, Process p)
+        {
+            memory = null;
+            if (p == null)
+            {
+                return;
+            }
+            ScanPointers();
+        }
+
+        public void ScanPointers()
+        {
+            List<IContentFinderSettingsMemory> candidates = new List<IContentFinderSettingsMemory>();
+            candidates.Add(container.Resolve<IContentFinderSettingsMemory651>());
+            memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
+        }
+
+        public bool IsValid()
+        {
+            if (memory == null || !memory.IsValid())
+            {
+                return false;
+            }
+            return true;
+        }
+
+        Version IVersionedMemory.GetVersion()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
+        }
+
+        public bool GetInContentFinderContent()
+        {
+            if (!IsValid())
+                return false;
+            return memory.GetInContentFinderContent();
+        }
+
+        public ContentFinderSettings GetContentFinderSettings()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetContentFinderSettings();
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
@@ -13,7 +13,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         byte explorerMode { get; }
         byte levelSync { get; }
 
-        ushort ilvlSync { get; }
         // TODO: Maybe we can track these down if they're ever actually needed?
         // byte lootRules { get; }
         // byte limitedLevelingRoulette { get; }

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
@@ -6,6 +6,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 {
     public interface ContentFinderSettings
     {
+        bool inContentFinderContent { get; }
         byte unrestrictedParty { get; }
         byte minimalItemLevel { get; }
         byte silenceEcho { get; }
@@ -20,8 +21,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 
     public interface IContentFinderSettingsMemory : IVersionedMemory
     {
-        bool GetInContentFinderContent();
-
         ContentFinderSettings GetContentFinderSettings();
     }
 
@@ -72,13 +71,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             if (!IsValid())
                 return null;
             return memory.GetVersion();
-        }
-
-        public bool GetInContentFinderContent()
-        {
-            if (!IsValid())
-                return false;
-            return memory.GetInContentFinderContent();
         }
 
         public ContentFinderSettings GetContentFinderSettings()

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
@@ -11,6 +11,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         byte silenceEcho { get; }
         byte explorerMode { get; }
         byte levelSync { get; }
+
+        ushort ilvlSync { get; }
         // TODO: Maybe we can track these down if they're ever actually needed?
         // byte lootRules { get; }
         // byte limitedLevelingRoulette { get; }

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -1,27 +1,18 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Advanced_Combat_Tracker;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 {
     class LineContentFinderSettings
     {
         public const uint LogFileLineID = 265;
-        private ILogger logger;
         private readonly FFXIVRepository ffxiv;
 
         private Func<string, DateTime, bool> logWriter;
 
         private IContentFinderSettingsMemory contentFinderSettingsMemory;
 
-        private bool wroteFirstLine = false;
-
         public LineContentFinderSettings(TinyIoCContainer container)
         {
-            logger = container.Resolve<ILogger>();
             ffxiv = container.Resolve<FFXIVRepository>();
             if (!ffxiv.IsFFXIVPluginPresent())
                 return;
@@ -34,43 +25,18 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
                 ID = LogFileLineID,
                 Version = 1,
             });
-            ActGlobals.oFormActMain.BeforeLogLineRead += LogLineHandler;
+            ffxiv.RegisterZoneChangeDelegate(OnZoneChange);
         }
 
-        private void LogLineHandler(bool isImport, LogLineEventArgs args)
+        private void OnZoneChange(uint zoneId, string zoneName)
         {
-            if (isImport)
-            {
-                return;
-            }
-
             if (!contentFinderSettingsMemory.IsValid())
                 return;
-
-            try
-            {
-                LogMessageType lineType = (LogMessageType)args.detectedType;
-
-                if (lineType != LogMessageType.ChangeZone && wroteFirstLine)
-                    return;
-
-                var line = args.originalLogLine.Split('|');
-                var zoneID = line[2];
-                var zoneName = line[3];
-
-                wroteFirstLine = true;
-                WriteInContentFinderSettingsLine(args.detectedTime, zoneID, zoneName);
-            }
-            catch (Exception e)
-            {
-                logger.Log(LogLevel.Error, "Failed to process log line: " + e.ToString());
-            }
+            WriteInContentFinderSettingsLine(DateTime.Now, $"{zoneId:X}", zoneName);
         }
 
         private void WriteInContentFinderSettingsLine(DateTime dateTime, string zoneID, string zoneName)
         {
-            // If we're not in a content finder content instance, set this to null
-            // So that we can default to all 0's later
             var settings = contentFinderSettingsMemory.GetContentFinderSettings();
 
             logWriter.Invoke(

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -69,14 +69,12 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 
         private void WriteInContentFinderSettingsLine(DateTime dateTime, string zoneID, string zoneName)
         {
-            var inContentFinderContent = contentFinderSettingsMemory.GetInContentFinderContent();
-
             // If we're not in a content finder content instance, set this to null
             // So that we can default to all 0's later
-            var settings = inContentFinderContent ? contentFinderSettingsMemory.GetContentFinderSettings() : null;
+            var settings = contentFinderSettingsMemory.GetContentFinderSettings();
 
             logWriter.Invoke(
-                $"{inContentFinderContent}|" +
+                $"{settings.inContentFinderContent}|" +
                 $"{zoneID}|" +
                 $"{zoneName}|" +
                 $"{settings?.ilvlSync ?? 0}|" +

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -25,7 +25,16 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
                 ID = LogFileLineID,
                 Version = 1,
             });
+            // Get the current zone ID before we subscribe
+            var currentZoneId = ffxiv.GetCurrentTerritoryID();
             ffxiv.RegisterZoneChangeDelegate(OnZoneChange);
+
+            // If we already had a zone ID, manually trigger a line
+            if (currentZoneId.HasValue)
+            {
+                var currentZoneName = Advanced_Combat_Tracker.ActGlobals.oFormActMain.CurrentZone;
+                OnZoneChange(currentZoneId.Value, currentZoneName);
+            }
         }
 
         private void OnZoneChange(uint zoneId, string zoneName)

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -49,15 +49,15 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             var settings = contentFinderSettingsMemory.GetContentFinderSettings();
 
             logWriter.Invoke(
-                $"{settings.inContentFinderContent}|" +
                 $"{zoneID}|" +
                 $"{zoneName}|" +
-                $"{settings?.ilvlSync ?? 0}|" +
-                $"{settings?.unrestrictedParty ?? 0}|" +
-                $"{settings?.minimalItemLevel ?? 0}|" +
-                $"{settings?.silenceEcho ?? 0}|" +
-                $"{settings?.explorerMode ?? 0}|" +
-                $"{settings?.levelSync ?? 0}",
+                $"{settings.inContentFinderContent}|" +
+                $"{settings.ilvlSync}|" +
+                $"{settings.unrestrictedParty}|" +
+                $"{settings.minimalItemLevel}|" +
+                $"{settings.silenceEcho}|" +
+                $"{settings.explorerMode}|" +
+                $"{settings.levelSync}",
                 dateTime);
         }
     }

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Advanced_Combat_Tracker;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
+{
+    class LineContentFinderSettings
+    {
+        public const uint LogFileLineID = 265;
+        private ILogger logger;
+        private readonly FFXIVRepository ffxiv;
+
+        private Func<string, DateTime, bool> logWriter;
+
+        private IContentFinderSettingsMemory contentFinderSettingsMemory;
+
+        private bool wroteFirstLine = false;
+
+        public LineContentFinderSettings(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            contentFinderSettingsMemory = container.Resolve<IContentFinderSettingsMemory>();
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "ContentFinderSettings",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+            ActGlobals.oFormActMain.BeforeLogLineRead += LogLineHandler;
+        }
+
+        private void LogLineHandler(bool isImport, LogLineEventArgs args)
+        {
+            if (isImport)
+            {
+                return;
+            }
+
+            if (!contentFinderSettingsMemory.IsValid())
+                return;
+
+            try
+            {
+                LogMessageType lineType = (LogMessageType)args.detectedType;
+
+                if (lineType != LogMessageType.ChangeZone && wroteFirstLine)
+                    return;
+                wroteFirstLine = true;
+                WriteInContentFinderSettingsLine(args.detectedTime);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, "Failed to process log line: " + e.ToString());
+            }
+        }
+
+        private void WriteInContentFinderSettingsLine(DateTime dateTime)
+        {
+            var inContentFinderContent = contentFinderSettingsMemory.GetInContentFinderContent();
+
+            // If we're not in a content finder content instance, set this to null
+            // So that we can default to all 0's later
+            var settings = inContentFinderContent ? contentFinderSettingsMemory.GetContentFinderSettings() : null;
+
+            logWriter.Invoke(
+                $"{inContentFinderContent}|" +
+                $"{settings?.unrestrictedParty ?? 0}|" +
+                $"{settings?.minimalItemLevel ?? 0}|" +
+                $"{settings?.silenceEcho ?? 0}|" +
+                $"{settings?.explorerMode ?? 0}|" +
+                $"{settings?.levelSync ?? 0}",
+                dateTime);
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -53,8 +53,13 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 
                 if (lineType != LogMessageType.ChangeZone && wroteFirstLine)
                     return;
+
+                var line = args.originalLogLine.Split('|');
+                var zoneID = line[2];
+                var zoneName = line[3];
+
                 wroteFirstLine = true;
-                WriteInContentFinderSettingsLine(args.detectedTime);
+                WriteInContentFinderSettingsLine(args.detectedTime, zoneID, zoneName);
             }
             catch (Exception e)
             {
@@ -62,7 +67,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             }
         }
 
-        private void WriteInContentFinderSettingsLine(DateTime dateTime)
+        private void WriteInContentFinderSettingsLine(DateTime dateTime, string zoneID, string zoneName)
         {
             var inContentFinderContent = contentFinderSettingsMemory.GetInContentFinderContent();
 
@@ -72,6 +77,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 
             logWriter.Invoke(
                 $"{inContentFinderContent}|" +
+                $"{zoneID}|" +
+                $"{zoneName}|" +
                 $"{settings?.ilvlSync ?? 0}|" +
                 $"{settings?.unrestrictedParty ?? 0}|" +
                 $"{settings?.minimalItemLevel ?? 0}|" +

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -72,6 +72,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 
             logWriter.Invoke(
                 $"{inContentFinderContent}|" +
+                $"{settings?.ilvlSync ?? 0}|" +
                 $"{settings?.unrestrictedParty ?? 0}|" +
                 $"{settings?.minimalItemLevel ?? 0}|" +
                 $"{settings?.silenceEcho ?? 0}|" +

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -66,7 +66,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
                 $"{zoneID}|" +
                 $"{zoneName}|" +
                 $"{settings.inContentFinderContent}|" +
-                $"{settings.ilvlSync}|" +
                 $"{settings.unrestrictedParty}|" +
                 $"{settings.minimalItemLevel}|" +
                 $"{settings.silenceEcho}|" +

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -16,6 +16,7 @@ using RainbowMage.OverlayPlugin.MemoryProcessors;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Aggro;
 using RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
+using RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Enmity;
 using RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud;
 using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
@@ -268,6 +269,7 @@ namespace RainbowMage.OverlayPlugin
                                 // These are registered to be lazy-loaded. Use interface to force TinyIoC to use singleton pattern.
                                 _container.Register<ICombatantMemory, CombatantMemoryManager>();
                                 _container.Register<ITargetMemory, TargetMemoryManager>();
+                                _container.Register<IContentFinderSettingsMemory, ContentFinderSettingsMemoryManager>();
                                 _container.Register<IAggroMemory, AggroMemoryManager>();
                                 _container.Register<IEnmityMemory, EnmityMemoryManager>();
                                 _container.Register<IEnmityHudMemory, EnmityHudMemoryManager>();

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -70,7 +70,14 @@
         "Comment": "Extra info from ActionEffect packets"
     },
     {
-        "StartID": 265,
+        "ID": 265,
+        "Name": "ContentFinderSettings",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "Current content finder settings"
+    },
+    {
+        "StartID": 266,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
Per Xi Ashtra's request initially in DMs on Discord, and Kihra and other conversation on the FFLogs discord starting roughly here: <https://discord.com/channels/192732719879290880/192732852830470144/1180026806984790047>

I included a lot of documentation on how I found these addresses as comments, on the off chance that they break in a future update.

Technically this info is available via a `CFDutyInfo` packet (current opcode `0x318`), but that's sent pre-zone-in and can't be relied on if ACT is started after zoning in. Instead, this looks at the memory locations where that info gets stored.