### PR TITLE
Fix build annotation warning for tech support screen mode

### DIFF
--- a/OverlayPlugin.Core/ClipboardTechSupport.cs
+++ b/OverlayPlugin.Core/ClipboardTechSupport.cs
@@ -192,7 +192,7 @@ namespace RainbowMage.OverlayPlugin
                 screenMode = "(not running)";
                 return;
             }
-            
+
             IntPtr mainWindowHandle = process.MainWindowHandle;
             if (mainWindowHandle == IntPtr.Zero)
             {

--- a/OverlayPlugin.Core/ClipboardTechSupport.cs
+++ b/OverlayPlugin.Core/ClipboardTechSupport.cs
@@ -27,7 +27,7 @@ namespace RainbowMage.OverlayPlugin
         private const ulong WS_POPUP = 0x80000000L;
         private const ulong WS_CAPTION = 0x00C00000L;
 
-        private static string screenMode = null;
+        private static string screenMode = "(unknown)";
 
         [DllImport("user32.dll")]
         static extern ulong GetWindowLongPtr(IntPtr hWnd, int nIndex);
@@ -110,7 +110,7 @@ namespace RainbowMage.OverlayPlugin
                 string gameVersion = repository.GetGameVersion();
                 settings.Add(new List<string> { "Game Version", gameVersion != "" ? gameVersion : "(not running)" });
 
-                if (screenMode == null)
+                if (screenMode == "(unknown)")
                 {
                     repository.RegisterProcessChangedHandler(GetFFXIVScreenMode);
                 }


### PR DESCRIPTION
Fixes the `'FFXIVRepository.GetCurrentFFXIVProcess()' is obsolete` build warning annotation that keeps showing up..