### PR TITLE
Add region to opcode map

### DIFF
--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -8,10 +8,9 @@ using RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings;
 using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
 using RainbowMage.OverlayPlugin.NetworkProcessors;
 using RainbowMage.OverlayPlugin.Updater;
-
 using MachinaRegion = System.String;
-using OpcodeVersion = System.String;
 using OpcodeName = System.String;
+using OpcodeVersion = System.String;
 
 namespace RainbowMage.OverlayPlugin
 {

--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -9,9 +9,14 @@ using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
 using RainbowMage.OverlayPlugin.NetworkProcessors;
 using RainbowMage.OverlayPlugin.Updater;
 
+using MachinaRegion = System.String;
+using OpcodeVersion = System.String;
+using OpcodeName = System.String;
+
 namespace RainbowMage.OverlayPlugin
 {
-    using Opcodes = Dictionary<string, Dictionary<string, OpcodeConfigEntry>>;
+
+    using Opcodes = Dictionary<MachinaRegion, Dictionary<OpcodeVersion, Dictionary<OpcodeName, OpcodeConfigEntry>>>;
 
     class OverlayPluginLogLines
     {
@@ -97,8 +102,7 @@ namespace RainbowMage.OverlayPlugin
 
             try
             {
-                // TODO: is there a better way to go JToken -> Dictionary here without a string intermediary?
-                opcodesConfig = JsonConvert.DeserializeObject<Opcodes>(config.CachedOpcodeFile.ToString());
+                opcodesConfig = config.CachedOpcodeFile.ToObject<Opcodes>();
             }
             catch (Exception ex)
             {
@@ -178,21 +182,29 @@ namespace RainbowMage.OverlayPlugin
             if (opcodes == null)
                 return null;
 
-            if (opcodes.ContainsKey(version))
+            var machinaRegion = repository.GetMachinaRegion().ToString();
+
+            if (opcodes.TryGetValue(machinaRegion, out var regionOpcodes))
             {
-                var versionOpcodes = opcodes[version];
-                if (versionOpcodes.ContainsKey(name))
+                if (regionOpcodes.TryGetValue(version, out var versionOpcodes))
                 {
-                    return versionOpcodes[name];
+                    if (versionOpcodes.TryGetValue(name, out var opcode))
+                    {
+                        return opcode;
+                    }
+                    else
+                    {
+                        LogException($"No {opcodeType} opcode for game region {machinaRegion}, version {version}, opcode name {name}");
+                    }
                 }
                 else
                 {
-                    LogException($"No {opcodeType} opcode for game version {version}, opcode name {name}");
+                    LogException($"No {opcodeType} opcodes for game region {machinaRegion}, version {version}");
                 }
             }
             else
             {
-                LogException($"No {opcodeType} opcodes for game version {version}");
+                LogException($"No {opcodeType} opcodes for game region {machinaRegion}");
             }
 
             return null;

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -2,124 +2,127 @@
 // Older version opcodes can be retrieved from git history for this file
 // For more information, see comments on https://github.com/OverlayPlugin/OverlayPlugin/issues/235
 {
-    // CN region
-    "2024.03.28.0000.0000": {
-        // Version: 6.51
-        "MapEffect": {
-            "opcode": 199,
-            "size": 11
-        },
-        "CEDirector": {
-            "opcode": 577,
-            "size": 16
-        },
-        "RSVData": {
-            "opcode": 819,
-            "size": 1080
-        },
-        "NpcYell": {
-            "opcode": 502,
-            "size": 32
-        },
-        "BattleTalk2": {
-            "opcode": 222,
-            "size": 40
-        },
-        "Countdown": {
-            "opcode": 779,
-            "size": 48
-        },
-        "CountdownCancel": {
-            "opcode": 797,
-            "size": 40
-        },
-        "ActorMove": {
-            "opcode": 477,
-            "size": 16
-        },
-        "ActorSetPos": {
-            "opcode": 469,
-            "size": 24
+    "Chinese": {
+        "2024.03.28.0000.0000": {
+            // Version: 6.51
+            "MapEffect": {
+                "opcode": 199,
+                "size": 11
+            },
+            "CEDirector": {
+                "opcode": 577,
+                "size": 16
+            },
+            "RSVData": {
+                "opcode": 819,
+                "size": 1080
+            },
+            "NpcYell": {
+                "opcode": 502,
+                "size": 32
+            },
+            "BattleTalk2": {
+                "opcode": 222,
+                "size": 40
+            },
+            "Countdown": {
+                "opcode": 779,
+                "size": 48
+            },
+            "CountdownCancel": {
+                "opcode": 797,
+                "size": 40
+            },
+            "ActorMove": {
+                "opcode": 477,
+                "size": 16
+            },
+            "ActorSetPos": {
+                "opcode": 469,
+                "size": 24
+            }
         }
     },
-    // Global region
-    "2024.03.27.0000.0000": {
-        // Version: 6.58 Hotfix
-        "MapEffect": {
-            "opcode": 280,
-            "size": 11
-        },
-        "CEDirector": {
-            "opcode": 899,
-            "size": 16
-        },
-        "RSVData": {
-            "opcode": 820,
-            "size": 1080
-        },
-        "NpcYell": {
-            "opcode": 726,
-            "size": 32
-        },
-        "BattleTalk2": {
-            "opcode": 464,
-            "size": 40
-        },
-        "Countdown": {
-            "opcode": 192,
-            "size": 48
-        },
-        "CountdownCancel": {
-            "opcode": 863,
-            "size": 40
-        },
-        "ActorMove": {
-            "opcode": 949,
-            "size": 16
-        },
-        "ActorSetPos": {
-            "opcode": 401,
-            "size": 24
+    "Global": {
+        "2024.03.27.0000.0000": {
+            // Version: 6.58 Hotfix
+            "MapEffect": {
+                "opcode": 280,
+                "size": 11
+            },
+            "CEDirector": {
+                "opcode": 899,
+                "size": 16
+            },
+            "RSVData": {
+                "opcode": 820,
+                "size": 1080
+            },
+            "NpcYell": {
+                "opcode": 726,
+                "size": 32
+            },
+            "BattleTalk2": {
+                "opcode": 464,
+                "size": 40
+            },
+            "Countdown": {
+                "opcode": 192,
+                "size": 48
+            },
+            "CountdownCancel": {
+                "opcode": 863,
+                "size": 40
+            },
+            "ActorMove": {
+                "opcode": 949,
+                "size": 16
+            },
+            "ActorSetPos": {
+                "opcode": 401,
+                "size": 24
+            }
         }
     },
-    // KR region
-    "2024.03.28.0000.0000":{
-        // Version: 6.5
-        "MapEffect": {
-            "opcode": 205,
-            "size": 11
-        },
-        "CEDirector": {
-            "opcode": 915,
-            "size": 16
-        },
-        "RSVData": {
-            "opcode": 463,
-            "size": 1080
-        },
-        "NpcYell": {
-            "opcode": 136,
-            "size": 32
-        },
-        "BattleTalk2": {
-            "opcode": 674,
-            "size": 40
-        },
-        "Countdown": {
-            "opcode": 216,
-            "size": 48
-        },
-        "CountdownCancel": {
-            "opcode": 320,
-            "size": 40
-        },
-        "ActorMove": {
-            "opcode": 679,
-            "size": 16
-        },
-        "ActorSetPos": {
-            "opcode": 392,
-            "size": 24
+    "Korean": {
+        "2024.03.28.0000.0000": {
+            // Version: 6.5
+            "MapEffect": {
+                "opcode": 205,
+                "size": 11
+            },
+            "CEDirector": {
+                "opcode": 915,
+                "size": 16
+            },
+            "RSVData": {
+                "opcode": 463,
+                "size": 1080
+            },
+            "NpcYell": {
+                "opcode": 136,
+                "size": 32
+            },
+            "BattleTalk2": {
+                "opcode": 674,
+                "size": 40
+            },
+            "Countdown": {
+                "opcode": 216,
+                "size": 48
+            },
+            "CountdownCancel": {
+                "opcode": 320,
+                "size": 40
+            },
+            "ActorMove": {
+                "opcode": 679,
+                "size": 16
+            },
+            "ActorSetPos": {
+                "opcode": 392,
+                "size": 24
+            }
         }
     }
 }


### PR DESCRIPTION
Also:
Fix mapping cached file opcodes to object
Clean up loading opcode values from dictionary

Fixes #335 

This is the more disruptive but more "correct" fix for the issue. I don't have time to write out the other option and test it tonight.