### PR TITLE
Add new categories for `LineActorControlExtra`

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
@@ -3,7 +3,7 @@
     public enum Server_ActorControlCategory : ushort
     {
         // Need a better name for this before merging!
-        MaybePlayVfxSlot = 0x0031, // 49
+        VfxUnknown49 = 0x0031, // 49
         SetAnimationState = 0x003E, // 62
         PlayActionTimeline = 0x0197, // 407
         EObjAnimation = 0x19D, // 413

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
@@ -4,6 +4,7 @@
     {
         VfxUnknown49 = 0x0031, // 49
         SetAnimationState = 0x003E, // 62
+        SetModelState = 0x003F, // 63
         PlayActionTimeline = 0x0197, // 407
         EObjAnimation = 0x19D, // 413
         StatusUpdate = 0x01F8, // 504

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
@@ -2,7 +2,6 @@
 {
     public enum Server_ActorControlCategory : ushort
     {
-        // Need a better name for this before merging!
         VfxUnknown49 = 0x0031, // 49
         SetAnimationState = 0x003E, // 62
         PlayActionTimeline = 0x0197, // 407

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlCommon.cs
@@ -2,7 +2,11 @@
 {
     public enum Server_ActorControlCategory : ushort
     {
+        // Need a better name for this before merging!
+        MaybePlayVfxSlot = 0x0031, // 49
         SetAnimationState = 0x003E, // 62
+        PlayActionTimeline = 0x0197, // 407
+        EObjAnimation = 0x19D, // 413
         StatusUpdate = 0x01F8, // 504
         // Name is a guess
         DisplayLogMessage = 0x020F, // 527

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
@@ -21,7 +21,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         public static readonly Server_ActorControlCategory[] AllowedActorControlCategories = {
             Server_ActorControlCategory.SetAnimationState,
             Server_ActorControlCategory.DisplayPublicContentTextMessage,
-            Server_ActorControlCategory.MaybePlayVfxSlot,
+            Server_ActorControlCategory.VfxUnknown49,
             Server_ActorControlCategory.PlayActionTimeline,
             Server_ActorControlCategory.EObjAnimation,
         };

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
@@ -20,7 +20,10 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         // Any category defined in this array will be allowed as an emitted line
         public static readonly Server_ActorControlCategory[] AllowedActorControlCategories = {
             Server_ActorControlCategory.SetAnimationState,
-            Server_ActorControlCategory.DisplayPublicContentTextMessage
+            Server_ActorControlCategory.DisplayPublicContentTextMessage,
+            Server_ActorControlCategory.MaybePlayVfxSlot,
+            Server_ActorControlCategory.PlayActionTimeline,
+            Server_ActorControlCategory.EObjAnimation,
         };
 
         internal class ActorControlExtraPacket : MachinaPacketWrapper

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
@@ -22,6 +22,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             Server_ActorControlCategory.SetAnimationState,
             Server_ActorControlCategory.DisplayPublicContentTextMessage,
             Server_ActorControlCategory.VfxUnknown49,
+            Server_ActorControlCategory.SetModelState,
             Server_ActorControlCategory.PlayActionTimeline,
             Server_ActorControlCategory.EObjAnimation,
         };


### PR DESCRIPTION
Closes #339 

Need a better name for 0x31 before merging.

Statistics going back to 2024-01-08 show:

```
$ grep -hPo 'ActorControl(?:|Self|Target)\|[^|]*\|(?:49|407|413|PlayActionTimeline|EObjAnimation)\|' Network_*.log | cut -d'|' -f1,3 | sort | uniq -c
   1666 ActorControl|49
  11894 ActorControl|EObjAnimation
  30481 ActorControl|PlayActionTimeline
$ grep -hPv '^409[67]\|' Network_*.log | wc -l
43078428
```

That's an additional `(30481+11894+1666)/43078428 = 0.00102` 0.1% increase in log line count by adding these categories. 