### PR TITLE
Update CEF to v120

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -42,7 +42,7 @@ jobs:
           path: |
             ./Thirdparty
             ./OverlayPlugin.Core/Thirdparty
-          key: ${{ runner.os }}-overlayplugin-${{ hashFiles('./tools/fetch_deps.ps1', './DEPS.json') }}
+          key: ${{ runner.os }}-overlayplugin-${{ hashFiles('./tools/fetch_deps.ps1', './DEPS.json', './tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs') }}
           restore-keys: |
             ${{ runner.os }}-overlayplugin-
       # Fetch dependencies only if cache-hit is false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           path: |
             ./Thirdparty
             ./OverlayPlugin.Core/Thirdparty
-          key: ${{ runner.os }}-overlayplugin-${{ hashFiles('./tools/fetch_deps.ps1', './DEPS.json') }}
+          key: ${{ runner.os }}-overlayplugin-${{ hashFiles('./tools/fetch_deps.ps1', './DEPS.json', './tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs') }}
           restore-keys: |
             ${{ runner.os }}-overlayplugin-
       # Fetch dependencies only if cache-hit is false

--- a/AddonExample/AddonExample.csproj
+++ b/AddonExample/AddonExample.csproj
@@ -4,7 +4,6 @@
     <AssemblyTitle>AddonExample</AssemblyTitle>
     <Product>AddonExample</Product>
     <Copyright>Copyright ©  2015</Copyright>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <OutputPath>..\out\$(Configuration)\addons\</OutputPath>
   </PropertyGroup>
   <ItemGroup>

--- a/AddonExample/AddonExampleEventSource.cs
+++ b/AddonExample/AddonExampleEventSource.cs
@@ -106,9 +106,14 @@ namespace AddonExample
             }));
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            base.Dispose();
+            if (disposing && originalTimer != null)
+            {
+                originalTimer.Dispose();
+                originalTimer = null;
+            }
+            base.Dispose(disposing);
         }
 
         // Sends an event called |event_name| to javascript, with an event.detail that contains

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,8 @@
         <TargetFramework>net48</TargetFramework>
         <Copyright>Copyright © RainbowMage 2015, Kuriyama hibiya 2016, ngld 2019, OverlayPlugin Team 2022</Copyright>
         <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+        <RunCodeAnalysis>false</RunCodeAnalysis>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AssemblyVersion>0.19.24</AssemblyVersion>
         <FileVersion>0.19.24</FileVersion>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
         <Copyright>Copyright © RainbowMage 2015, Kuriyama hibiya 2016, ngld 2019, OverlayPlugin Team 2022</Copyright>
-        <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
         <RunCodeAnalysis>false</RunCodeAnalysis>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
         <AssemblyVersion>0.19.24</AssemblyVersion>

--- a/HtmlRenderer/HtmlRenderer.csproj
+++ b/HtmlRenderer/HtmlRenderer.csproj
@@ -8,6 +8,9 @@
     <Description>HTML based offscreen rendering library for the OverlayPlugin.</Description>
     <OutputPath>..\out\$(Configuration)\libs\</OutputPath>
   </PropertyGroup>
+  <Target Name="PrintCEFDir" Condition=" '$(PrintCEFDir)'!='false' " BeforeTargets="PrepareForBuild">
+    <WriteLinesToFile File="..\out\$(Configuration)\CefPath.txt" Overwrite="true" Lines="$(Pkgcef_redist_x64)" />
+  </Target>
   <ItemGroup>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -41,15 +44,20 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="cef.redist.x64" Version="95.7.14" />
-    <PackageReference Include="CefSharp.Common" Version="95.7.141" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="CefSharp.OffScreen" Version="95.7.141" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="CefSharp.Common" Version="95.7.141" Condition="'$(Configuration)' == 'Release'">
+    <PackageReference Include="cef.redist.x64" Version="120.1.10">
+      <GeneratePathProperty>true</GeneratePathProperty>
       <IncludeAssets>compile</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="CefSharp.OffScreen" Version="95.7.141" Condition="'$(Configuration)' == 'Release'">
+    <PackageReference Include="CefSharp.Common" Version="120.1.110" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="CefSharp.OffScreen" Version="120.1.110" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="CefSharp.Common" Version="120.1.110" Condition="'$(Configuration)' == 'Release'">
+      <IncludeAssets>compile</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="CefSharp.OffScreen" Version="120.1.110" Condition="'$(Configuration)' == 'Release'">
       <IncludeAssets>compile</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/HtmlRenderer/NativeMethods.cs
+++ b/HtmlRenderer/NativeMethods.cs
@@ -227,7 +227,7 @@ namespace RainbowMage.HtmlRenderer
         [DllImport("user32.dll")]
         public static extern IntPtr GetForegroundWindow();
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         public static extern int GetModuleFileName(IntPtr hModule, StringBuilder lpFilename, int nSize);
 
         [DllImport("user32.dll")]

--- a/HtmlRenderer/OverlayControl.cs
+++ b/HtmlRenderer/OverlayControl.cs
@@ -131,14 +131,14 @@ namespace RainbowMage.HtmlRenderer
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (this.Renderer != null)
+            if (disposing)
             {
-                this.Renderer.Dispose();
-            }
-
-            if (disposing && (components != null))
-            {
-                components.Dispose();
+                Renderer?.Dispose();
+                Renderer = null;
+                components?.Dispose();
+                components = null;
+                surfaceBuffer?.Dispose();
+                surfaceBuffer = null;
             }
             base.Dispose(disposing);
         }

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -400,12 +400,23 @@ namespace RainbowMage.HtmlRenderer
             return null;
         }
 
+        private bool _disposed = false;
+
         public void Dispose()
         {
-            if (this._browser != null)
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
             {
-                this._browser.Dispose();
-                this._browser = null;
+                if (disposing)
+                {
+                    this._browser?.Dispose();
+                    this._browser = null;
+                }
             }
         }
 

--- a/OverlayPlugin.Core/Controls/ControlPanel.cs
+++ b/OverlayPlugin.Core/Controls/ControlPanel.cs
@@ -17,6 +17,10 @@ namespace RainbowMage.OverlayPlugin
     {
         TinyIoCContainer _container;
         ILogger _logger;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "_pluginMain is disposed of by TinyIoCContainer")]
         PluginMain _pluginMain;
         IPluginConfig _config;
         Registry _registry;
@@ -94,7 +98,9 @@ namespace RainbowMage.OverlayPlugin
         {
             if (disposing)
             {
-                if (components != null) components.Dispose();
+                components?.Dispose();
+                _generalTab?.Dispose();
+                _eventTab?.Dispose();
                 _registry.EventSourceRegistered -= AddEventSourceTab;
                 _logger.ClearListener();
             }

--- a/OverlayPlugin.Core/Controls/NewOverlayDialog.cs
+++ b/OverlayPlugin.Core/Controls/NewOverlayDialog.cs
@@ -17,6 +17,10 @@ namespace RainbowMage.OverlayPlugin
         public ValidateNameDelegate NameValidator { get; set; }
         public IOverlay SelectedOverlay { get; private set; }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "pluginMain is disposed of by TinyIoCContainer")]
         private PluginMain pluginMain;
         private Registry registry;
         private ILogger logger;

--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -23,7 +23,15 @@ namespace RainbowMage.OverlayPlugin
         const string NGROK_CHOCO_SCRIPT = "https://raw.githubusercontent.com/ngrok/choco-ngrok/main/tools/chocolateyinstall.ps1";
 
         IPluginConfig _config;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "_server is disposed of by TinyIoCContainer")]
         WSServer _server;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "_plugin is disposed of by TinyIoCContainer")]
         PluginMain _plugin;
         Registry _registry;
         Process _ngrok;

--- a/OverlayPlugin.Core/Controls/WSConfigPanel.resx
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.resx
@@ -768,18 +768,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   <data name="simpStopBtn.Text" xml:space="preserve">
     <value>Stop</value>
   </data>
-  <data name="&gt;&gt;simpStopBtn.Name" xml:space="preserve">
-    <value>simpStopBtn</value>
-  </data>
-  <data name="&gt;&gt;simpStopBtn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;simpStopBtn.Parent" xml:space="preserve">
-    <value>tunnelPage</value>
-  </data>
-  <data name="&gt;&gt;simpStopBtn.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="simpStartBtn.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
@@ -794,18 +782,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   </data>
   <data name="simpStartBtn.Text" xml:space="preserve">
     <value>Start</value>
-  </data>
-  <data name="&gt;&gt;simpStartBtn.Name" xml:space="preserve">
-    <value>simpStartBtn</value>
-  </data>
-  <data name="&gt;&gt;simpStartBtn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;simpStartBtn.Parent" xml:space="preserve">
-    <value>tunnelPage</value>
-  </data>
-  <data name="&gt;&gt;simpStartBtn.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="simpLogBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left, Right</value>
@@ -822,18 +798,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   <data name="simpLogBox.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
-  <data name="&gt;&gt;simpLogBox.Name" xml:space="preserve">
-    <value>simpLogBox</value>
-  </data>
-  <data name="&gt;&gt;simpLogBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;simpLogBox.Parent" xml:space="preserve">
-    <value>tunnelPage</value>
-  </data>
-  <data name="&gt;&gt;simpLogBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="simpStatusLbl.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -848,18 +812,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   </data>
   <data name="simpStatusLbl.Text" xml:space="preserve">
     <value>Unknown</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLbl.Name" xml:space="preserve">
-    <value>simpStatusLbl</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLbl.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLbl.Parent" xml:space="preserve">
-    <value>tunnelPage</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLbl.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="regionCb.Items" xml:space="preserve">
     <value>us - United States (Ohio)</value>
@@ -891,18 +843,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   <data name="regionCb.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;regionCb.Name" xml:space="preserve">
-    <value>regionCb</value>
-  </data>
-  <data name="&gt;&gt;regionCb.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;regionCb.Parent" xml:space="preserve">
-    <value>tunnelPage</value>
-  </data>
-  <data name="&gt;&gt;regionCb.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
   <data name="regionLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -918,18 +858,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   <data name="regionLabel.Text" xml:space="preserve">
     <value>Region:</value>
   </data>
-  <data name="&gt;&gt;regionLabel.Name" xml:space="preserve">
-    <value>regionLabel</value>
-  </data>
-  <data name="&gt;&gt;regionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;regionLabel.Parent" xml:space="preserve">
-    <value>tunnelPage</value>
-  </data>
-  <data name="&gt;&gt;regionLabel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
   <data name="simpStatusLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -944,18 +872,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   </data>
   <data name="simpStatusLabel.Text" xml:space="preserve">
     <value>Status:</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLabel.Name" xml:space="preserve">
-    <value>simpStatusLabel</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLabel.Parent" xml:space="preserve">
-    <value>tunnelPage</value>
-  </data>
-  <data name="&gt;&gt;simpStatusLabel.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -975,18 +891,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   <data name="label3.Text" xml:space="preserve">
     <value>Status:</value>
   </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>settingsPage</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="statusLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1004,18 +908,6 @@ Finally, if WSServer is started through the Stream/Local Overlay tab, it will au
   </data>
   <data name="statusLabel.Text" xml:space="preserve">
     <value>Unknown</value>
-  </data>
-  <data name="&gt;&gt;statusLabel.Name" xml:space="preserve">
-    <value>statusLabel</value>
-  </data>
-  <data name="&gt;&gt;statusLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;statusLabel.Parent" xml:space="preserve">
-    <value>settingsPage</value>
-  </data>
-  <data name="&gt;&gt;statusLabel.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/OverlayPlugin.Core/EventSourceBase.cs
+++ b/OverlayPlugin.Core/EventSourceBase.cs
@@ -71,9 +71,19 @@ namespace RainbowMage.OverlayPlugin
             logger.Log(level, message, args);
         }
 
-        public virtual void Dispose()
+        public void Dispose()
         {
-            timer?.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && timer != null)
+            {
+                timer.Dispose();
+                timer = null;
+            }
         }
 
         public virtual void Start()

--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
@@ -51,7 +51,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemoryManager.cs
@@ -52,7 +52,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
@@ -58,7 +58,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -12,7 +12,7 @@ using RainbowMage.OverlayPlugin.NetworkProcessors;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
-    public class LineCombatant
+    public class LineCombatant : IDisposable
     {
         public const uint LogFileLineID = 261;
         private ILogger logger;
@@ -169,6 +169,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         private Func<string, DateTime, bool> logWriter;
 
         private CancellationTokenSource cancellationToken;
+        private bool _disposed;
 
         public LineCombatant(TinyIoCContainer container)
         {
@@ -218,10 +219,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 
         ~LineCombatant()
         {
-            if (cancellationToken != null)
-            {
-                cancellationToken.Cancel();
-            }
+            Dispose(false);
         }
 
         private void PollCombatants()
@@ -474,6 +472,25 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             Add,
             Remove,
             Change,
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    cancellationToken?.Cancel();
+                    cancellationToken?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemoryManager.cs
@@ -51,7 +51,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
@@ -53,7 +53,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
@@ -51,7 +51,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory.cs
@@ -49,7 +49,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
 
         protected IntPtr partyInstanceAddress = IntPtr.Zero;
 
-        private long partySingletonAddressInstance;
         protected Func<IntPtr> GetGroupManagerAddress;
 
 

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
@@ -53,7 +53,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemoryManager.cs
@@ -57,7 +57,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
             return true;
         }
 
-        Version IVersionedMemory.GetVersion()
+        public Version GetVersion()
         {
             if (!IsValid())
                 return null;

--- a/OverlayPlugin.Core/NativeMethods.cs
+++ b/OverlayPlugin.Core/NativeMethods.cs
@@ -302,6 +302,15 @@ namespace RainbowMage.OverlayPlugin
         public static extern bool ReadProcessMemory(IntPtr hProcess, IntPtr lpBaseAddress, byte[] lpBuffer, IntPtr nSize, ref IntPtr lpNumberOfBytesRead);
 
 #pragma warning restore 0649
+
+        // Registers a hot key with Windows.
+        [DllImport("user32.dll")]
+        public static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+        // Unregisters the hot key with Windows.
+        [DllImport("user32.dll")]
+        public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        public static int WM_HOTKEY = 0x0312;
     }
 
     [Flags]

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -311,7 +311,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     {
                         logWriter(string.Format(CultureInfo.InvariantCulture,
                             "{0:X8}|{1:X4}|{2:X8}|{3}||||",
-                            sourceId, globalEffectCounter, (int)LineSubType.ERROR), serverTime);
+                            sourceId, abilityId, globalEffectCounter, (int)LineSubType.ERROR), serverTime);
                         return;
                     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -5,7 +5,6 @@ using RainbowMage.OverlayPlugin.MemoryProcessors;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
-    [Serializable]
     [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
     internal unsafe struct RSV_v62
     {

--- a/OverlayPlugin.Core/OverlayHider.cs
+++ b/OverlayPlugin.Core/OverlayHider.cs
@@ -12,17 +12,22 @@ using static RainbowMage.OverlayPlugin.MemoryProcessors.InCombat.LineInCombat;
 
 namespace RainbowMage.OverlayPlugin
 {
-    class OverlayHider
+    class OverlayHider : IDisposable
     {
         private bool gameActive = true;
         private bool inCutscene = false;
         private bool inCombat = false;
         private IPluginConfig config;
         private ILogger logger;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "main is disposed of by TinyIoCContainer")]
         private PluginMain main;
         private FFXIVRepository repository;
         private int ffxivPid = -1;
         private Timer focusTimer;
+        private bool _disposed;
 
         public OverlayHider(TinyIoCContainer container)
         {
@@ -153,6 +158,26 @@ namespace RainbowMage.OverlayPlugin
             {
                 UpdateOverlays();
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    focusTimer?.Stop();
+                    focusTimer?.Dispose();
+                    focusTimer = null;
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OverlayPlugin.Core/OverlayZCorrector.cs
+++ b/OverlayPlugin.Core/OverlayZCorrector.cs
@@ -8,13 +8,18 @@ using System.Threading.Tasks;
 
 namespace RainbowMage.OverlayPlugin
 {
-    class OverlayZCorrector
+    class OverlayZCorrector : IDisposable
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "main is disposed of by TinyIoCContainer")]
         private PluginMain main;
         private ILogger logger;
         private Timer timer;
         private FFXIVRepository repository;
         private Process xivProc;
+        private bool _disposed;
 
         public OverlayZCorrector(TinyIoCContainer container)
         {
@@ -72,6 +77,26 @@ namespace RainbowMage.OverlayPlugin
             }
 
             // logger.Log(LogLevel.Debug, $"ZReorder: Took {watch.Elapsed.TotalSeconds}s.");
+        }
+
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    timer?.Dispose();
+                    timer = null;
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OverlayPlugin.Core/Overlays/LabelOverlayConfigPanel.cs
+++ b/OverlayPlugin.Core/Overlays/LabelOverlayConfigPanel.cs
@@ -14,6 +14,11 @@ namespace RainbowMage.OverlayPlugin.Overlays
     {
         private LabelOverlayConfig config;
         private LabelOverlay overlay;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "keyboardHook is disposed of by TinyIoCContainer")]
         private readonly KeyboardHook keyboardHook;
 
         public LabelOverlayConfigPanel(TinyIoCContainer container, LabelOverlay overlay)

--- a/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.cs
+++ b/OverlayPlugin.Core/Overlays/MiniParseConfigPanel.cs
@@ -14,6 +14,10 @@ namespace RainbowMage.OverlayPlugin.Overlays
     {
         private MiniParseOverlayConfig config;
         private MiniParseOverlay overlay;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Usage",
+            "CA2213:Disposable fields should be disposed",
+            Justification = "keyboardHook is disposed of by TinyIoCContainer")]
         private readonly KeyboardHook keyboardHook;
 
         static readonly List<KeyValuePair<string, GlobalHotkeyType>> hotkeyTypeDict = new List<KeyValuePair<string, GlobalHotkeyType>>()

--- a/OverlayPlugin.Core/Overlays/MiniParseOverlay.cs
+++ b/OverlayPlugin.Core/Overlays/MiniParseOverlay.cs
@@ -97,10 +97,13 @@ namespace RainbowMage.OverlayPlugin.Overlays
             Overlay.Renderer.BrowserConsoleLog += Renderer_BrowserConsoleLog;
         }
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            base.Dispose();
-            previewTimer?.Dispose();
+            if (disposing)
+            {
+                previewTimer?.Dispose();
+            }
+            base.Dispose(disposing);
         }
 
         public override Control CreateConfigControl()

--- a/OverlayPlugin.Core/PluginConfig.cs
+++ b/OverlayPlugin.Core/PluginConfig.cs
@@ -19,6 +19,8 @@ namespace RainbowMage.OverlayPlugin
     public class PluginConfig : IPluginConfig
     {
         const string BACKUP_SUFFIX = ".backup";
+        [NonSerialized]
+        [JsonIgnore]
         private TinyIoCContainer _container;
 
         [JsonIgnore]
@@ -169,6 +171,9 @@ namespace RainbowMage.OverlayPlugin
             }
         }
 
+        // TODO: This isn't being serialized to JSON (and JToken isn't serializable directly)
+        // so this isn't being cached locally anymore?
+        [NonSerialized]
         private JToken _cachedOpcodeFile = new JObject();
         public JToken CachedOpcodeFile
         {
@@ -338,7 +343,7 @@ namespace RainbowMage.OverlayPlugin
                         }
                         else
                         {
-                            throw ex;
+                            throw;
                         }
                     }
                 }

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -27,7 +27,7 @@ using RainbowMage.OverlayPlugin.Overlays;
 
 namespace RainbowMage.OverlayPlugin
 {
-    public class PluginMain
+    public class PluginMain : IDisposable
     {
         private TinyIoCContainer _container;
         private ILogger _logger;
@@ -41,6 +41,7 @@ namespace RainbowMage.OverlayPlugin
         Timer initTimer;
         Timer configSaveTimer;
         private bool clearCache = false;
+        private bool _disposed;
 
         internal PluginConfig Config { get; private set; }
         internal List<IOverlay> Overlays { get; private set; }
@@ -586,6 +587,30 @@ namespace RainbowMage.OverlayPlugin
                 "RainbowMage.OverlayPlugin.config." + (xml ? "xml" : "json"));
 
             return path;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    controlPanel?.Dispose();
+                    wsTabPage?.Dispose();
+                    wsConfigPanel?.Dispose();
+                    initTimer?.Stop();
+                    initTimer?.Dispose();
+                    configSaveTimer?.Stop();
+                    configSaveTimer?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OverlayPlugin.Core/WebSocket/WSServer.cs
+++ b/OverlayPlugin.Core/WebSocket/WSServer.cs
@@ -15,17 +15,17 @@ using RainbowMage.OverlayPlugin.Overlays;
 
 namespace RainbowMage.OverlayPlugin
 {
-    public class WSServer
+    public class WSServer : IDisposable
     {
         TinyIoCContainer _container;
         ILogger _logger;
         WebSocketServer _server;
         IPluginConfig _cfg;
-        PluginMain _plugin;
         List<IWSConnection> _connections = new List<IWSConnection>();
         bool _failed = false;
 
         public EventHandler<StateChangedArgs> OnStateChanged;
+        private bool _disposed;
 
         interface IWSConnection : IEventReceiver
         {
@@ -77,7 +77,6 @@ namespace RainbowMage.OverlayPlugin
             _container = container;
             _logger = container.Resolve<ILogger>();
             _cfg = container.Resolve<IPluginConfig>();
-            _plugin = container.Resolve<PluginMain>();
         }
 
         public void Start()
@@ -520,6 +519,24 @@ namespace RainbowMage.OverlayPlugin
                 this.Running = Running;
                 this.Failed = Failed;
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _server?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OverlayPlugin.Updater/HttpClientWrapper.cs
+++ b/OverlayPlugin.Updater/HttpClientWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Threading;
 
 namespace RainbowMage.OverlayPlugin.Updater
@@ -131,5 +132,7 @@ namespace RainbowMage.OverlayPlugin.Updater
         {
             this.Retry = retry;
         }
+
+        protected HttpClientException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
     }
 }

--- a/OverlayPlugin.Updater/Installer.cs
+++ b/OverlayPlugin.Updater/Installer.cs
@@ -13,7 +13,7 @@ using SharpCompress.Archives;
 
 namespace RainbowMage.OverlayPlugin.Updater
 {
-    public class Installer
+    public class Installer : IDisposable
     {
         const uint FILE_OVERWRITE_RETRIES = 10;
         const int FILE_OVERWRITE_WAIT = 300;
@@ -22,6 +22,7 @@ namespace RainbowMage.OverlayPlugin.Updater
         public string TempDir { get; private set; }
         string _destDir = null;
         CancellationToken _token = CancellationToken.None;
+        private bool _disposed;
 
         public ProgressDisplay Display => _display;
 
@@ -482,6 +483,25 @@ namespace RainbowMage.OverlayPlugin.Updater
                     }
                 }
             }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _display?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/OverlayPlugin/PluginLoader.cs
+++ b/OverlayPlugin/PluginLoader.cs
@@ -14,7 +14,7 @@ using RainbowMage.OverlayPlugin.Updater;
 
 namespace RainbowMage.OverlayPlugin
 {
-    public class PluginLoader : IActPluginV1
+    public class PluginLoader : IActPluginV1, IDisposable
     {
         PluginMain pluginMain;
         Logger logger;
@@ -23,6 +23,7 @@ namespace RainbowMage.OverlayPlugin
         TabPage pluginScreenSpace;
         Label pluginStatusText;
         bool initFailed = false;
+        private bool _disposed;
 
         public TinyIoCContainer Container { get; private set; }
 
@@ -162,6 +163,25 @@ namespace RainbowMage.OverlayPlugin
         private string GetCefPath()
         {
             return Path.Combine(ActGlobals.oFormActMain.AppDataFolder.FullName, "OverlayPluginCef", Environment.Is64BitProcess ? "x64" : "x86");
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    pluginMain.Dispose();
+                    Container.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/build-cef-redists.ps1
+++ b/build-cef-redists.ps1
@@ -2,33 +2,27 @@ try {
     # This assumes Visual Studio 2019 is installed in C:. You might have to change this depending on your system.
     $VS_PATH = "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community"
 
-    if ( -not (Test-Path "Thirdparty\ACT\Advanced Combat Tracker.exe" )) {
-        echo 'Error: Please run tools\fetch_deps.ps1'
-        exit 1
-    }
-
-    if ( -not (Test-Path "Thirdparty\FFXIV_ACT_Plugin\SDK\FFXIV_ACT_Plugin.Common.dll" )) {
-        echo 'Error: Please run tools\fetch_deps.ps1'
-        exit 1
-    }
-
     $ENV:PATH = "$VS_PATH\MSBuild\Current\Bin;${ENV:PATH}";
     if (Test-Path "C:\Program Files\7-Zip\7z.exe") {
         $ENV:PATH = "C:\Program Files\7-Zip;${ENV:PATH}";
     }
 
-    echo "==> Building..."
+    $OutDir = Join-Path $PWD out
 
-    msbuild -p:Configuration=Release -p:Platform=x64 "OverlayPlugin.sln" -t:Restore
-    msbuild -p:Configuration=Release -p:Platform=x64 "OverlayPlugin.sln" -t:Rebuild
+    echo "==> Building PrintCEFDir to find CEF redist path..."
+
+    dotnet build -c release -t:PrintCEFDir .\HtmlRenderer\HtmlRenderer.csproj
     if (-not $?) { exit 1 }
 
-    echo "==> Building CEF archives..."
+    $CEFDir = Join-Path ([System.IO.File]::ReadAllText("$OutDir\Release\CEFPath.txt")).Trim() CEF;
 
-    cd out\Release\libs\x64
-    copy ..\CefSharp* .
+    echo "==> Building CEF archive from contents of $CEFDir..."
 
-    $text = [System.IO.File]::ReadAllText("$PWD\README.txt");
+    Push-Location $CEFDir
+
+    Write-Host $PWD
+
+    $text = [System.IO.File]::ReadAllText("$CEFDir\README.txt");
     $regex = [regex]::New("CEF Version:\s*([0-9.]+)");
     $m = $regex.Match($text);
 
@@ -38,26 +32,12 @@ try {
     }
 
     $version = $m.Groups[1]
-    $archive = "..\..\..\CefSharp-$version-x64.7z"
+    $archive = Join-Path $OutDir "CefSharp-$version-x64.7z"
 
     if (Test-Path $archive) { rm $archive }
     7z a $archive "-x!*.xml" "-x!*.pdb" .
 
-    # Rename the archive here so I don't have to before uploading.
-    # If you're wondering why I change the extension: People don't read. This seems like the easiest way to force them to.
-    #mv $archive "..\..\..\CefSharp-$version-x64.DO_NOT_DOWNLOAD"
-
-    cd ..\..\libs\x86
-    copy ..\CefSharp* .
-
-    $archive = "..\..\..\CefSharp-$version-x86.7z"
-
-    if (Test-Path $archive) { rm $archive }
-    7z a $archive "-x!*.xml" "-x!*.pdb" .
-
-    #mv $archive "..\..\..\CefSharp-$version-x86.DO_NOT_DOWNLOAD"
-
-    cd ..\..
+    Pop-Location
 } catch {
     Write-Error $Error[0]
 }

--- a/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
+++ b/tools/StripFFXIVClientStructs/StripFFXIVClientStructs/StripFFXIVClientStructs.cs
@@ -74,7 +74,6 @@ namespace StripFFXIVClientStructs
         private static string[] GlobalUsings = new string[] {
             "System.Runtime.InteropServices",
             "FFXIVClientStructs.{0}.STD",
-            "FFXIVClientStructs.{0}.FFXIV.Client.Graphics",
         };
 
         // Entries in this dictionary will have their types remapped to concrete types.
@@ -99,11 +98,6 @@ namespace StripFFXIVClientStructs
     {{
         public Node* Head;
         public ulong Count;
-        public ref struct Enumerator
-        {{
-            private readonly Node* _head;
-            private Node* _current;
-        }}
 
         [StructLayout(LayoutKind.Sequential)]
         public struct Node
@@ -138,11 +132,6 @@ namespace StripFFXIVClientStructs
     {{
         public Node* Head;
         public ulong Count;
-        public ref struct Enumerator
-        {{
-            private readonly Node* _head;
-            private Node* _current;
-        }}
 
         [StructLayout(LayoutKind.Sequential)]
         public struct Node

--- a/tools/VSBuildDeps/VSBuildDeps.csproj
+++ b/tools/VSBuildDeps/VSBuildDeps.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{6423EE85-3E94-4290-8699-BF403245501F}</ProjectGuid>
     <AssemblyTitle>OverlayPlugin.VSBuildDeps</AssemblyTitle>
@@ -23,6 +23,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\StripFFXIVClientStructs\StripFFXIVClientStructs\StripFFXIVClientStructs.csproj" Private="False" />
+    <ProjectReference Include="..\StripFFXIVClientStructs\StripFFXIVClientStructs\StripFFXIVClientStructs.csproj" Private="False">
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is pretty much untested currently.

Based on #283 to avoid merge issues down the line and to make sure build warnings/errors are more obvious, since the build process was changed in that PR to stop suppressing warnings.

Only commits starting with 704bb4b9df81d8df4fce8aeec5818ccf66490942 are relevant here.

This PR rewrites the logic to build CEF redist to pull directly from the nuget package directory rather than doing a copy of the redist files and such. Also bumps the version of CEF/Chromium to v120. And finally actually switches to using OverlayPlugin/CeF repository for fetching the redist.

Testing that still needs done:

- [ ] Test a fresh install to ensure that we're fetching the redist from the correct github repo
- [ ] Test a fresh install to make sure it actually works
- [ ] Delete existing `OverlayPluginCef` then test a fresh build with `Debug` for full functionality
- [ ] Delete existing `OverlayPluginCef` then test a fresh build with `Release` for full functionality
- [ ] Linux testing with wine 5/6/7/8/maybe 9?
- [ ] Linux testing with both users that use OverlayPlugin overlays and users that use websocket to display overlays