### PR TITLE
Add ActorMove and ActorSetPos lines

### DIFF
--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -31,6 +31,8 @@ namespace RainbowMage.OverlayPlugin
             container.Register(new LineBattleTalk2(container));
             container.Register(new LineCountdown(container));
             container.Register(new LineCountdownCancel(container));
+            container.Register(new LineActorMove(container));
+            container.Register(new LineActorSetPos(container));
         }
     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
@@ -19,7 +19,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         public const int structSize = 16;
 
         [FieldOffset(0x0)]
-        public ushort heading;
+        public ushort rotation;
 
         [FieldOffset(0x2)]
         public ushort unknown1;
@@ -36,12 +36,13 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         public string ToString(uint actorID, FFXIVRepository ffxiv)
         {
             return $"{actorID:X8}|" +
-                $"{ffxiv.ConvertHeading(heading):F4}|" +
+                $"{ffxiv.ConvertHeading(rotation):F4}|" +
                 $"{unknown1:X4}|" +
                 $"{unknown2:X4}|" +
                 $"{ffxiv.ConvertUInt16Coordinate(x):F4}|" +
-                $"{ffxiv.ConvertUInt16Coordinate(y):F4}|" +
-                $"{ffxiv.ConvertUInt16Coordinate(z):F4}";
+                // y and z are intentionally flipped to match other log lines
+                $"{ffxiv.ConvertUInt16Coordinate(z):F4}|" +
+                $"{ffxiv.ConvertUInt16Coordinate(y):F4}";
         }
     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using RainbowMage.OverlayPlugin.MemoryProcessors;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
+    internal unsafe struct ActorMove_v655
+    {
+        // 6.5.5 packet data (minus header):
+        // 1897 3004 3C00 B681 AA80 9F83 00000000
+        // AAAA BBBB CCCC DDDD EEEE FFFF GGGGGGGG
+        // 0x0  0x2  0x4  0x6  0x8  0xA  0xC
+        // Rot  Unk  Unk  X    Y    Z    Unk
+
+        // Have never seen data in 0xC, probably padding?
+
+        public const int structSize = 16;
+
+        [FieldOffset(0x0)]
+        public ushort heading;
+
+        [FieldOffset(0x2)]
+        public ushort unknown1;
+        [FieldOffset(0x4)]
+        public ushort unknown2;
+
+        [FieldOffset(0x6)]
+        public ushort x;
+        [FieldOffset(0x8)]
+        public ushort y;
+        [FieldOffset(0xA)]
+        public ushort z;
+
+        public string ToString(uint actorID, FFXIVRepository ffxiv)
+        {
+            return $"{actorID:X8}|" +
+                $"{ffxiv.ConvertHeading(heading):F4}|" +
+                $"{unknown1:X4}|" +
+                $"{unknown2:X4}|" +
+                $"{ffxiv.ConvertUInt16Coordinate(x):F4}|" +
+                $"{ffxiv.ConvertUInt16Coordinate(y):F4}|" +
+                $"{ffxiv.ConvertUInt16Coordinate(z):F4}";
+        }
+    }
+
+    public class LineActorMove
+    {
+        public const uint LogFileLineID = 270;
+        private ILogger logger;
+        private OverlayPluginLogLineConfig opcodeConfig;
+        private IOpcodeConfigEntry opcode = null;
+
+        private readonly int offsetHeaderActorID;
+        private readonly int offsetMessageType;
+        private readonly int offsetPacketData;
+
+        private readonly FFXIVRepository ffxiv;
+
+        private Func<string, DateTime, bool> logWriter;
+
+        public LineActorMove(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                offsetHeaderActorID = netHelper.GetOffset(msgHeaderType, "ActorID");
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                offsetPacketData = Marshal.SizeOf(msgHeaderType);
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "ActorMove",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            // Wait for network data to actually fetch opcode info from file and register log line
+            // This is because the FFXIV_ACT_Plugin's `GetGameVersion` method only returns valid data
+            // if the player is currently logged in/a network connection is active
+            if (opcode == null)
+            {
+                opcode = opcodeConfig["ActorMove"];
+                if (opcode == null)
+                {
+                    return;
+                }
+            }
+
+            if (message.Length < opcode.size + offsetPacketData)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
+                {
+                    uint actorID = *(uint*)&buffer[offsetHeaderActorID];
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                    ActorMove_v655 actorMovePacket = *(ActorMove_v655*)&buffer[offsetPacketData];
+                    logWriter(actorMovePacket.ToString(actorID, ffxiv), serverTime);
+
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
@@ -117,6 +117,13 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
                 {
                     uint actorID = *(uint*)&buffer[offsetHeaderActorID];
+
+                    // Only emit for non-player actors
+                    if (actorID < 0x40000000)
+                    {
+                        return;
+                    }
+
                     DateTime serverTime = ffxiv.EpochToDateTime(epoch);
                     ActorMove_v655 actorMovePacket = *(ActorMove_v655*)&buffer[offsetPacketData];
                     logWriter(actorMovePacket.ToString(actorID, ffxiv), serverTime);

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorSetPos.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorSetPos.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using RainbowMage.OverlayPlugin.MemoryProcessors;
+
+namespace RainbowMage.OverlayPlugin.NetworkProcessors
+{
+    [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
+    internal unsafe struct ActorSetPos_v655
+    {
+        // 6.5.5 packet data (minus header):
+        // 6AD3 0F  02  00000000 233E3BC1 00000000 D06AF840 00000000
+        // AAAA BB  CC  DDDDDDDD EEEEEEEE FFFFFFFF GGGGGGGG HHHHHHHH
+        // 0x0  0x2 0x3 0x4      0x8      0xC      0x10     0x14
+        // Rot  unk unk unk      X        Y        Z        unk
+
+        // Have never seen data in 0x4 or 0x14, probably just padding?
+
+        public const int structSize = 24;
+        [FieldOffset(0x0)]
+        public ushort rotation;
+
+        [FieldOffset(0x2)]
+        public byte unknown1;
+
+        [FieldOffset(0x3)]
+        public byte unknown2;
+
+        // Yes, these are actually floats, and not some janky ushort that needs converted through ConvertUInt16Coordinate
+        [FieldOffset(0x8)]
+        public float x;
+        [FieldOffset(0xC)]
+        public float y;
+        [FieldOffset(0x10)]
+        public float z;
+
+        public string ToString(uint actorID, FFXIVRepository ffxiv)
+        {
+            return $"{actorID:X8}|" +
+                $"{ffxiv.ConvertHeading(rotation):F4}|" +
+                $"{unknown1:X2}|" +
+                $"{unknown2:X2}|" +
+                $"{x:F4}|" +
+                // y and z are intentionally flipped to match other log lines
+                $"{z:F4}|" +
+                $"{y:F4}";
+        }
+    }
+
+    public class LineActorSetPos
+    {
+        public const uint LogFileLineID = 271;
+        private ILogger logger;
+        private OverlayPluginLogLineConfig opcodeConfig;
+        private IOpcodeConfigEntry opcode = null;
+
+        private readonly int offsetHeaderActorID;
+        private readonly int offsetMessageType;
+        private readonly int offsetPacketData;
+
+        private readonly FFXIVRepository ffxiv;
+
+        private Func<string, DateTime, bool> logWriter;
+
+        public LineActorSetPos(TinyIoCContainer container)
+        {
+            logger = container.Resolve<ILogger>();
+            ffxiv = container.Resolve<FFXIVRepository>();
+            var netHelper = container.Resolve<NetworkParser>();
+            if (!ffxiv.IsFFXIVPluginPresent())
+                return;
+            opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
+            try
+            {
+                var mach = Assembly.Load("Machina.FFXIV");
+                var msgHeaderType = mach.GetType("Machina.FFXIV.Headers.Server_MessageHeader");
+                offsetHeaderActorID = netHelper.GetOffset(msgHeaderType, "ActorID");
+                offsetMessageType = netHelper.GetOffset(msgHeaderType, "MessageType");
+                offsetPacketData = Marshal.SizeOf(msgHeaderType);
+                ffxiv.RegisterNetworkParser(MessageReceived);
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserNoFfxiv);
+            }
+            catch (Exception e)
+            {
+                logger.Log(LogLevel.Error, Resources.NetworkParserInitException, e);
+            }
+            var customLogLines = container.Resolve<FFXIVCustomLogLines>();
+            this.logWriter = customLogLines.RegisterCustomLogLine(new LogLineRegistryEntry()
+            {
+                Name = "ActorSetPos",
+                Source = "OverlayPlugin",
+                ID = LogFileLineID,
+                Version = 1,
+            });
+        }
+
+        private unsafe void MessageReceived(string id, long epoch, byte[] message)
+        {
+            // Wait for network data to actually fetch opcode info from file and register log line
+            // This is because the FFXIV_ACT_Plugin's `GetGameVersion` method only returns valid data
+            // if the player is currently logged in/a network connection is active
+            if (opcode == null)
+            {
+                opcode = opcodeConfig["ActorSetPos"];
+                if (opcode == null)
+                {
+                    return;
+                }
+            }
+
+            if (message.Length < opcode.size + offsetPacketData)
+                return;
+
+            fixed (byte* buffer = message)
+            {
+                if (*(ushort*)&buffer[offsetMessageType] == opcode.opcode)
+                {
+                    uint actorID = *(uint*)&buffer[offsetHeaderActorID];
+                    DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                    ActorSetPos_v655 actorSetPosPacket = *(ActorSetPos_v655*)&buffer[offsetPacketData];
+                    logWriter(actorSetPosPacket.ToString(actorID, ffxiv), serverTime);
+
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -48,6 +48,14 @@
         "CountdownCancel": {
             "opcode": 322,
             "size": 40
+        },
+        "ActorMove": {
+            "opcode": 845,
+            "size": 16
+        },
+        "ActorSetPos": {
+            "opcode": 174,
+            "size": 24
         }
     },
     // KR region

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -105,7 +105,21 @@
         "Comment": "CountdownCancel packet data"
     },
     {
-        "StartID": 270,
+        "ID": 270,
+        "Name": "ActorMove",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "ActorMove packet data"
+    },
+    {
+        "ID": 271,
+        "Name": "ActorSetPos",
+        "Source": "OverlayPlugin",
+        "Version": 1,
+        "Comment": "ActorSetPos packet data"
+    },
+    {
+        "StartID": 272,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
Ready for initial review. We should do some sort of rate limiting on `ActorMove`, as it can get very, very spammy during e.g. large FATEs. I'm open to thoughts here, my initial instinct was to limit to 1 line per actor per 500ms. Maybe only rate limit players.

`ActorSetPos` doesn't need any rate limiting, it's pretty rare.

Here's some example lines from doing an unsynced Ifrit (Hard):

```
270|2024-02-26T16:00:17.2200000-05:00|400120DD|-1.5882|0000|0050|14.6489|0.0000|0.0000|d1ddc8ce9596e013
270|2024-02-26T16:00:17.5340000-05:00|400120DD|-1.5962|0000|0050|13.6418|0.0000|-0.0305|935b038d8e441a4e
270|2024-02-26T16:00:21.1960000-05:00|400120DD|-1.2989|0000|0050|13.3061|0.0000|0.0916|a5ebe3da4c3244ce
270|2024-02-26T16:00:21.7340000-05:00|400120DD|-1.1570|0000|0050|13.3061|0.0000|0.0916|6fca70cfc14460dc
270|2024-02-26T16:00:22.0490000-05:00|400120DD|-0.8149|0000|0050|13.3061|0.0000|0.0916|f2895265899c114d
270|2024-02-26T16:00:22.3620000-05:00|400120DD|-0.3392|0000|0050|13.3061|0.0000|0.0916|0dffe177c0a46e8f
270|2024-02-26T16:00:22.6770000-05:00|400120DD|0.2639|0000|0050|13.3061|0.0000|0.0916|9e73801447836eb8
270|2024-02-26T16:00:22.9890000-05:00|400120DD|0.9809|0000|0050|13.3061|0.0000|0.0916|0377f9e74808526a
270|2024-02-26T16:00:23.3040000-05:00|400120DD|1.7533|0000|0050|13.3061|0.0000|0.0916|c563be4c53716c35
270|2024-02-26T16:00:27.8670000-05:00|400120DD|1.8108|0000|0050|13.3061|0.0000|0.0916|e6661a58015a6613
270|2024-02-26T16:00:37.9920000-05:00|400120DD|1.9228|0000|0050|13.3061|0.0000|0.0916|a653fa03b5829893
270|2024-02-26T16:00:38.7470000-05:00|400120DD|1.7821|0000|0050|13.3061|0.0000|0.0916|acfc6fa656313a96
271|2024-02-26T16:00:44.1860000-05:00|400120DD|-0.0001|00|00|0.0000|0.0000|0.0000|38b8bf79cc582848
270|2024-02-26T16:00:51.3290000-05:00|400120DD|0.5654|0000|0050|0.0000|0.0000|0.0000|625607a0bfb7f8e8
270|2024-02-26T16:00:51.6410000-05:00|400120DD|1.6439|0000|0050|0.0000|0.0000|0.0000|6597121488ccc350
270|2024-02-26T16:00:52.4020000-05:00|400120DD|1.6439|0000|0050|0.7019|0.0000|-0.0610|a2ed38d11c2f2322
270|2024-02-26T16:00:52.7140000-05:00|400120DD|1.6439|0000|0050|0.7935|0.0000|-0.0610|70f4efe3627bece0
270|2024-02-26T16:01:00.3900000-05:00|400120DD|1.6424|0000|0050|2.2279|0.0000|-0.1526|38299ce63410a20d
270|2024-02-26T16:01:00.7030000-05:00|400120DD|1.6424|0000|0050|4.6999|0.0000|-0.3357|ca3606edb8fb0b4a
270|2024-02-26T16:01:01.0160000-05:00|400120DD|1.6424|0000|0050|7.2024|0.0305|-0.5188|39125dcde1d1ae34
270|2024-02-26T16:01:01.3290000-05:00|400120DD|1.6424|0000|0050|9.7049|0.0305|-0.7019|26be0571a20e7a96
270|2024-02-26T16:01:01.6410000-05:00|400120DD|1.6424|0000|0050|10.7730|0.0305|-0.7630|d9c8d32d65c4caca
270|2024-02-26T16:01:02.3060000-05:00|400120D9|-0.3687|0002|0014|36.0118|0.0000|0.0000|21f52c98304d46b6
270|2024-02-26T16:01:02.6180000-05:00|400120D9|-1.6446|0002|0014|36.0118|0.0000|0.0000|eb74fc8f11cdf3ed
270|2024-02-26T16:01:04.3130000-05:00|400120D8|-0.5613|0002|0014|36.0118|0.0000|0.0000|c2b5b533dbfbcd0f
270|2024-02-26T16:01:04.6270000-05:00|400120D8|-1.6446|0002|0014|36.0118|0.0000|0.0000|c97d905c0720fef9
270|2024-02-26T16:01:06.3260000-05:00|400120D7|-0.5613|0002|0014|36.0118|0.0000|0.0000|c58538612be2b7bd
270|2024-02-26T16:01:06.6380000-05:00|400120D7|-1.6446|0002|0014|36.0118|0.0000|0.0000|7fa68b5691e97576
271|2024-02-26T16:01:11.1070000-05:00|400120DC|-0.0001|00|00|0.0000|-21.0000|0.0000|0f7302b94d2d2a0b
271|2024-02-26T16:01:11.1070000-05:00|400120DB|-0.7855|00|00|14.8500|-14.8500|0.0000|00e1f19f8218c657
271|2024-02-26T16:01:11.1070000-05:00|400120DA|-1.5705|00|00|21.0000|0.0000|0.0000|7050f3bcc9cd2e5c
270|2024-02-26T16:01:21.5870000-05:00|400120DD|1.6871|0000|0050|10.7730|0.0305|-0.7630|f7ef7ad84b077ce3
270|2024-02-26T16:01:21.8990000-05:00|400120DD|-2.3477|0000|0050|10.7730|0.0305|-0.7630|20e98f4198c6ea98
270|2024-02-26T16:01:22.2110000-05:00|400120DD|-1.5688|0000|0050|10.7730|0.0305|-0.7630|2499e30f13fb73f2
270|2024-02-26T16:01:22.5240000-05:00|400120DD|-1.5425|0000|0050|10.7730|0.0305|-0.7630|0675c211cab48c10
271|2024-02-26T16:01:23.1910000-05:00|400120DD|-1.4631|00|00|11.4747|-1.2412|0.0456|fd4cef80fe3d3771
```

Of particular note are these three lines, which correspond to the Ifrit clones spawning at the edge of the arena for dashes:

```
271|2024-02-26T16:01:11.1070000-05:00|400120DC|-0.0001|00|00|0.0000|-21.0000|0.0000|0f7302b94d2d2a0b
271|2024-02-26T16:01:11.1070000-05:00|400120DB|-0.7855|00|00|14.8500|-14.8500|0.0000|00e1f19f8218c657
271|2024-02-26T16:01:11.1070000-05:00|400120DA|-1.5705|00|00|21.0000|0.0000|0.0000|7050f3bcc9cd2e5c
```