### PR TITLE
Add NpcYell and BattleTalk2 lines

### DIFF
--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -27,6 +27,8 @@ namespace RainbowMage.OverlayPlugin
             container.Register(new LineActorCastExtra(container));
             container.Register(new LineAbilityExtra(container));
             container.Register(new LineContentFinderSettings(container));
+            container.Register(new LineNpcYell(container));
+            container.Register(new LineBattleTalk2(container));
         }
     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineBattleTalk2.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineBattleTalk2.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using RainbowMage.OverlayPlugin.MemoryProcessors;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
+    internal unsafe struct BattleTalk2_v655
+    {
+        // 00|2024-02-25T15:13:29.0000000-05:00|0044|Whiskerwall Kupdi Koop|Mogglesguard, assemble! We must drive them out together, kupo!|e9f836e9767bed2e
+        // Pre-processed data from packet (sorry, no raw packet for this one, instead it's my scuffed debugging packet dump's data)
+        // 00000000|00000000|80034E2B|000002CE|33804|5000|0|2|0|0
+        // first 4 bytes are actor ID, not always set
+        // 0x80034E2B = instance content ID
+        // 0x2CE = entry on `BNpcName` table
+        // 33804 = entry on `InstanceContentTextData` table
+        // 5000 = display time in ms?
+        // 2 = some sort of flags for display settings?
+
+        public const int structSize = 40;
+        [FieldOffset(0x0)]
+        public uint actorID;
+        [FieldOffset(0x8)]
+        public uint instanceContentID;
+        [FieldOffset(0xC)]
+        public uint npcNameID;
+        [FieldOffset(0x10)]
+        public uint instanceContentTextID;
+        [FieldOffset(0x14)]
+        public uint param1;
+        [FieldOffset(0x18)]
+        public uint param2;
+        [FieldOffset(0x1C)]
+        public uint param3;
+        [FieldOffset(0x20)]
+        public uint param4;
+        [FieldOffset(0x24)]
+        public uint param5;
+
+        public override string ToString()
+        {
+            return
+                $"{actorID:X8}|" +
+                $"{instanceContentID:X8}|" +
+                $"{npcNameID:X8}|" +
+                $"{instanceContentTextID:X8}|" +
+                $"{param1:X8}|" +
+                $"{param2:X8}|" +
+                $"{param3:X8}|" +
+                $"{param4:X8}|" +
+                $"{param5:X8}";
+        }
+    }
+
+    public class LineBattleTalk2
+    {
+        public const uint LogFileLineID = 267;
+        private ILogger logger;
+        private OverlayPluginLogLineConfig opcodeConfig;
+        private IOpcodeConfigEntry opcode = null;
+        private readonly int offsetMessageType;
+        private readonly int offsetPacketData;
+        private readonly FFXIVRepository ffxiv;
+
+        private Func<string, DateTime, bool> logWriter;
+
+        public LineBattleTalk2(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                offsetPacketData = Marshal.SizeOf(msgHeaderType);
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "BattleTalk2",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            // Wait for network data to actually fetch opcode info from file and register log line
+            // This is because the FFXIV_ACT_Plugin's `GetGameVersion` method only returns valid data
+            // if the player is currently logged in/a network connection is active
+            if (opcode == null)
+            {
+                opcode = opcodeConfig["BattleTalk2"];
+                if (opcode == null)
+                {
+                    return;
+                }
+            }
+
+            if (message.Length < opcode.size + offsetPacketData)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
+                {
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                    BattleTalk2_v655 battleTalk2Packet = *(BattleTalk2_v655*)&buffer[offsetPacketData];
+                    logWriter(battleTalk2Packet.ToString(), serverTime);
+
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
@@ -28,7 +28,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             return
                 $"{actorID:X8}|" +
                 $"{nameID:X8}|" +
-                $"{yellID:X8}|";
+                $"{yellID:X8}";
         }
     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using RainbowMage.OverlayPlugin.MemoryProcessors;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
+    internal unsafe struct NpcYell_v655
+    {
+        // 00|2024-02-22T22:35:03.0000000-05:00|0044|Shanoa|Meow!♪|1d173e4a0eacfd95
+        // 6.5.5 packet data (minus header):
+        // 8A6B0140 00000000 0624 0000 D624 00000000 00000000 00000000 00000000 0000
+        // AAAAAAAA BBBBBBBB CCCC DDDD EEEE FFFFFFFF GGGGGGGG HHHHHHHH IIIIIIII JJJJ
+        // 0x0      0x4      0x8  0xA  0xC
+        // Actor ID          NameID    YellID
+
+        public const int structSize = 32;
+        [FieldOffset(0x0)]
+        public uint actorID;
+        [FieldOffset(0x8)]
+        public ushort nameID;
+        [FieldOffset(0xC)]
+        public ushort yellID;
+
+        public override string ToString()
+        {
+            return
+                $"{actorID:X8}|" +
+                $"{nameID:X8}|" +
+                $"{yellID:X8}|";
+        }
+    }
+
+    public class LineNpcYell
+    {
+        public const uint LogFileLineID = 266;
+        private ILogger logger;
+        private OverlayPluginLogLineConfig opcodeConfig;
+        private IOpcodeConfigEntry opcode = null;
+        private readonly int offsetMessageType;
+        private readonly int offsetPacketData;
+        private readonly FFXIVRepository ffxiv;
+
+        private Func<string, DateTime, bool> logWriter;
+
+        public LineNpcYell(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                offsetPacketData = Marshal.SizeOf(msgHeaderType);
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "NpcYell",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            // Wait for network data to actually fetch opcode info from file and register log line
+            // This is because the FFXIV_ACT_Plugin's `GetGameVersion` method only returns valid data
+            // if the player is currently logged in/a network connection is active
+            if (opcode == null)
+            {
+                opcode = opcodeConfig["NpcYell"];
+                if (opcode == null)
+                {
+                    return;
+                }
+            }
+
+            if (message.Length < opcode.size + offsetPacketData)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
+                {
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                    NpcYell_v655 yellPacket = *(NpcYell_v655*)&buffer[offsetPacketData];
+                    logWriter(yellPacket.ToString(), serverTime);
+
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
@@ -27,8 +27,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         {
             return
                 $"{actorID:X8}|" +
-                $"{nameID:X8}|" +
-                $"{yellID:X8}";
+                $"{nameID:X4}|" +
+                $"{yellID:X4}";
         }
     }
 

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -16,14 +16,6 @@
         "RSVData": {
             "opcode": 582,
             "size": 1080
-        },
-        "NpcYell": {
-            "opcode": 101,
-            "size": 32
-        },
-        "BattleTalk2": {
-            "opcode": 475,
-            "size": 40
         }
     },
     // Global region
@@ -40,6 +32,14 @@
         "RSVData": {
             "opcode": 625,
             "size": 1080
+        },
+        "NpcYell": {
+            "opcode": 101,
+            "size": 32
+        },
+        "BattleTalk2": {
+            "opcode": 475,
+            "size": 40
         }
     },
     // KR region

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -16,6 +16,14 @@
         "RSVData": {
             "opcode": 582,
             "size": 1080
+        },
+        "NpcYell": {
+            "opcode": 101,
+            "size": 32
+        },
+        "BattleTalk2": {
+            "opcode": 475,
+            "size": 40
         }
     },
     // Global region

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -77,7 +77,21 @@
         "Comment": "Current content finder settings"
     },
     {
-        "StartID": 266,
+        "ID": 266,
+        "Name": "NpcYell",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "NpcYell packet data"
+    },
+    {
+        "ID": 267,
+        "Name": "BattleTalk2",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "BattleTalk2 packet data"
+    },
+    {
+        "StartID": 268,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
This should allow cactbot to fix many of the "timeline doesn't work" issues caused by people enabling chat privacy option or using dalamud plugins that mess with chat, e.g. Nael quotes in UCOB.

Note that this does not cover all `00` lines that cactbot is currently using, so work on that project to start using these new lines may want to be held until the `Countdown` lines can be added, and maybe potentially the crafting-related lines.

Example run of Thornmarch below. `BattleTalk2` lines in this fight generate a chat line, whereas `NpcYell` lines don't. In some content they do generate chat lines, e.g. UCOB, but I don't have a log of that handy.

I included the "defeat" chat lines so that it's a bit more obvious where the `266` `NpcYell` lines fall in the encounter timing, though these can be looked up on e.g. XIVAPI at <https://xivapi.com/NpcYell/1947> = 0x79B

```
267|2024-02-25T15:38:10.3400000-05:00|00000000|80034E2B|000002CE|0000840C|00001388|00000000|00000002|00000000|00000000|725b8ea7a2bb4521
00|2024-02-25T15:38:09.0000000-05:00|0044|Whiskerwall Kupdi Koop|Mogglesguard, assemble! We must drive them out together, kupo!|0e6829d2972b3d16
00|2024-02-25T15:38:10.0000000-05:00|0AAB||You begin casting Glare III.|3eb52462b5a26f2c
00|2024-02-25T15:38:12.0000000-05:00|0AA9||Critical! You hit Whiskerwall Kupdi Koop for 144 damage.|f4971f60bca1a174
266|2024-02-25T15:38:13.6720000-05:00|400117F1|000002CF|0000079E||3156a75c36e5bff1
266|2024-02-25T15:38:13.6720000-05:00|400117F2|000002CE|0000079B||17b6f5f8a64e1698
266|2024-02-25T15:38:13.6720000-05:00|400117F0|000002D1|000007A8||590d4d93df7db3e5
00|2024-02-25T15:38:15.0000000-05:00|0B3A||You defeat Whiskerwall Kupdi Koop.|3ba12aa28f93cbf9
266|2024-02-25T15:38:25.9700000-05:00|400117F1|000002CF|000007A0||c3936f9ba3bd3993
266|2024-02-25T15:38:26.1040000-05:00|400117EF|000002D0|000007A3||25bb94430f131045
266|2024-02-25T15:38:26.1040000-05:00|400117EE|000002D3|000007B5||b13c5357f4f8619b
266|2024-02-25T15:38:26.1040000-05:00|400117F0|000002D1|000007AA||8c7392900ebe9b70
00|2024-02-25T15:38:27.0000000-05:00|0B3A||You defeat Ruffletuft Kupta Kapa.|cb570ec7999c626d
00|2024-02-25T15:38:27.0000000-05:00|0B3A||You defeat Woolywart Kupqu Kogi.|576c8fa4f4f36bf5
266|2024-02-25T15:38:32.1540000-05:00|400117EF|000002D0|000007A5||fad4047569f0a894
00|2024-02-25T15:38:33.0000000-05:00|0B3A||You defeat Furryfoot Kupli Kipp.|f267d48a36798fb5
266|2024-02-25T15:38:37.5800000-05:00|400117ED|000002D2|000007AD||3e83083e54b6171b
266|2024-02-25T15:38:37.5800000-05:00|400117EC|000002D4|000007BA||72da345538e89c57
266|2024-02-25T15:38:37.5800000-05:00|400117EE|000002D3|000007B7||c70bdce950630dfe
00|2024-02-25T15:38:38.0000000-05:00|0B3A||You defeat Puksi Piko the Shaggysong.|1957497f1291fa09
267|2024-02-25T15:38:44.2610000-05:00|00000000|80034E2B|000002D2|00008411|00001B58|00000000|00000002|00000000|00000000|38d599574185e342
00|2024-02-25T15:38:43.0000000-05:00|0044|Pukla Puki the Pomburner|You'll be blown to smithereens, kupo!|c6a1ffa0d80e21fb
266|2024-02-25T15:38:57.6870000-05:00|400117ED|000002D2|000007AF||0e2730018db44f4a
266|2024-02-25T15:38:57.8200000-05:00|400117EC|000002D4|000007BC||ed2656eb41e0488f
267|2024-02-25T15:38:57.8200000-05:00|400117F2|80034E2B|000002CE|0000840D|00000BB8|00000000|00000002|00000000|00000000|db5a007be8d75a72
00|2024-02-25T15:38:57.0000000-05:00|0044|Whiskerwall Kupdi Koop|Our foe is formidable, kupo. But surely, they are no match for our king!|d050884aa1955980
00|2024-02-25T15:38:59.0000000-05:00|0B3A||You defeat Pukla Puki the Pomburner.|a7c2dca011a5f438
00|2024-02-25T15:38:59.0000000-05:00|0B3A||You defeat Pukna Pako the Tailturner.|fe7bf39ca9d497d9
267|2024-02-25T15:39:07.9700000-05:00|00000000|80034E2B|00002CC5|0000840E|00000BB8|00000000|00000002|00000000|00000000|f3036b6aa522f070
00|2024-02-25T15:39:07.0000000-05:00|0044|Mogglesguard|Hail to the king, kupo!|83d40e6cbf4ba9f8
266|2024-02-25T15:39:10.9950000-05:00|400117EC|000002D4|000007BE||dfc4f1c4da48b228
267|2024-02-25T15:39:20.0580000-05:00|40011882|80034E2B|000002D5|0000840B|00000BB8|00000000|00000002|00000000|00000000|333f9f2c330117fe
00|2024-02-25T15:39:19.0000000-05:00|0044|Good King Moggle Mog XII|You shall suffer for your transgressions against my subjects!|37d388a05cfd9490
267|2024-02-25T15:39:29.0850000-05:00|40011882|80034E2B|000002D5|0000840F|00000BB8|00000000|00000002|00000000|00000000|da55c1d2668e94f6
00|2024-02-25T15:39:28.0000000-05:00|0044|Good King Moggle Mog XII|And now our battle begins in earnest!|f509f5585fe160af
00|2024-02-25T15:39:35.0000000-05:00|0B3A||You defeat Good King Moggle Mog XII.|27005a8a9e93c5d
```

(There's a double pipe at the end of the `266` lines in this output. I fixed that bug but don't have time to re-run the content to get a fixed log output)