### PR TITLE
Also fix generated URL for ipv6 wildcard

### DIFF
--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -356,6 +356,10 @@ namespace RainbowMage.OverlayPlugin
                 {
                     hostUrl += "127.0.0.1";
                 }
+                else if (_config.WSServerIP == "[::]")
+                {
+                    hostUrl += "[::1]";
+                }
                 else
                 {
                     hostUrl += _config.WSServerIP;


### PR DESCRIPTION
Same as #305 but for `[::]`

Fixes the other half of #304 