### PR TITLE
Update reserved log line logic

### DIFF
--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -52,7 +52,11 @@ namespace RainbowMage.OverlayPlugin
                         {
                             if (registry.ContainsKey(ID))
                             {
-                                logger.Log(LogLevel.Error, $"Reserved log line entry already registered ({ID}).");
+                                var entry = registry[ID];
+                                if (entry.Source != Source)
+                                {
+                                    logger.Log(LogLevel.Error, $"Reserved log line entry already registered ({ID}).");
+                                }
                                 continue;
                             }
                             registry[ID] = new LogLineRegistryEntry()
@@ -61,6 +65,7 @@ namespace RainbowMage.OverlayPlugin
                                 Name = Name,
                                 Source = Source,
                                 Version = Version,
+                                Range = true,
                             };
                         }
                     }
@@ -70,8 +75,12 @@ namespace RainbowMage.OverlayPlugin
                         var Name = reservedDataEntry.Name;
                         if (registry.ContainsKey(ID))
                         {
-                            logger.Log(LogLevel.Error, $"Reserved log line entry already registered ({ID}).");
-                            continue;
+                            var entry = registry[ID];
+                            if (entry.Source != reservedDataEntry.Source || entry.Range == false)
+                            {
+                                logger.Log(LogLevel.Error, $"Reserved log line entry already registered ({ID}).");
+                                continue;
+                            }
                         }
                         if (Name == null)
                         {
@@ -87,6 +96,7 @@ namespace RainbowMage.OverlayPlugin
                             Name = Name,
                             Source = Source,
                             Version = Version,
+                            Range = false,
                         };
                     }
                 }
@@ -148,6 +158,7 @@ namespace RainbowMage.OverlayPlugin
         string Name { get; }
         string Source { get; }
         uint Version { get; }
+        bool Range { get; }
     }
 
     public class LogLineRegistryEntry : ILogLineRegistryEntry
@@ -156,6 +167,7 @@ namespace RainbowMage.OverlayPlugin
         public string Name { get; set; }
         public string Source { get; set; }
         public uint Version { get; set; }
+        public bool Range { get; set; }
 
         public override string ToString()
         {
@@ -171,7 +183,7 @@ namespace RainbowMage.OverlayPlugin
 
             var otherEntry = (ILogLineRegistryEntry)obj;
 
-            return ID == otherEntry.ID && Source == otherEntry.Source;
+            return ID == otherEntry.ID && Source == otherEntry.Source && Range == otherEntry.Range;
         }
 
         public override int GetHashCode()

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -133,7 +133,7 @@
         "Comment": "Extra info from ActorControl packets"
     },
     {
-        "StartID": 274,
+        "StartID": 256,
         "EndID": 512,
         "Source": "OverlayPlugin",
         "Version": 0,


### PR DESCRIPTION
This PR allows reserved log line definitions that define a range to encompass the entire range.

This should prevent some merge conflicts going forward if we have multiple PRs in-flight for new log lines.

The logic changes are as follows:

1. When reserving a range of log lines, if we've already reserved an ID and the source is the same, skip the registration silently
2. When reserving an individual log line, if we've already reserved it as part of a range of lines and the source is the same, overwrite the existing reservation entry