### PR TITLE
Adjust ffxiv clientstructs build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -26,6 +26,9 @@ try {
     if ($ci) {
         echo "==> Continuous integration flag set. Building Debug..."
         dotnet publish -c debug
+
+        echo "`$ENV:CI=$ENV:CI"
+        echo "`$ENV:GITHUB_RUN_ID=$ENV:GITHUB_RUN_ID"
         
         if (-not $?) { exit 1 }
     }

--- a/build.ps1
+++ b/build.ps1
@@ -23,12 +23,15 @@ try {
         $ENV:PATH = "C:\Program Files\7-Zip;${ENV:PATH}";
     }
 
+    if ($ENV:CI -eq "true" -and $ENV:GITHUB_RUN_ID -ne $null) {
+        echo "==> Running as a GitHub Action, pre-running clientstructs scripts"
+
+        .\tools\strip-clientstructs.ps1
+    }
+
     if ($ci) {
         echo "==> Continuous integration flag set. Building Debug..."
         dotnet publish -c debug
-
-        echo "`$ENV:CI=$ENV:CI"
-        echo "`$ENV:GITHUB_RUN_ID=$ENV:GITHUB_RUN_ID"
         
         if (-not $?) { exit 1 }
     }


### PR DESCRIPTION
Hopefully this will fix issues with builds.

Originally this was doing some additional logic all over the place, to attempt to fix the issue. But in the end just pre-running the strip script when in a GH action seems to be sufficient to fix it.

The root cause is likely something to do with parallel builds, but despite disabling parallel builds with a flag to `dotnet`, it was still failing to find the requisite files even after verifying they exist prior to running the actual build step (via an additional script execution in the csproj file).