### PR TITLE
Refactor plugin loading and UI code to fix cross-thread issues

### DIFF
--- a/OverlayPlugin.Common/ILogger.cs
+++ b/OverlayPlugin.Common/ILogger.cs
@@ -12,6 +12,7 @@ namespace RainbowMage.OverlayPlugin
         event EventHandler<IReadOnlyCollection<LogEntry>> OnLog;
         void Log(LogLevel level, string message);
         void Log(LogLevel level, string format, params object[] args);
+        void RefreshLogs();
     }
 
     public class LogEntry

--- a/OverlayPlugin.Common/ILogger.cs
+++ b/OverlayPlugin.Common/ILogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,35 +9,57 @@ namespace RainbowMage.OverlayPlugin
 {
     public interface ILogger
     {
+        event EventHandler<IReadOnlyCollection<LogEntry>> OnLog;
         void Log(LogLevel level, string message);
         void Log(LogLevel level, string format, params object[] args);
-        void RegisterListener(Action<LogEntry> listener);
-        void ClearListener();
     }
 
     public class LogEntry
     {
+        public long ID { get; set; }
         public string Message { get; set; }
         public LogLevel Level { get; set; }
         public DateTime Time { get; set; }
 
-        public LogEntry(LogLevel level, DateTime time, string message)
+        public LogEntry(long id, LogLevel level, DateTime time, string message)
         {
-            this.Message = message;
-            this.Level = level;
-            this.Time = time;
+            ID = id;
+            Message = message;
+            Level = level;
+            Time = time;
         }
-    }
 
-    public class LogEventArgs : EventArgs
-    {
-        public string Message { get; private set; }
-        public LogLevel Level { get; private set; }
-        public LogEventArgs(LogLevel level, string message)
+        public string ToRtfString()
         {
-            this.Message = message;
-            this.Level = level;
+            var cf = 1 + ((int)Level);
+            if (Level == LogLevel.Info) cf = 0;
+            if (Level == LogLevel.Warning || Level == LogLevel.Error) --cf;
+
+            if (Level == LogLevel.Error)
+            {
+                return $"{{\\v{ID}}}\\cf{cf}[{Time}] {Level}: {EscapeRtf(Message)}\\cf0\\\n";
+            }
+            else
+            {
+                return $"{{\\v{ID}}}\\cf0[{Time}] \\cf{cf}{Level}\\cf0: {EscapeRtf(Message)}\\\n";
+            }
         }
+
+        private static string EscapeRtf(string msg)
+        {
+            return msg
+                .Replace("\\", "\\\\")
+                .Replace("{", "\\{")
+                .Replace("}", "\\}")
+                .Replace("\n", "\\\n");
+        }
+
+        public const string DefaultColorTable = @"{\colortbl"
+                    + @";" // Default
+                    + @"\red128\green128\blue128;" // Trace
+                    + @"\red192\green192\blue192;" // Debug
+                    + @"\red255\green165\blue0;" // Warning
+                    + @"\red255\green0\blue0;}"; // Error
     }
 
     public enum LogLevel

--- a/OverlayPlugin.Common/IPluginConfig.cs
+++ b/OverlayPlugin.Common/IPluginConfig.cs
@@ -22,6 +22,8 @@ namespace RainbowMage.OverlayPlugin
         DateTime LastUpdateCheck { get; set; }
         bool IsFirstLaunch { get; set; }
         Dictionary<string, JObject> EventSourceConfigs { get; set; }
+        
+        bool ColorblindMode { get; set; }
 
         void MarkDirty();
     }

--- a/OverlayPlugin.Common/ITinyIoCAutoRegister.cs
+++ b/OverlayPlugin.Common/ITinyIoCAutoRegister.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RainbowMage.OverlayPlugin
+{
+    /// <summary>
+    /// Use this interface to specify that this class should be registered early in the
+    /// before the initialization process
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoRegisterPreInit<T> { }
+
+    /// <summary>
+    /// Use this interface to specify that this class should be registered early in the
+    /// plugin initialization process, before actually initializing anything else
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoRegisterBeforeInit<T> { }
+
+    /// <summary>
+    /// Use this interface to specify that this class should be registered during the
+    /// plugin initialization process
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoRegisterDuringInit<T> { }
+
+    /// <summary>
+    /// Use this interface to specify that this class should be registered after all other plugin
+    /// types and GUI elements are initialized
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoRegisterAfterInit<T> { }
+
+    /// <summary>
+    /// Use this interface to specify that this class should be registered and immediately constructed
+    /// before the plugin initialization process
+    /// 
+    /// Note that for auto constructed types, construction is done as a second pass after
+    /// IoC entries are registered for the stage
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoConstructPreInit<T> : ITinyIoCAutoRegisterPreInit<T> { }
+
+    /// <summary>
+    /// Use this interface to specify that this class should be registered and immediately constructed
+    /// early in the plugin initialization process, before actually initializing anything else
+    /// 
+    /// Note that for auto constructed types, construction is done as a second pass after
+    /// IoC entries are registered for the stage
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoConstructBeforeInit<T> : ITinyIoCAutoRegisterPreInit<T> { }
+
+    /// <summary>
+    /// Use this interface to specify that this class should be registered and immediately constructed
+    /// during the plugin initialization process
+    /// 
+    /// Note that for auto constructed types, construction is done as a second pass after
+    /// IoC entries are registered for the stage
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoConstructDuringInit<T> : ITinyIoCAutoRegisterDuringInit<T> { }
+
+    /// <summary>
+    /// Use this interface to specify that this class should be registered and immediately constructed
+    /// after all other plugin types and GUI elements are initialized
+    /// 
+    /// Note that for auto constructed types, construction is done as a second pass after
+    /// IoC entries are registered for the stage
+    /// 
+    /// TinyIoC Auto Register and Auto Construct helpers cannot be used in the HtmlRenderer assembly
+    /// due to its reliance on CefSharp
+    /// </summary>
+    /// <typeparam name="T">The type that should be registered for IoC resolution</typeparam>
+    public interface ITinyIoCAutoConstructAfterInit<T> : ITinyIoCAutoRegisterAfterInit<T> { }
+
+    public static class TinyIoCAutoHelper
+    {
+        private static List<Assembly> Assemblies = new List<Assembly>();
+
+        public static void RegisterAssemblies(List<Assembly> assemblies)
+        {
+            Assemblies.AddRange(assemblies.Where(a => !Assemblies.Contains(a)));
+        }
+
+        public static void AutoRegisterPreInit()
+        {
+            AutoRegister(typeof(ITinyIoCAutoRegisterPreInit<>));
+        }
+
+        public static void AutoRegisterBeforeInit()
+        {
+            AutoRegister(typeof(ITinyIoCAutoRegisterBeforeInit<>));
+        }
+
+        public static void AutoRegisterDuringInit()
+        {
+            AutoRegister(typeof(ITinyIoCAutoRegisterDuringInit<>));
+        }
+
+        public static void AutoRegisterAfterInit()
+        {
+            AutoRegister(typeof(ITinyIoCAutoRegisterAfterInit<>));
+        }
+
+        public static void AutoRegister(Type t)
+        {
+            var container = TinyIoCContainer.Current;
+            foreach (var asm in Assemblies)
+            {
+                var types = asm.SafeGetTypes().Where(type => type.IsClass && type.GetInterfaces().Any(type2 => type2.IsGenericType && type2.GetGenericTypeDefinition() == t));
+
+                foreach (var type in types)
+                {
+                    var interfaces = type.GetInterfaces().Where(type2 => type2.IsGenericType && type2.GetGenericTypeDefinition() == t).ToList();
+                    var registerType = interfaces[0].GenericTypeArguments[0];
+                    var registerImplementation = type;
+                    if (!container.CanResolve(registerType))
+                    {
+                        TinyIoCContainer.Current.Register(registerType, registerImplementation).AsSingleton();
+                    }
+                }
+            }
+        }
+        public static void AutoConstructPreInit()
+        {
+            AutoConstruct(typeof(ITinyIoCAutoConstructPreInit<>));
+        }
+
+
+        public static void AutoConstructBeforeInit()
+        {
+            AutoConstruct(typeof(ITinyIoCAutoConstructBeforeInit<>));
+        }
+
+        public static void AutoConstructDuringInit()
+        {
+            AutoConstruct(typeof(ITinyIoCAutoConstructDuringInit<>));
+        }
+
+        public static void AutoConstructAfterInit()
+        {
+            AutoConstruct(typeof(ITinyIoCAutoConstructAfterInit<>));
+        }
+
+        public static void AutoConstruct(Type t)
+        {
+            foreach (var asm in Assemblies)
+            {
+                var types = asm.SafeGetTypes().Where(type => type.IsClass && type.GetInterfaces().Any(type2 => type2.IsGenericType && type2.GetGenericTypeDefinition() == t));
+
+                foreach (var type in types)
+                {
+                    // We know that the type is already registered, so we just need to resolve it and let TinyIoC handle the construction itself
+                    var interfaces = type.GetInterfaces().Where(type2 => type2.IsGenericType && type2.GetGenericTypeDefinition() == t).ToList();
+                    var registerType = interfaces[0].GenericTypeArguments[0];
+                    TinyIoCContainer.Current.Resolve(registerType);
+                }
+            }
+        }
+    }
+}

--- a/OverlayPlugin.Common/Registry.cs
+++ b/OverlayPlugin.Common/Registry.cs
@@ -4,7 +4,7 @@ using Advanced_Combat_Tracker;
 
 namespace RainbowMage.OverlayPlugin
 {
-    public class Registry
+    public class Registry : ITinyIoCAutoConstructPreInit<Registry>
     {
         private TinyIoCContainer _container;
         private List<Type> _overlays;

--- a/OverlayPlugin.Core/Controls/ControlPanel.Designer.cs
+++ b/OverlayPlugin.Core/Controls/ControlPanel.Designer.cs
@@ -26,7 +26,7 @@ namespace RainbowMage.OverlayPlugin
             this.buttonRemoveOverlay = new System.Windows.Forms.Button();
             this.checkBoxFollowLog = new System.Windows.Forms.CheckBox();
             this.buttonClearLog = new System.Windows.Forms.Button();
-            this.logBox = new System.Windows.Forms.TextBox();
+            this.logBox = new System.Windows.Forms.RichTextBox();
             this.tabPageMain = new System.Windows.Forms.TabPage();
             this.label_ListEmpty = new System.Windows.Forms.Label();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
@@ -171,7 +171,7 @@ namespace RainbowMage.OverlayPlugin
         private TableLayoutPanel tableLayoutPanel0;
         private FlowLayoutPanel flowLayoutPanel;
         private Label label_ListEmpty;
-        private TextBox logBox;
+        private RichTextBox logBox;
         private CheckBox checkBoxFollowLog;
         private Button buttonClearLog;
         private Button buttonRename;

--- a/OverlayPlugin.Core/Controls/ControlPanel.cs
+++ b/OverlayPlugin.Core/Controls/ControlPanel.cs
@@ -3,13 +3,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
-using System.Globalization;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using Advanced_Combat_Tracker;
 
 namespace RainbowMage.OverlayPlugin
 {
@@ -118,7 +113,12 @@ namespace RainbowMage.OverlayPlugin
                     logBox.Text = "";
                 }
 
-                var newText = @"{\rtf1\ansi" + LogEntry.DefaultColorTable;
+                var newText = @"{\rtf1\ansi";
+
+                if (_config.ColorblindMode == false)
+                {
+                    newText += LogEntry.DefaultColorTable;
+                }
 
                 foreach (var entry in e)
                 {

--- a/OverlayPlugin.Core/Controls/ControlPanel.cs
+++ b/OverlayPlugin.Core/Controls/ControlPanel.cs
@@ -39,7 +39,7 @@ namespace RainbowMage.OverlayPlugin
             { "SpellTimerOverlay", Resources.MapOverlaySpellTimer },
         };
 
-        public ControlPanel(TinyIoCContainer container)
+        public ControlPanel()
         {
             InitializeComponent();
             tableLayoutPanel0.PerformLayout();
@@ -47,11 +47,11 @@ namespace RainbowMage.OverlayPlugin
             // important if we never make it that far.
             splitContainer1.SplitterDistance = 5;
 
-            _container = container;
-            _logger = container.Resolve<ILogger>();
-            _pluginMain = container.Resolve<PluginMain>();
-            _config = container.Resolve<IPluginConfig>();
-            _registry = container.Resolve<Registry>();
+            _container = TinyIoCContainer.Current;
+            _logger = _container.Resolve<ILogger>();
+            _pluginMain = _container.Resolve<PluginMain>();
+            _config = _container.Resolve<IPluginConfig>();
+            _registry = _container.Resolve<Registry>();
 
             this.checkBoxFollowLog.Checked = _config.FollowLatestLog;
 
@@ -60,14 +60,14 @@ namespace RainbowMage.OverlayPlugin
                 Name = Resources.GeneralTab,
                 Text = "",
             };
-            _generalTab.Controls.Add(new GeneralConfigTab(container));
+            _generalTab.Controls.Add(new GeneralConfigTab(_container));
 
             _eventTab = new ConfigTabPage
             {
                 Name = Resources.EventConfigTab,
                 Text = "",
             };
-            _eventTab.Controls.Add(new EventSources.BuiltinEventConfigPanel(container));
+            _eventTab.Controls.Add(new EventSources.BuiltinEventConfigPanel(_container));
 
             logBox.Text = Resources.LogNotConnectedError;
             _logger.RegisterListener(AddLogEntry);

--- a/OverlayPlugin.Core/Controls/GeneralConfigTab.Designer.cs
+++ b/OverlayPlugin.Core/Controls/GeneralConfigTab.Designer.cs
@@ -34,6 +34,7 @@
             this.btnUpdateCheck = new System.Windows.Forms.Button();
             this.cbHideOverlaysWhenNotActive = new System.Windows.Forms.CheckBox();
             this.cbHideOverlaysDuringCutscene = new System.Windows.Forms.CheckBox();
+            this.cbColorblindMode = new System.Windows.Forms.CheckBox();
             this.lblGithub = new System.Windows.Forms.Label();
             this.lnkGithubRepo = new System.Windows.Forms.LinkLabel();
             this.lblNewUserWelcome = new System.Windows.Forms.Label();
@@ -73,6 +74,12 @@
             resources.ApplyResources(this.cbHideOverlaysDuringCutscene, "cbHideOverlaysDuringCutscene");
             this.cbHideOverlaysDuringCutscene.Name = "cbHideOverlaysDuringCutscene";
             this.cbHideOverlaysDuringCutscene.UseVisualStyleBackColor = true;
+            // 
+            // cbColorblindMode
+            // 
+            resources.ApplyResources(this.cbColorblindMode, "cbColorblindMode");
+            this.cbColorblindMode.Name = "cbColorblindMode";
+            this.cbColorblindMode.UseVisualStyleBackColor = true;
             // 
             // lblGithub
             // 
@@ -136,6 +143,7 @@
             this.Controls.Add(this.cbUpdateCheck);
             this.Controls.Add(this.cbHideOverlaysDuringCutscene);
             this.Controls.Add(this.cbHideOverlaysWhenNotActive);
+            this.Controls.Add(this.cbColorblindMode);
             this.Name = "GeneralConfigTab";
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -148,12 +156,13 @@
         private System.Windows.Forms.Button btnUpdateCheck;
         private System.Windows.Forms.CheckBox cbHideOverlaysWhenNotActive;
         private System.Windows.Forms.CheckBox cbHideOverlaysDuringCutscene;
+        private System.Windows.Forms.CheckBox cbColorblindMode;
         private System.Windows.Forms.Label lblGithub;
         private System.Windows.Forms.LinkLabel lnkGithubRepo;
         private System.Windows.Forms.Label lblNewUserWelcome;
         private System.Windows.Forms.Label lblReadMe;
         private System.Windows.Forms.Button btnCactbotUpdate;
-    private System.Windows.Forms.Button btnClipboardTechSupport;
+        private System.Windows.Forms.Button btnClipboardTechSupport;
         private System.Windows.Forms.Button btnClearCEFCache;
     }
 }

--- a/OverlayPlugin.Core/Controls/GeneralConfigTab.cs
+++ b/OverlayPlugin.Core/Controls/GeneralConfigTab.cs
@@ -1,12 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -38,12 +32,16 @@ namespace RainbowMage.OverlayPlugin
             cbUpdateCheck.Checked = config.UpdateCheck;
             cbHideOverlaysWhenNotActive.Checked = config.HideOverlaysWhenNotActive;
             cbHideOverlaysDuringCutscene.Checked = config.HideOverlayDuringCutscene;
+            
+            cbColorblindMode.Checked = config.ColorblindMode;
 
             // Attach the event handlers only *after* loading the configuration because we'd otherwise trigger them ourselves.
             cbErrorReports.CheckedChanged += CbErrorReports_CheckedChanged;
             cbUpdateCheck.CheckedChanged += CbUpdateCheck_CheckedChanged;
             cbHideOverlaysWhenNotActive.CheckedChanged += cbHideOverlaysWhenNotActive_CheckedChanged;
             cbHideOverlaysDuringCutscene.CheckedChanged += cbHideOverlaysDuringCutscene_CheckedChanged;
+            
+            cbColorblindMode.CheckedChanged += CbColorblindMode_CheckedChanged;
         }
 
         public void SetReadmeVisible(bool visible)
@@ -116,6 +114,14 @@ namespace RainbowMage.OverlayPlugin
         {
             config.HideOverlayDuringCutscene = cbHideOverlaysDuringCutscene.Checked;
             container.Resolve<OverlayHider>().UpdateOverlays();
+        }
+
+        private void CbColorblindMode_CheckedChanged(object sender, EventArgs e)
+        {
+            config.ColorblindMode = cbColorblindMode.Checked;
+
+            // Trigger an OnLog event so that the log panel can update its display
+            logger.RefreshLogs();
         }
 
         private void lnkGithubRepo_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/OverlayPlugin.Core/Controls/GeneralConfigTab.cs
+++ b/OverlayPlugin.Core/Controls/GeneralConfigTab.cs
@@ -70,7 +70,7 @@ namespace RainbowMage.OverlayPlugin
                 Thread.Sleep(500);
 
                 if (lastClick != now) return;
-                Updater.Updater.PerformUpdateIfNecessary(pluginDirectory, container, true, timePassed < 500);
+                Updater.Updater.PerformUpdateIfNecessary(pluginDirectory, true, timePassed < 500);
             });
         }
 

--- a/OverlayPlugin.Core/Controls/GeneralConfigTab.resx
+++ b/OverlayPlugin.Core/Controls/GeneralConfigTab.resx
@@ -184,7 +184,7 @@
     <value>NoControl</value>
   </data>
   <data name="btnUpdateCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 116</value>
+    <value>20, 142</value>
   </data>
   <data name="btnUpdateCheck.Size" type="System.Drawing.Size, System.Drawing">
     <value>201, 23</value>
@@ -267,11 +267,38 @@
   <data name="&gt;&gt;cbHideOverlaysDuringCutscene.ZOrder" xml:space="preserve">
     <value>10</value>
   </data>
+  <data name="cbColorblindMode.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbColorblindMode.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 106</value>
+  </data>
+  <data name="cbColorblindMode.Size" type="System.Drawing.Size, System.Drawing">
+    <value>102, 17</value>
+  </data>
+  <data name="cbColorblindMode.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="cbColorblindMode.Text" xml:space="preserve">
+    <value>Colorblind Mode</value>
+  </data>
+  <data name="&gt;&gt;cbColorblindMode.Name" xml:space="preserve">
+    <value>cbColorblindMode</value>
+  </data>
+  <data name="&gt;&gt;cbColorblindMode.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbColorblindMode.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cbColorblindMode.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
   <data name="lblGithub.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblGithub.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 186</value>
+    <value>17, 212</value>
   </data>
   <data name="lblGithub.Size" type="System.Drawing.Size, System.Drawing">
     <value>72, 13</value>
@@ -298,7 +325,7 @@
     <value>True</value>
   </data>
   <data name="lnkGithubRepo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>95, 186</value>
+    <value>95, 212</value>
   </data>
   <data name="lnkGithubRepo.Size" type="System.Drawing.Size, System.Drawing">
     <value>235, 13</value>
@@ -322,7 +349,7 @@
     <value>5</value>
   </data>
   <data name="lblNewUserWelcome.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 256</value>
+    <value>17, 276</value>
   </data>
   <data name="lblNewUserWelcome.Size" type="System.Drawing.Size, System.Drawing">
     <value>501, 119</value>
@@ -355,7 +382,7 @@ Please try using the presets instead of manually setting the URL since this can 
     <value>Microsoft Sans Serif, 11pt, style=Bold</value>
   </data>
   <data name="lblReadMe.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 229</value>
+    <value>17, 249</value>
   </data>
   <data name="lblReadMe.Size" type="System.Drawing.Size, System.Drawing">
     <value>100, 18</value>
@@ -379,7 +406,7 @@ Please try using the presets instead of manually setting the URL since this can 
     <value>3</value>
   </data>
   <data name="btnCactbotUpdate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>241, 116</value>
+    <value>241, 142</value>
   </data>
   <data name="btnCactbotUpdate.Size" type="System.Drawing.Size, System.Drawing">
     <value>185, 23</value>
@@ -406,7 +433,7 @@ Please try using the presets instead of manually setting the URL since this can 
     <value>NoControl</value>
   </data>
   <data name="btnClipboardTechSupport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>20, 145</value>
+    <value>20, 171</value>
   </data>
   <data name="btnClipboardTechSupport.Size" type="System.Drawing.Size, System.Drawing">
     <value>201, 23</value>
@@ -433,7 +460,7 @@ Please try using the presets instead of manually setting the URL since this can 
     <value>NoControl</value>
   </data>
   <data name="btnClearCEFCache.Location" type="System.Drawing.Point, System.Drawing">
-    <value>241, 145</value>
+    <value>241, 171</value>
   </data>
   <data name="btnClearCEFCache.Size" type="System.Drawing.Size, System.Drawing">
     <value>185, 23</value>

--- a/OverlayPlugin.Core/Controls/LogPanel.Designer.cs
+++ b/OverlayPlugin.Core/Controls/LogPanel.Designer.cs
@@ -28,7 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.logBox = new System.Windows.Forms.TextBox();
+            this.logBox = new System.Windows.Forms.RichTextBox();
             this.SuspendLayout();
             // 
             // logBox
@@ -39,7 +39,7 @@
             this.logBox.Multiline = true;
             this.logBox.Name = "logBox";
             this.logBox.ReadOnly = true;
-            this.logBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.logBox.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
             this.logBox.Size = new System.Drawing.Size(519, 372);
             this.logBox.TabIndex = 0;
             // 
@@ -57,6 +57,6 @@
 
         #endregion
 
-        private System.Windows.Forms.TextBox logBox;
+        private System.Windows.Forms.RichTextBox logBox;
     }
 }

--- a/OverlayPlugin.Core/Controls/LogPanel.cs
+++ b/OverlayPlugin.Core/Controls/LogPanel.cs
@@ -16,9 +16,22 @@ namespace RainbowMage.OverlayPlugin.Controls
         {
             InitializeComponent();
 
-            container.Resolve<ILogger>().RegisterListener((entry) =>
-            {
-                logBox.AppendText($"[{entry.Time}] {entry.Level}: {entry.Message}" + Environment.NewLine);
+            container.Resolve<ILogger>().OnLog += HandleOnLog;
+        }
+
+        private void HandleOnLog(object sender, IReadOnlyCollection<LogEntry> e)
+        {
+            PluginMain.InvokeOnUIThread(() => {
+                var newText = @"{\rtf1\ansi";
+
+                foreach (var entry in e)
+                {
+                    newText += entry.ToRtfString();
+                }
+
+                newText += "}";
+
+                logBox.Rtf = newText;
             });
         }
     }

--- a/OverlayPlugin.Core/Controls/WSConfigPanel.cs
+++ b/OverlayPlugin.Core/Controls/WSConfigPanel.cs
@@ -47,9 +47,11 @@ namespace RainbowMage.OverlayPlugin
             Error
         };
 
-        public WSConfigPanel(TinyIoCContainer container)
+        public WSConfigPanel()
         {
             InitializeComponent();
+
+            var container = TinyIoCContainer.Current;
 
             _config = container.Resolve<IPluginConfig>();
             _server = container.Resolve<WSServer>();

--- a/OverlayPlugin.Core/EventDispatcher.cs
+++ b/OverlayPlugin.Core/EventDispatcher.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 
 namespace RainbowMage.OverlayPlugin
 {
-    class EventDispatcher
+    class EventDispatcher : ITinyIoCAutoConstructPreInit<EventDispatcher>
     {
         ILogger _logger;
         Dictionary<string, Func<JObject, JToken>> handlers;

--- a/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/EnmityEventSource.cs
@@ -123,10 +123,10 @@ namespace RainbowMage.OverlayPlugin.EventSources
                 Task.Run(async delegate
                 {
                     await Task.Delay(endEncounterOutOfCombatDelayMs, endEncounterToken.Token);
-                    ActGlobals.oFormActMain.Invoke((Action)(() =>
+                    await PluginMain.InvokeOnUIThread(() =>
                     {
                         ActGlobals.oFormActMain.EndCombat(true);
-                    }));
+                    });
                 });
             }
             // If combat starts again, cancel any outstanding tasks to stop the ACT encounter.

--- a/OverlayPlugin.Core/EventSources/FFXIVOptionalEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVOptionalEventSource.cs
@@ -48,10 +48,10 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         private void StopACTCombat()
         {
-            ActGlobals.oFormActMain.Invoke((Action)(() =>
+            PluginMain.InvokeOnUIThread(() =>
             {
                 ActGlobals.oFormActMain.EndCombat(true);
-            }));
+            });
         }
 
         private void LogLineHandler(bool isImport, LogLineEventArgs args)

--- a/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/MiniParseEventSource.cs
@@ -153,10 +153,10 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
         private void StopACTCombat()
         {
-            ActGlobals.oFormActMain.Invoke((Action)(() =>
+            PluginMain.InvokeOnUIThread(() =>
             {
                 ActGlobals.oFormActMain.EndCombat(true);
-            }));
+            });
         }
 
         public override Control CreateConfigControl()

--- a/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVCustomLogLines.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json;
 
 namespace RainbowMage.OverlayPlugin
 {
-    public class FFXIVCustomLogLines
+    public class FFXIVCustomLogLines : ITinyIoCAutoConstructDuringInit<FFXIVCustomLogLines>
     {
         private ILogger logger;
         private FFXIVRepository repository;

--- a/OverlayPlugin.Core/Integration/FFXIVRepository.cs
+++ b/OverlayPlugin.Core/Integration/FFXIVRepository.cs
@@ -71,7 +71,7 @@ namespace RainbowMage.OverlayPlugin
         Korean = 3
     }
 
-    public class FFXIVRepository
+    public class FFXIVRepository : ITinyIoCAutoConstructDuringInit<FFXIVRepository>
     {
         private readonly ILogger logger;
         private IDataRepository repository;

--- a/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
+++ b/OverlayPlugin.Core/Integration/OverlayPluginLogLines.cs
@@ -3,10 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
-using RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings;
-using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
-using RainbowMage.OverlayPlugin.NetworkProcessors;
 using RainbowMage.OverlayPlugin.Updater;
 using MachinaRegion = System.String;
 using OpcodeName = System.String;
@@ -17,29 +13,16 @@ namespace RainbowMage.OverlayPlugin
 
     using Opcodes = Dictionary<MachinaRegion, Dictionary<OpcodeVersion, Dictionary<OpcodeName, OpcodeConfigEntry>>>;
 
-    class OverlayPluginLogLines
+    interface IOverlayPluginLogLine<T> { }
+
+    class OverlayPluginLogLines : ITinyIoCAutoConstructDuringInit<OverlayPluginLogLines>
     {
         public OverlayPluginLogLines(TinyIoCContainer container)
         {
             container.Register(new OverlayPluginLogLineConfig(container));
-            container.Register(new LineMapEffect(container));
-            container.Register(new LineFateControl(container));
-            container.Register(new LineCEDirector(container));
-            container.Register(new LineInCombat(container));
-            container.Register(new LineCombatant(container));
-            container.Register(new LineRSV(container));
-            container.Register(new LineActorCastExtra(container));
-            container.Register(new LineAbilityExtra(container));
-            container.Register(new LineContentFinderSettings(container));
-            container.Register(new LineNpcYell(container));
-            container.Register(new LineBattleTalk2(container));
-            container.Register(new LineCountdown(container));
-            container.Register(new LineCountdownCancel(container));
-            container.Register(new LineActorMove(container));
-            container.Register(new LineActorSetPos(container));
-            container.Register(new LineSpawnNpcExtra(container));
-            container.Register(new LineActorControlExtra(container));
-            container.Register(new LineActorControlSelfExtra(container));
+
+            TinyIoCAutoHelper.AutoRegister(typeof(IOverlayPluginLogLine<>));
+            TinyIoCAutoHelper.AutoConstruct(typeof(IOverlayPluginLogLine<>));
         }
     }
 

--- a/OverlayPlugin.Core/Integration/TriggIntegration.cs
+++ b/OverlayPlugin.Core/Integration/TriggIntegration.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json.Linq;
 
 namespace RainbowMage.OverlayPlugin
 {
-    class TriggIntegration
+    class TriggIntegration : ITinyIoCAutoConstructDuringInit<TriggIntegration>
     {
         private PluginMain _plugin;
         public delegate void CustomCallbackDelegate(object o, string param);

--- a/OverlayPlugin.Core/JSApi/OverlayApi.cs
+++ b/OverlayPlugin.Core/JSApi/OverlayApi.cs
@@ -52,10 +52,10 @@ namespace RainbowMage.OverlayPlugin
 
         public void endEncounter()
         {
-            ActGlobals.oFormActMain.Invoke((Action)(() =>
+            PluginMain.InvokeOnUIThread(() =>
             {
                 ActGlobals.oFormActMain.EndCombat(true);
-            }));
+            });
         }
 
         public void makeScreenshot()
@@ -79,7 +79,10 @@ namespace RainbowMage.OverlayPlugin
 
         public void setAcceptFocus(bool accept)
         {
-            receiver.SetAcceptFocus(accept);
+            PluginMain.InvokeOnUIThread(() =>
+            {
+                receiver.SetAcceptFocus(accept);
+            });
         }
 
         // Also handles (un)subscription to make switching between this and WS easier.

--- a/OverlayPlugin.Core/KeyboardHook.cs
+++ b/OverlayPlugin.Core/KeyboardHook.cs
@@ -5,7 +5,7 @@ using System.Windows.Forms;
 
 namespace RainbowMage.OverlayPlugin
 {
-    public sealed class KeyboardHook : NativeWindow, IDisposable
+    public sealed class KeyboardHook : NativeWindow, IDisposable, ITinyIoCAutoConstructPreInit<KeyboardHook>
     {
         private Dictionary<int, HotKeyInfo> _hotkeys = new Dictionary<int, HotKeyInfo>();
         private ILogger _logger;

--- a/OverlayPlugin.Core/Logger.cs
+++ b/OverlayPlugin.Core/Logger.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin
     /// <summary>
     /// ログを記録する機能を提供するクラス。
     /// </summary>
-    public class Logger : ILogger
+    public class Logger : ILogger, ITinyIoCAutoConstructPreInit<ILogger>, ITinyIoCAutoConstructPreInit<Logger>
     {
         /// <summary>
         /// 記録されたログを取得します。

--- a/OverlayPlugin.Core/Logger.cs
+++ b/OverlayPlugin.Core/Logger.cs
@@ -49,7 +49,7 @@ namespace RainbowMage.OverlayPlugin
                 Logs.RemoveAt(0);
             }
 
-            OnLog?.Invoke(this, new List<LogEntry>(Logs).AsReadOnly());
+            RefreshLogs();
         }
 
         /// <summary>
@@ -61,6 +61,11 @@ namespace RainbowMage.OverlayPlugin
         public void Log(LogLevel level, string format, params object[] args)
         {
             Log(level, string.Format(format, args));
+        }
+
+        public void RefreshLogs()
+        {
+            OnLog?.Invoke(this, new List<LogEntry>(Logs));
         }
     }
 }

--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemory60.cs
@@ -4,7 +4,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
 {
     interface IAggroMemory60 : IAggroMemory { }
 
-    class AggroMemory60 : AggroMemory, IAggroMemory60
+    class AggroMemory60 : AggroMemory, IAggroMemory60, ITinyIoCAutoRegisterAfterInit<IAggroMemory60>
     {
         private const int aggroEnmityOffset = -2336;
 

--- a/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Aggro/AggroMemoryManager.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
         List<AggroEntry> GetAggroList(List<Combatant.Combatant> combatantList);
     }
 
-    public class AggroMemoryManager : IAggroMemory
+    public class AggroMemoryManager : IAggroMemory, ITinyIoCAutoRegisterDuringInit<IAggroMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -18,7 +18,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Aggro
         public AggroMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IAggroMemory60, AggroMemory60>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemory62.cs
@@ -10,7 +10,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
     using AtkStage = global::FFXIVClientStructs.Global.FFXIV.Component.GUI.AtkStage;
     interface IAtkStageMemory62 : IAtkStageMemory { }
 
-    class AtkStageMemory62 : AtkStageMemory, IAtkStageMemory62
+    class AtkStageMemory62 : AtkStageMemory, IAtkStageMemory62, ITinyIoCAutoRegisterAfterInit<IAtkStageMemory62>
     {
         private static long GetAtkStageSingletonAddress(TinyIoCContainer container)
         {

--- a/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/AtkStage/AtkStageMemoryManager.cs
@@ -10,7 +10,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
         dynamic GetAddon(string name);
     }
 
-    class AtkStageMemoryManager : IAtkStageMemory
+    class AtkStageMemoryManager : IAtkStageMemory, ITinyIoCAutoRegisterDuringInit<IAtkStageMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -19,7 +19,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage
         public AtkStageMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IAtkStageMemory62, AtkStageMemory62>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory63.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
     interface ICombatantMemory63 : ICombatantMemory { }
 
-    class CombatantMemory63 : CombatantMemory, ICombatantMemory63
+    class CombatantMemory63 : CombatantMemory, ICombatantMemory63, ITinyIoCAutoRegisterAfterInit<ICombatantMemory63>
     {
         private const string charmapSignature = "488B5720B8000000E0483BD00F84????????488D0D";
 

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory64.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory64.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
     interface ICombatantMemory64 : ICombatantMemory { }
 
-    class CombatantMemory64 : CombatantMemory, ICombatantMemory64
+    class CombatantMemory64 : CombatantMemory, ICombatantMemory64, ITinyIoCAutoRegisterAfterInit<ICombatantMemory64>
     {
         private const string charmapSignature = "488B5720B8000000E0483BD00F84????????488D0D";
 

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory65.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory65.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
     interface ICombatantMemory65 : ICombatantMemory { }
 
-    class CombatantMemory65 : CombatantMemory, ICombatantMemory65
+    class CombatantMemory65 : CombatantMemory, ICombatantMemory65, ITinyIoCAutoRegisterAfterInit<ICombatantMemory65>
     {
         private const string charmapSignature = "488B5720B8000000E0483BD00F84????????488D0D";
 

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
@@ -12,7 +12,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         List<Combatant> GetCombatantList();
     }
 
-    public class CombatantMemoryManager : ICombatantMemory
+    public class CombatantMemoryManager : ICombatantMemory, ITinyIoCAutoRegisterDuringInit<ICombatantMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -21,9 +21,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         public CombatantMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<ICombatantMemory63, CombatantMemory63>();
-            container.Register<ICombatantMemory64, CombatantMemory64>();
-            container.Register<ICombatantMemory65, CombatantMemory65>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -12,7 +12,7 @@ using RainbowMage.OverlayPlugin.NetworkProcessors;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
-    public class LineCombatant : IDisposable
+    public class LineCombatant : IDisposable, IOverlayPluginLogLine<LineCombatant>
     {
         public const uint LogFileLineID = 261;
         private ILogger logger;

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings651.cs
@@ -4,7 +4,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 {
     interface IContentFinderSettingsMemory651 : IContentFinderSettingsMemory { }
 
-    class ContentFinderSettingsMemory651 : ContentFinderSettingsMemory, IContentFinderSettingsMemory651
+    class ContentFinderSettingsMemory651 : ContentFinderSettingsMemory, IContentFinderSettingsMemory651, ITinyIoCAutoRegisterAfterInit<IContentFinderSettingsMemory651>
     {
         // FUN_140985ee0:140985fae
         private const string settingsSignature = "0FB63D????????EB??488B0D????????BA????????4883C1??E8????????8378????410F97C6";

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
@@ -23,7 +23,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         ContentFinderSettings GetContentFinderSettings();
     }
 
-    class ContentFinderSettingsMemoryManager : IContentFinderSettingsMemory
+    class ContentFinderSettingsMemoryManager : IContentFinderSettingsMemory, ITinyIoCAutoRegisterDuringInit<IContentFinderSettingsMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -32,7 +32,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         public ContentFinderSettingsMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IContentFinderSettingsMemory651, ContentFinderSettingsMemory651>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/LineContentFinderSettings.cs
@@ -3,7 +3,7 @@ using Advanced_Combat_Tracker;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
 {
-    class LineContentFinderSettings
+    class LineContentFinderSettings : IOverlayPluginLogLine<LineContentFinderSettings>
     {
         public const uint LogFileLineID = 265;
         private readonly FFXIVRepository ffxiv;

--- a/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemory60.cs
@@ -4,7 +4,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
 {
     interface IEnmityMemory60 : IEnmityMemory { }
 
-    class EnmityMemory60 : EnmityMemory, IEnmityMemory60
+    class EnmityMemory60 : EnmityMemory, IEnmityMemory60, ITinyIoCAutoRegisterAfterInit<IEnmityMemory60>
     {
         public const string enmitySignature = "83f9ff7412448b048e8bd3488d0d";
         private const int enmitySignatureOffset = -2608;

--- a/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Enmity/EnmityMemoryManager.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
         List<EnmityEntry> GetEnmityEntryList(List<Combatant.Combatant> combatantList);
     }
 
-    public class EnmityMemoryManager : IEnmityMemory
+    public class EnmityMemoryManager : IEnmityMemory, ITinyIoCAutoRegisterDuringInit<IEnmityMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -18,7 +18,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Enmity
         public EnmityMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IEnmityMemory60, EnmityMemory60>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory60.cs
@@ -5,7 +5,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
 {
     interface IEnmityHudMemory60 : IEnmityHudMemory { }
 
-    class EnmityHudMemory60 : EnmityHudMemory, IEnmityHudMemory60
+    class EnmityHudMemory60 : EnmityHudMemory, IEnmityHudMemory60, ITinyIoCAutoRegisterAfterInit<IEnmityHudMemory60>
     {
         private const string enmityHudSignature = "48895C246048897C2470488B3D";
         private static readonly int[] enmityHudPointerPath = new int[] { 0x30, 0x58, 0x98, 0x20 };

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory62.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemory62.cs
@@ -5,7 +5,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
 {
     interface IEnmityHudMemory62 : IEnmityHudMemory { }
 
-    class EnmityHudMemory62 : EnmityHudMemory, IEnmityHudMemory62
+    class EnmityHudMemory62 : EnmityHudMemory, IEnmityHudMemory62, ITinyIoCAutoRegisterAfterInit<IEnmityHudMemory62>
     {
         private const string enmityHudSignature = "48895C246048897C2470488B3D";
         private static readonly int[] enmityHudPointerPath = new int[] { 0x30, 0x58, 0xA8, 0x20 };

--- a/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/EnmityHud/EnmityHudMemoryManager.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
         List<EnmityHudEntry> GetEnmityHudEntries();
     }
 
-    public class EnmityHudMemoryManager : IEnmityHudMemory
+    public class EnmityHudMemoryManager : IEnmityHudMemory, ITinyIoCAutoRegisterDuringInit<IEnmityHudMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -18,8 +18,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud
         public EnmityHudMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IEnmityHudMemory60, EnmityHudMemory60>();
-            container.Register<IEnmityHudMemory62, EnmityHudMemory62>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/Data.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVClientStructs/Data.cs
@@ -12,7 +12,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs
         Global
     }
 
-    public class Data
+    public class Data : ITinyIoCAutoConstructDuringInit<Data>
     {
         private readonly ILogger logger;
         private readonly string yamlFilePath;

--- a/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/FFXIVMemory.cs
@@ -13,7 +13,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors
         bool IsValid();
     }
 
-    public class FFXIVMemory
+    public class FFXIVMemory : ITinyIoCAutoConstructDuringInit<FFXIVMemory>
     {
         private event EventHandler<Process> OnProcessChange;
 

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemory61.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemory61.cs
@@ -4,7 +4,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
 {
     interface IInCombatMemory61 : IInCombatMemory { }
 
-    class InCombatMemory61 : InCombatMemory, IInCombatMemory61
+    class InCombatMemory61 : InCombatMemory, IInCombatMemory61, ITinyIoCAutoRegisterAfterInit<IInCombatMemory61>
     {
         private const string inCombatSignature = "803D????????000F95C04883C428";
         private const int inCombatSignatureOffset = -12;

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/InCombatMemoryManager.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
         bool GetInCombat();
     }
 
-    class InCombatMemoryManager : IInCombatMemory
+    class InCombatMemoryManager : IInCombatMemory, ITinyIoCAutoRegisterDuringInit<IInCombatMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -18,7 +18,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
         public InCombatMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IInCombatMemory61, InCombatMemory61>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/InCombat/LineInCombat.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/InCombat/LineInCombat.cs
@@ -7,7 +7,7 @@ using static RainbowMage.OverlayPlugin.EventSources.EnmityEventSource;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.InCombat
 {
-    public class LineInCombat
+    public class LineInCombat : IOverlayPluginLogLine<LineInCombat>
     {
         public const uint LogFileLineID = 260;
         private ILogger logger;

--- a/OverlayPlugin.Core/MemoryProcessors/JobGauge/JobGauge655.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/JobGauge/JobGauge655.cs
@@ -5,7 +5,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.JobGauge
 {
     interface IJobGaugeMemory655 : IJobGaugeMemory { }
 
-    partial class JobGaugeMemory655 : JobGaugeMemory, IJobGaugeMemory655
+    partial class JobGaugeMemory655 : JobGaugeMemory, IJobGaugeMemory655, ITinyIoCAutoRegisterAfterInit<IJobGaugeMemory655>
     {
         private static string jobDataSignature = "488B3D????????33ED";
         private static int jobDataSignatureOffset = -6;

--- a/OverlayPlugin.Core/MemoryProcessors/JobGauge/JobGaugeMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/JobGauge/JobGaugeMemoryManager.cs
@@ -72,7 +72,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.JobGauge
         IJobGauge GetJobGauge();
     }
 
-    class JobGaugeMemoryManager : IJobGaugeMemory
+    class JobGaugeMemoryManager : IJobGaugeMemory, ITinyIoCAutoRegisterDuringInit<IJobGaugeMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -82,7 +82,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.JobGauge
         public JobGaugeMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IJobGaugeMemory655, JobGaugeMemory655>();
             repository = container.Resolve<FFXIVRepository>();
             logger = container.Resolve<ILogger>();
 

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory64.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
 {
     interface IPartyMemory64 : IPartyMemory { }
 
-    public class PartyMemory64 : PartyMemory, IPartyMemory64
+    public class PartyMemory64 : PartyMemory, IPartyMemory64, ITinyIoCAutoRegisterAfterInit<IPartyMemory64>
     {
         // Due to lack of multi-version support in FFXIVClientStructs, we need to duplicate these structures here per-version
         // We use FFXIVClientStructs versions of the structs because they have more required details than FFXIV_ACT_Plugin's struct definitions

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory65.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemory65.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
 {
     interface IPartyMemory65 : IPartyMemory { }
 
-    public class PartyMemory65 : PartyMemory, IPartyMemory65
+    public class PartyMemory65 : PartyMemory, IPartyMemory65, ITinyIoCAutoRegisterAfterInit<IPartyMemory65>
     {
         // Due to lack of multi-version support in FFXIVClientStructs, we need to duplicate these structures here per-version
         // We use FFXIVClientStructs versions of the structs because they have more required details than FFXIV_ACT_Plugin's struct definitions

--- a/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Party/PartyMemoryManager.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         PartyListsStruct GetPartyLists();
     }
 
-    class PartyMemoryManager : IPartyMemory
+    class PartyMemoryManager : IPartyMemory, ITinyIoCAutoRegisterDuringInit<IPartyMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -18,8 +18,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Party
         public PartyMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<IPartyMemory64, PartyMemory64>();
-            container.Register<IPartyMemory65, PartyMemory65>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory60.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory60.cs
@@ -4,7 +4,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
 {
     interface ITargetMemory60 : ITargetMemory { }
 
-    class TargetMemory60 : TargetMemory, ITargetMemory60
+    class TargetMemory60 : TargetMemory, ITargetMemory60, ITinyIoCAutoRegisterAfterInit<ITargetMemory60>
     {
         private const string targetSignature = "83E901740832C04883C4205BC3488D0D";
 

--- a/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory63.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemory63.cs
@@ -4,7 +4,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
 {
     interface ITargetMemory63 : ITargetMemory { }
 
-    class TargetMemory63 : TargetMemory, ITargetMemory63
+    class TargetMemory63 : TargetMemory, ITargetMemory63, ITinyIoCAutoRegisterAfterInit<ITargetMemory63>
     {
         private const string targetSignature = "483BC3750832C04883C4205BC3488D0D";
 

--- a/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Target/TargetMemoryManager.cs
@@ -13,7 +13,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
         Combatant.Combatant GetHoverCombatant();
     }
 
-    class TargetMemoryManager : ITargetMemory
+    class TargetMemoryManager : ITargetMemory, ITinyIoCAutoRegisterDuringInit<ITargetMemory>
     {
         private readonly TinyIoCContainer container;
         private readonly FFXIVRepository repository;
@@ -22,8 +22,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Target
         public TargetMemoryManager(TinyIoCContainer container)
         {
             this.container = container;
-            container.Register<ITargetMemory63, TargetMemory63>();
-            container.Register<ITargetMemory60, TargetMemory60>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();

--- a/OverlayPlugin.Core/NativeMethods.cs
+++ b/OverlayPlugin.Core/NativeMethods.cs
@@ -10,11 +10,13 @@ namespace RainbowMage.OverlayPlugin
     /// <summary>
     /// ネイティブ関数を提供します。
     /// </summary>
-    class NativeMethods
+    class NativeMethods : IDisposable, ITinyIoCAutoConstructPreInit<NativeMethods>
     {
         private WinEventDelegate dele = null;
         private IntPtr foregroundHookHandle;
         private IntPtr minimizeEndHookHandle;
+
+        private bool disposedValue;
 
         public NativeMethods(TinyIoCContainer container)
         {
@@ -32,11 +34,33 @@ namespace RainbowMage.OverlayPlugin
 
         ~NativeMethods()
         {
-            if (foregroundHookHandle != IntPtr.Zero)
-                UnhookWinEvent(foregroundHookHandle);
+            Dispose(disposing: false);
+        }
 
-            if (minimizeEndHookHandle != IntPtr.Zero)
-                UnhookWinEvent(minimizeEndHookHandle);
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    dele = null;
+                }
+
+                if (foregroundHookHandle != IntPtr.Zero)
+                    UnhookWinEvent(foregroundHookHandle);
+
+                if (minimizeEndHookHandle != IntPtr.Zero)
+                    UnhookWinEvent(minimizeEndHookHandle);
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
 
         delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -9,7 +9,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     /**
      * Class for position/angle info from ActionEffect (i.e. line 21/22).
      */
-    class LineAbilityExtra : LineBaseSubMachina<LineAbilityExtra.AbilityExtraPacket<LineAbilityExtra.Server_ActionEffect1_Extra>>
+    class LineAbilityExtra : LineBaseSubMachina<LineAbilityExtra.AbilityExtraPacket<LineAbilityExtra.Server_ActionEffect1_Extra>>, IOverlayPluginLogLine<LineAbilityExtra>
     {
         public const uint LogFileLineID = 264;
         public const string LogLineName = "AbilityExtra";

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorCastExtra.cs
@@ -4,7 +4,7 @@ using RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
-    class LineActorCastExtra : LineBaseSubMachina<LineActorCastExtra.ActorCastExtraPacket>
+    class LineActorCastExtra : LineBaseSubMachina<LineActorCastExtra.ActorCastExtraPacket>, IOverlayPluginLogLine<LineActorCastExtra>
     {
         public const uint LogFileLineID = 263;
         public const string LogLineName = "ActorCastExtra";

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlExtra.cs
@@ -11,7 +11,7 @@ using RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
-    class LineActorControlExtra : LineBaseSubMachina<LineActorControlExtra.ActorControlExtraPacket>
+    class LineActorControlExtra : LineBaseSubMachina<LineActorControlExtra.ActorControlExtraPacket>, IOverlayPluginLogLine<LineActorControlExtra>
     {
         public const uint LogFileLineID = 273;
         public const string LogLineName = "ActorControlExtra";

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorControlSelfExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorControlSelfExtra.cs
@@ -22,7 +22,7 @@ using RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
-    class LineActorControlSelfExtra : LineBaseSubMachina<LineActorControlSelfExtra.ActorControlSelfExtraPacket>
+    class LineActorControlSelfExtra : LineBaseSubMachina<LineActorControlSelfExtra.ActorControlSelfExtraPacket>, IOverlayPluginLogLine<LineActorControlSelfExtra>
     {
         public const uint LogFileLineID = 274;
         public const string LogLineName = "ActorControlSelfExtra";

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorMove.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineActorMove : LineBaseCustom<
             Server_MessageHeader_Global, LineActorMove.ActorMove_v655,
             Server_MessageHeader_CN, LineActorMove.ActorMove_v655,
-            Server_MessageHeader_KR, LineActorMove.ActorMove_v655>
+            Server_MessageHeader_KR, LineActorMove.ActorMove_v655>, IOverlayPluginLogLine<LineActorMove>
     {
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct ActorMove_v655 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineActorSetPos.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineActorSetPos.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineActorSetPos : LineBaseCustom<
             Server_MessageHeader_Global, LineActorSetPos.ActorSetPos_v655,
             Server_MessageHeader_CN, LineActorSetPos.ActorSetPos_v655,
-            Server_MessageHeader_KR, LineActorSetPos.ActorSetPos_v655>
+            Server_MessageHeader_KR, LineActorSetPos.ActorSetPos_v655>, IOverlayPluginLogLine<LineActorSetPos>
     {
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct ActorSetPos_v655 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineBattleTalk2.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineBattleTalk2.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineBattleTalk2 : LineBaseCustom<
             Server_MessageHeader_Global, LineBattleTalk2.BattleTalk2_v655,
             Server_MessageHeader_CN, LineBattleTalk2.BattleTalk2_v655,
-            Server_MessageHeader_KR, LineBattleTalk2.BattleTalk2_v655>
+            Server_MessageHeader_KR, LineBattleTalk2.BattleTalk2_v655>, IOverlayPluginLogLine<LineBattleTalk2>
     {
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct BattleTalk2_v655 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineCEDirector.cs
@@ -7,7 +7,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineCEDirector : LineBaseCustom<
             Server_MessageHeader_Global, LineCEDirector.CEDirector_v62,
             Server_MessageHeader_CN, LineCEDirector.CEDirector_v62,
-            Server_MessageHeader_KR, LineCEDirector.CEDirector_v62>
+            Server_MessageHeader_KR, LineCEDirector.CEDirector_v62>, IOverlayPluginLogLine<LineCEDirector>
     {
         [StructLayout(LayoutKind.Explicit)]
         internal struct CEDirector_v62 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineCountdown.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineCountdown.cs
@@ -7,7 +7,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineCountdown : LineBaseCustom<
             Server_MessageHeader_Global, LineCountdown.Countdown_v655,
             Server_MessageHeader_CN, LineCountdown.Countdown_v655,
-            Server_MessageHeader_KR, LineCountdown.Countdown_v655>
+            Server_MessageHeader_KR, LineCountdown.Countdown_v655>, IOverlayPluginLogLine<LineCountdown>
     {
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct Countdown_v655 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineCountdownCancel.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineCountdownCancel.cs
@@ -7,7 +7,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineCountdownCancel : LineBaseCustom<
             Server_MessageHeader_Global, LineCountdownCancel.CountdownCancel_v655,
             Server_MessageHeader_CN, LineCountdownCancel.CountdownCancel_v655,
-            Server_MessageHeader_KR, LineCountdownCancel.CountdownCancel_v655>
+            Server_MessageHeader_KR, LineCountdownCancel.CountdownCancel_v655>, IOverlayPluginLogLine<LineCountdownCancel>
     {
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct CountdownCancel_v655 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineFateControl.cs
@@ -5,7 +5,7 @@ using RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
-    class LineFateControl : LineBaseSubMachina<LineFateControl.FateControlPacket>
+    class LineFateControl : LineBaseSubMachina<LineFateControl.FateControlPacket>, IOverlayPluginLogLine<LineFateControl>
     {
         public static readonly Server_ActorControlCategory[] FateActorControlCategories = {
             Server_ActorControlCategory.FateAdd,

--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineMapEffect : LineBaseCustom<
             Server_MessageHeader_Global, LineMapEffect.MapEffect_v62,
             Server_MessageHeader_CN, LineMapEffect.MapEffect_v62,
-            Server_MessageHeader_KR, LineMapEffect.MapEffect_v62>
+            Server_MessageHeader_KR, LineMapEffect.MapEffect_v62>, IOverlayPluginLogLine<LineMapEffect>
     {
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
         internal struct MapEffect_v62 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineNpcYell.cs
@@ -6,7 +6,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineNpcYell : LineBaseCustom<
             Server_MessageHeader_Global, LineNpcYell.NpcYell_v655,
             Server_MessageHeader_CN, LineNpcYell.NpcYell_v655,
-            Server_MessageHeader_KR, LineNpcYell.NpcYell_v655>
+            Server_MessageHeader_KR, LineNpcYell.NpcYell_v655>, IOverlayPluginLogLine<LineNpcYell>
     {
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct NpcYell_v655 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -8,7 +8,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
     class LineRSV : LineBaseCustom<
             Server_MessageHeader_Global, LineRSV.RSV_v62,
             Server_MessageHeader_CN, LineRSV.RSV_v62,
-            Server_MessageHeader_KR, LineRSV.RSV_v62>
+            Server_MessageHeader_KR, LineRSV.RSV_v62>, IOverlayPluginLogLine<LineRSV>
     {
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct RSV_v62 : IPacketStruct

--- a/OverlayPlugin.Core/NetworkProcessors/LineSpawnNpcExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineSpawnNpcExtra.cs
@@ -36,7 +36,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
     class LineSpawnNpcExtra : LineBaseCustomMachina<Server_MessageHeader_Global, LineSpawnNpcExtra.Server_NpcSpawn_Global_6_51,
             Server_MessageHeader_CN, LineSpawnNpcExtra.Server_NpcSpawn_Global_6_51,
-            Server_MessageHeader_KR, LineSpawnNpcExtra.Server_NpcSpawn_Global_6_51>
+            Server_MessageHeader_KR, LineSpawnNpcExtra.Server_NpcSpawn_Global_6_51>, IOverlayPluginLogLine<LineSpawnNpcExtra>
     {
         public const uint LogFileLineID = 272;
         public const string LogLineName = "NpcSpawnExtra";

--- a/OverlayPlugin.Core/NetworkProcessors/NetworkParser.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/NetworkParser.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
-    class NetworkParser
+    class NetworkParser : ITinyIoCAutoConstructDuringInit<NetworkParser>
     {
         public event EventHandler<OnlineStatusChangedArgs> OnOnlineStatusChanged;
 

--- a/OverlayPlugin.Core/OverlayHider.cs
+++ b/OverlayPlugin.Core/OverlayHider.cs
@@ -12,7 +12,7 @@ using static RainbowMage.OverlayPlugin.MemoryProcessors.InCombat.LineInCombat;
 
 namespace RainbowMage.OverlayPlugin
 {
-    class OverlayHider : IDisposable
+    class OverlayHider : IDisposable, ITinyIoCAutoConstructAfterInit<OverlayHider>
     {
         private bool gameActive = true;
         private bool inCutscene = false;

--- a/OverlayPlugin.Core/OverlayZCorrector.cs
+++ b/OverlayPlugin.Core/OverlayZCorrector.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace RainbowMage.OverlayPlugin
 {
-    class OverlayZCorrector : IDisposable
+    class OverlayZCorrector : IDisposable, ITinyIoCAutoConstructAfterInit<OverlayZCorrector>
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Usage",

--- a/OverlayPlugin.Core/Overlays/MiniParseOverlay.cs
+++ b/OverlayPlugin.Core/Overlays/MiniParseOverlay.cs
@@ -243,8 +243,11 @@ namespace RainbowMage.OverlayPlugin.Overlays
                     ExecuteScript("if (window.OverlayPluginApi) window.OverlayPluginApi.preview = true;");
                 }
 
-                // Reset page-specific state
-                Overlay.SetAcceptFocus(false);
+                // Invoke on UI thread due to accessing `Handle` as part of `SetAcceptFocus`.
+                PluginMain.InvokeOnUIThread(() => {
+                    // Reset page-specific state
+                    Overlay.SetAcceptFocus(false);
+                });
 
                 // Subscriptions are cleared on page navigation so we have to restore this after every load.
                 Subscribe("CombatData");

--- a/OverlayPlugin.Core/PluginConfig.cs
+++ b/OverlayPlugin.Core/PluginConfig.cs
@@ -295,6 +295,20 @@ namespace RainbowMage.OverlayPlugin
         public List<JObject> OverlayObjects;
 
         public Dictionary<string, JObject> EventSourceConfigs { get; set; }
+        
+        private bool _ColorblindMode;
+        public bool ColorblindMode
+        {
+            get
+            {
+                return _ColorblindMode;
+            }
+            set
+            {
+                _ColorblindMode = value;
+                isDirty = true;
+            }
+        }
 
         [JsonIgnore]
         private ILogger logger;

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -11,18 +10,6 @@ using Newtonsoft.Json;
 using RainbowMage.HtmlRenderer;
 using RainbowMage.OverlayPlugin.Controls;
 using RainbowMage.OverlayPlugin.EventSources;
-using RainbowMage.OverlayPlugin.MemoryProcessors;
-using RainbowMage.OverlayPlugin.MemoryProcessors.Aggro;
-using RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage;
-using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
-using RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings;
-using RainbowMage.OverlayPlugin.MemoryProcessors.Enmity;
-using RainbowMage.OverlayPlugin.MemoryProcessors.EnmityHud;
-using RainbowMage.OverlayPlugin.MemoryProcessors.InCombat;
-using RainbowMage.OverlayPlugin.MemoryProcessors.JobGauge;
-using RainbowMage.OverlayPlugin.MemoryProcessors.Party;
-using RainbowMage.OverlayPlugin.MemoryProcessors.Target;
-using RainbowMage.OverlayPlugin.NetworkProcessors;
 using RainbowMage.OverlayPlugin.Overlays;
 
 namespace RainbowMage.OverlayPlugin
@@ -49,11 +36,11 @@ namespace RainbowMage.OverlayPlugin
 
         internal string PluginDirectory { get; private set; }
 
-        public PluginMain(string pluginDirectory, Logger logger, TinyIoCContainer container)
+        public PluginMain(string pluginDirectory)
         {
-            _container = container;
+            _container = TinyIoCContainer.Current;
             PluginDirectory = pluginDirectory;
-            _logger = logger;
+            _logger = _container.Resolve<ILogger>();
 
             configSaveTimer = new Timer();
             configSaveTimer.Interval = 300000; // 5 minutes
@@ -67,13 +54,13 @@ namespace RainbowMage.OverlayPlugin
         /// </summary>
         /// <param name="pluginScreenSpace"></param>
         /// <param name="pluginStatusText"></param>
-        public void InitPlugin(TabPage pluginScreenSpace, Label pluginStatusText)
+        public async Task InitPlugin(TabPage pluginScreenSpace, Label pluginStatusText)
         {
             try
             {
                 this.tabPage = pluginScreenSpace;
                 this.label = pluginStatusText;
-                this.label.Text = "Init Phase 1: Infrastructure";
+                await SetPluginStatusText("Init Phase 1: Infrastructure");
 
 #if DEBUG
                 _logger.Log(LogLevel.Warning, "##################################");
@@ -94,13 +81,7 @@ namespace RainbowMage.OverlayPlugin
                 // 1.a Stuff without state
                 FFXIVExportVariables.Init();
 
-                // 1.b Stuff with state
-                _container.Register(new NativeMethods(_container));
-                _container.Register(new EventDispatcher(_container));
-                _container.Register(new Registry(_container));
-                _container.Register(new KeyboardHook(_container));
-
-                this.label.Text = "Init Phase 1: Config";
+                await SetPluginStatusText("Init Phase 1: Config");
                 if (!LoadConfig())
                 {
                     _logger.Log(LogLevel.Error, "Failed to load the plugin config. Please report this error on the GitHub repo or on the ACT Discord.");
@@ -112,15 +93,15 @@ namespace RainbowMage.OverlayPlugin
                     return;
                 }
 
-                this.label.Text = "Init Phase 1: WSServer";
-                _container.Register(new WSServer(_container));
+                TinyIoCAutoHelper.AutoRegisterBeforeInit();
+                TinyIoCAutoHelper.AutoConstructBeforeInit();
 
 #if TRACEPERF
                 _logger.Log(LogLevel.Debug, "Component init and config load took {0}s.", watch.Elapsed.TotalSeconds);
                 watch.Reset();
 #endif
 
-                this.label.Text = "Init Phase 1: CEF";
+                await SetPluginStatusText("Init Phase 1: CEF");
                 try
                 {
                     Renderer.Initialize(PluginDirectory, ActGlobals.oFormActMain.AppDataFolder.FullName, Config.ErrorReports);
@@ -135,7 +116,7 @@ namespace RainbowMage.OverlayPlugin
                 watch.Reset();
 #endif
 
-                this.label.Text = "Init Phase 1: Legacy message bus";
+                await SetPluginStatusText("Init Phase 1: Legacy message bus");
                 // プラグイン間のメッセージ関連
                 OverlayApi.BroadcastMessage += (o, e) =>
                 {
@@ -174,15 +155,15 @@ namespace RainbowMage.OverlayPlugin
                 watch.Reset();
 #endif
 
-                this.label.Text = "Init Phase 1: UI";
+                await SetPluginStatusText("Init Phase 1: UI");
 
                 // Setup the UI
-                this.controlPanel = new ControlPanel(_container);
+                this.controlPanel = new ControlPanel();
                 this.controlPanel.Dock = DockStyle.Fill;
                 this.tabPage.Controls.Add(this.controlPanel);
                 this.tabPage.Name = "OverlayPlugin";
 
-                this.wsConfigPanel = new WSConfigPanel(_container);
+                this.wsConfigPanel = new WSConfigPanel();
                 this.wsConfigPanel.Dock = DockStyle.Fill;
 
                 this.wsTabPage = new TabPage("OverlayPlugin WSServer");
@@ -194,10 +175,10 @@ namespace RainbowMage.OverlayPlugin
                 // Fire off the update check (which runs in the background)
                 if (Config.UpdateCheck)
                 {
-                    Updater.Updater.PerformUpdateIfNecessary(PluginDirectory, _container);
+                    Updater.Updater.PerformUpdateIfNecessary(PluginDirectory);
                 }
 
-                this.label.Text = "Init Phase 1: Presets";
+                await SetPluginStatusText("Init Phase 1: Presets");
                 // Load our presets
                 try
                 {
@@ -232,7 +213,7 @@ namespace RainbowMage.OverlayPlugin
                     _logger.Log(LogLevel.Error, string.Format("Failed to load presets: {0}", ex));
                 }
 
-                this.label.Text = "Init Phase 1: Waiting for plugins to load";
+                await SetPluginStatusText("Init Phase 1: Waiting for plugins to load");
                 initTimer = new Timer();
                 initTimer.Interval = 300;
                 initTimer.Tick += async (o, e) =>
@@ -249,37 +230,13 @@ namespace RainbowMage.OverlayPlugin
                             initTimer.Stop();
 
                             // ** Init phase 2
-                            this.label.Text = "Init Phase 2: Integrations";
+                            await SetPluginStatusText("Init Phase 2: Integrations");
 
                             // Wrap FFXIV plugin related initialization in try/catch to allow OP to work when FFXIV plugin isn't present
                             try
                             {
-                                // Initialize the parser in the second phase since it needs the FFXIV plugin.
-                                // If OverlayPlugin is placed above the FFXIV plugin, it won't be available in the first
-                                // phase but it'll be loaded by the time we enter the second phase.
-                                _container.Register(new FFXIVRepository(_container));
-                                _container.Register(new NetworkParser(_container));
-                                _container.Register(new TriggIntegration(_container));
-                                _container.Register(new FFXIVCustomLogLines(_container));
-                                _container.Register(new MemoryProcessors.FFXIVClientStructs.Data(_container));
-
-                                // Register FFXIV memory reading subcomponents.
-                                // Must be done before loading addons.
-                                _container.Register(new FFXIVMemory(_container));
-
-                                // These are registered to be lazy-loaded. Use interface to force TinyIoC to use singleton pattern.
-                                _container.Register<ICombatantMemory, CombatantMemoryManager>();
-                                _container.Register<ITargetMemory, TargetMemoryManager>();
-                                _container.Register<IContentFinderSettingsMemory, ContentFinderSettingsMemoryManager>();
-                                _container.Register<IAggroMemory, AggroMemoryManager>();
-                                _container.Register<IEnmityMemory, EnmityMemoryManager>();
-                                _container.Register<IEnmityHudMemory, EnmityHudMemoryManager>();
-                                _container.Register<IInCombatMemory, InCombatMemoryManager>();
-                                _container.Register<IAtkStageMemory, AtkStageMemoryManager>();
-                                _container.Register<IPartyMemory, PartyMemoryManager>();
-                                _container.Register<IJobGaugeMemory, JobGaugeMemoryManager>();
-
-                                _container.Register(new OverlayPluginLogLines(_container));
+                                TinyIoCAutoHelper.AutoRegisterDuringInit();
+                                TinyIoCAutoHelper.AutoConstructDuringInit();
                             }
                             catch (Exception ex)
                             {
@@ -292,12 +249,12 @@ namespace RainbowMage.OverlayPlugin
                             // addons. Plugins below OverlayPlugin wouldn't have been loaded in the first init phase.
                             // However, in the second phase all plugins have been loaded which means we can look for addons
                             // in that list.
-                            this.label.Text = "Init Phase 2: Addons";
+                            await SetPluginStatusText("Init Phase 2: Addons");
                             await Task.Run(LoadAddons);
                             wsConfigPanel.RebuildOverlayOptions();
 
-                            this.label.Text = "Init Phase 2: UI";
-                            ActGlobals.oFormActMain.Invoke((Action)(() =>
+                            await SetPluginStatusText("Init Phase 2: UI");
+                            await InvokeOnUIThread(() =>
                             {
                                 try
                                 {
@@ -308,8 +265,8 @@ namespace RainbowMage.OverlayPlugin
                                     controlPanel.InitializeOverlayConfigTabs();
 
                                     this.label.Text = "Init Phase 2: Overlay tasks";
-                                    _container.Register(new OverlayHider(_container));
-                                    _container.Register(new OverlayZCorrector(_container));
+                                    TinyIoCAutoHelper.AutoRegisterAfterInit();
+                                    TinyIoCAutoHelper.AutoConstructAfterInit();
 
                                     // WSServer has to start after the LoadAddons() call because clients can connect immediately
                                     // after it's initialized and that requires the event sources to be initialized.
@@ -330,7 +287,7 @@ namespace RainbowMage.OverlayPlugin
                                 {
                                     _logger.Log(LogLevel.Error, "InitPlugin: {0}", ex);
                                 }
-                            }));
+                            });
                         }
                         catch (Exception ex)
                         {
@@ -460,7 +417,7 @@ namespace RainbowMage.OverlayPlugin
             }
 
             _logger.Log(LogLevel.Info, "DeInitPlugin: Finalized.");
-            if (this.label != null) this.label.Text = "Finalized.";
+            _ = SetPluginStatusText("Finalized.");
         }
 
         private void LoadAddons()
@@ -609,6 +566,44 @@ namespace RainbowMage.OverlayPlugin
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        public async Task SetPluginStatusText(string text)
+        {
+            await InvokeOnUIThread(() =>
+            {
+                if (label != null) label.Text = text;
+            });
+        }
+
+        public static Task<T> InvokeOnUIThread<T>(Func<T> p)
+        {
+            return Task.Run(new Func<T>(() =>
+            {
+                if (ActGlobals.oFormActMain.InvokeRequired)
+                {
+                    return (T)ActGlobals.oFormActMain.EndInvoke(ActGlobals.oFormActMain.BeginInvoke(p));
+                }
+                else
+                {
+                    return p();
+                }
+            }));
+        }
+
+        public static Task InvokeOnUIThread(Action p)
+        {
+            return Task.Run(() =>
+            {
+                if (ActGlobals.oFormActMain.InvokeRequired)
+                {
+                    ActGlobals.oFormActMain.EndInvoke(ActGlobals.oFormActMain.BeginInvoke(p));
+                }
+                else
+                {
+                    p();
+                }
+            });
         }
     }
 }

--- a/OverlayPlugin.Core/WebSocket/WSServer.cs
+++ b/OverlayPlugin.Core/WebSocket/WSServer.cs
@@ -15,7 +15,7 @@ using RainbowMage.OverlayPlugin.Overlays;
 
 namespace RainbowMage.OverlayPlugin
 {
-    public class WSServer : IDisposable
+    public class WSServer : IDisposable, ITinyIoCAutoConstructBeforeInit<WSServer>
     {
         TinyIoCContainer _container;
         ILogger _logger;

--- a/OverlayPlugin.Updater/CefMissingTab.Designer.cs
+++ b/OverlayPlugin.Updater/CefMissingTab.Designer.cs
@@ -13,6 +13,7 @@
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
+            TinyIoCContainer.Current.Resolve<ILogger>().OnLog -= HandleOnLog;
             if (disposing && (components != null))
             {
                 components.Dispose();
@@ -43,7 +44,7 @@
             this.label3 = new System.Windows.Forms.Label();
             this.btnOpenManual = new System.Windows.Forms.Button();
             this.tabPage3 = new System.Windows.Forms.TabPage();
-            this.logBox = new System.Windows.Forms.TextBox();
+            this.logBox = new System.Windows.Forms.RichTextBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
@@ -188,6 +189,6 @@
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Button btnOpenManual;
         private System.Windows.Forms.TabPage tabPage3;
-        private System.Windows.Forms.TextBox logBox;
+        private System.Windows.Forms.RichTextBox logBox;
     }
 }

--- a/OverlayPlugin.Updater/CefMissingTab.cs
+++ b/OverlayPlugin.Updater/CefMissingTab.cs
@@ -15,18 +15,16 @@ namespace RainbowMage.OverlayPlugin.Updater
     {
         private string _cefPath;
         private object _pluginLoader;
-        private TinyIoCContainer _container;
 
-        public CefMissingTab(string cefPath, object pluginLoader, TinyIoCContainer container)
+        public CefMissingTab(string cefPath, object pluginLoader)
         {
             InitializeComponent();
 
-            _container = container;
             _cefPath = cefPath;
             _pluginLoader = pluginLoader;
             lnkManual.Text = CefInstaller.GetUrl();
 
-            container.Resolve<ILogger>().RegisterListener((entry) =>
+            TinyIoCContainer.Current.Resolve<ILogger>().RegisterListener((entry) =>
             {
                 logBox.AppendText($"[{entry.Time}] {entry.Level}: {entry.Message}" + Environment.NewLine);
             });
@@ -44,7 +42,7 @@ namespace RainbowMage.OverlayPlugin.Updater
             if (await CefInstaller.InstallCef(_cefPath, dialog.FileName))
             {
                 Parent.Controls.Remove(this);
-                _pluginLoader.GetType().GetMethod("FinishInit").Invoke(_pluginLoader, new object[] { _container });
+                _pluginLoader.GetType().GetMethod("FinishInit").Invoke(_pluginLoader, new object[] { });
             }
         }
 
@@ -53,7 +51,7 @@ namespace RainbowMage.OverlayPlugin.Updater
             if (await CefInstaller.EnsureCef(_cefPath))
             {
                 Parent.Controls.Remove(this);
-                _pluginLoader.GetType().GetMethod("FinishInit").Invoke(_pluginLoader, new object[] { _container });
+                _pluginLoader.GetType().GetMethod("FinishInit").Invoke(_pluginLoader, new object[] { });
             }
         }
 

--- a/OverlayPlugin.Updater/CefMissingTab.cs
+++ b/OverlayPlugin.Updater/CefMissingTab.cs
@@ -1,12 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Diagnostics;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace RainbowMage.OverlayPlugin.Updater
@@ -24,10 +18,23 @@ namespace RainbowMage.OverlayPlugin.Updater
             _pluginLoader = pluginLoader;
             lnkManual.Text = CefInstaller.GetUrl();
 
-            TinyIoCContainer.Current.Resolve<ILogger>().RegisterListener((entry) =>
-            {
-                logBox.AppendText($"[{entry.Time}] {entry.Level}: {entry.Message}" + Environment.NewLine);
-            });
+            TinyIoCContainer.Current.Resolve<ILogger>().OnLog += HandleOnLog;
+        }
+
+        private void HandleOnLog(object sender, IReadOnlyCollection<LogEntry> e)
+        {
+            Advanced_Combat_Tracker.ActGlobals.oFormActMain.Invoke((Action)(() => {
+                var newText = @"{\rtf1\ansi";
+
+                foreach (var entry in e)
+                {
+                    newText += entry.ToRtfString();
+                }
+
+                newText += "}";
+
+                logBox.Rtf = newText;
+            }));
         }
 
         private async void btnOpenManual_Click(object sender, EventArgs e)

--- a/OverlayPlugin.Updater/HttpClientWrapper.cs
+++ b/OverlayPlugin.Updater/HttpClientWrapper.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace RainbowMage.OverlayPlugin.Updater
 {
@@ -116,7 +117,15 @@ namespace RainbowMage.OverlayPlugin.Updater
                     Monitor.Pulse(completionLock);
                 }
             });
-            action();
+            // Do not run HttpClient requests on the UI thread
+            if (!Advanced_Combat_Tracker.ActGlobals.oFormActMain.InvokeRequired)
+            {
+                Task.Run(action);
+            }
+            else
+            {
+                action();
+            }
 
             lock (completionLock)
             {

--- a/OverlayPlugin.Updater/Updater.cs
+++ b/OverlayPlugin.Updater/Updater.cs
@@ -329,8 +329,10 @@ namespace RainbowMage.OverlayPlugin.Updater
             }
         }
 
-        public static async void PerformUpdateIfNecessary(string pluginDirectory, TinyIoCContainer container, bool manualCheck = false, bool checkPreRelease = false)
+        public static async void PerformUpdateIfNecessary(string pluginDirectory, bool manualCheck = false, bool checkPreRelease = false)
         {
+            var container = TinyIoCContainer.Current;
+
             var logger = container.Resolve<ILogger>();
 
             // e.g. dir/OverlayPlugin/out/Release/OverlayPlugin.dll checking for dir/OverlayPlugin/.git/

--- a/OverlayPlugin/PluginLoader.cs
+++ b/OverlayPlugin/PluginLoader.cs
@@ -25,6 +25,9 @@ namespace RainbowMage.OverlayPlugin
 
         public void InitPlugin(TabPage pluginScreenSpace, Label pluginStatusText)
         {
+#if DEBUG
+            Control.CheckForIllegalCrossThreadCalls = true;
+#endif
             pluginDirectory = GetPluginDirectory();
 
             if (asmResolver == null)

--- a/OverlayPlugin/SanityChecker.cs
+++ b/OverlayPlugin/SanityChecker.cs
@@ -10,6 +10,8 @@ namespace RainbowMage.OverlayPlugin
 {
     public static class SanityChecker
     {
+        private static Dictionary<string, Assembly> LoadedAssemblies = new Dictionary<string, Assembly>();
+
         /**
          * The assembly load order is as follows:
          * 
@@ -54,11 +56,24 @@ namespace RainbowMage.OverlayPlugin
                 return false;
             }
 
+            LoadedAssemblies[name] = asm;
+
             return true;
         }
 
-        public static void CheckDependencyVersions(ILogger logger)
+        public static Assembly GetAssembly(string name) {
+            return LoadedAssemblies[name];
+        }
+
+        public static List<Assembly> GetAssemblies()
         {
+            return LoadedAssemblies.Values.ToList();
+        }
+
+        public static void CheckDependencyVersions()
+        {
+            ILogger logger = TinyIoCContainer.Current.Resolve<ILogger>();
+
             var expectedVersions = new Dictionary<string, string>
             {
                 { "Newtonsoft.Json", "12.0.0" },


### PR DESCRIPTION
This is a large-scale refactor of the plugin's init code and UI creation/access code to fix a number of potential and reported issues with non-UI-thread access to UI components.

As this required rewriting the logic used to append `LogEntry`s to the various log panels, I decided to throw in adding color to the main `ConfigPanel`'s log textbox as well.

![image](https://github.com/OverlayPlugin/OverlayPlugin/assets/6119598/e239a419-2454-425c-b085-ec392a584c48)

![image](https://github.com/OverlayPlugin/OverlayPlugin/assets/6119598/4366d65b-8491-44ba-b1fc-d9a72e4abd9c)

I don't use Triggernometry, so I can't test that the `OverlayPlugin.Core/Integration/TriggIntegration.cs` class is functioning as expected.