### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           [xml]$csprojcontents = Get-Content -Path "Directory.Build.props";
           $version = $csprojcontents.Project.PropertyGroup.AssemblyVersion;
           $version = ($version | Out-String).Trim()
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Check Tag Exists
         id: check_tag
@@ -33,15 +33,18 @@ jobs:
         run: |
           if [ $(git tag -l "v${{ steps.determine_version.outputs.version }}") ]; then
               echo "Existing git tag found. Exiting..."
+              echo "do_release=false" >> $GITHUB_OUTPUT
           else
               echo "Version bump detected - ${{ steps.determine_version.outputs.version }}"
-              echo "::set-output name=do_release::true"
+              echo "do_release=true" >> $GITHUB_OUTPUT
           fi
 
   create_release:
     needs: [validate_tag]
     runs-on: windows-latest
-    if: ${{ github.repository == 'OverlayPlugin/OverlayPlugin' && needs.validate_tag.outputs.do_release == 'true' }}
+    if: |
+      github.repository == 'OverlayPlugin/OverlayPlugin' &&
+      needs.validate_tag.outputs.do_release == 'true'
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: windows-latest
     outputs:
       version: ${{ steps.determine_version.outputs.version }}
+      do_release: ${{ steps.check_tag.outputs.do_release }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -27,16 +28,20 @@ jobs:
           echo "::set-output name=version::$version"
 
       - name: Check Tag Exists
+        id: check_tag
         shell: bash
         run: |
           if [ $(git tag -l "v${{ steps.determine_version.outputs.version }}") ]; then
-              echo "Error: Existing git tag found. Exiting..."
-              exit 1
+              echo "Existing git tag found. Exiting..."
+          else
+              echo "Version bump detected - ${{ steps.determine_version.outputs.version }}"
+              echo "::set-output name=do_release::true"
           fi
 
   create_release:
     needs: [validate_tag]
     runs-on: windows-latest
+    if: ${{ github.repository == 'OverlayPlugin/OverlayPlugin' && needs.validate_tag.outputs.do_release == 'true' }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Right now the release workflow errors if `Directory.Build.props` is touched without an actual version bump happening. This PR should fix that by skipping the `create_release` job if no release is needed, rather than erroring out during `check_tag`.