### PR TITLE
Fix generated overlay URL when using '*' as the websocket bind IP

### DIFF
--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -352,7 +352,7 @@ namespace RainbowMage.OverlayPlugin
                     hostUrl += "ws://";
                 }
 
-                if (_config.WSServerIP == "0.0.0.0")
+                if (_config.WSServerIP == "0.0.0.0" || _config.WSServerIP == "*")
                 {
                     hostUrl += "127.0.0.1";
                 }


### PR DESCRIPTION
Fixes #304 

If you use '*' as your websocket bind IP address, it will not use '127.0.0.1' in the generated overlay URL.