### PR TITLE
Add animation lock field to 264 (LineAbilityExtra)

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -36,14 +36,15 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     // exception if we try to prematurely cast it to UInt16
                     var abilityId = aeHeader.Get<uint>("actionId");
                     var globalEffectCounter = aeHeader.Get<uint>("globalEffectCounter");
+                    var animationLock = aeHeader.Get<float>("animationLockTime");
 
                     if (rawPacket.actionEffectCount == 1)
                     {
                         // AE1 is not useful. It does not contain this data. But we still need to write something
                         // to indicate that a proper line will not be happening.
                         return string.Format(CultureInfo.InvariantCulture,
-                            "{0:X8}|{1:X4}|{2:X8}|{3}||||",
-                            ActorID, abilityId, globalEffectCounter, (int)LineSubType.NO_DATA);
+                            "{0:X8}|{1:X4}|{2:X8}|{3}||||{4:F3}|",
+                            ActorID, abilityId, globalEffectCounter, (int)LineSubType.NO_DATA, animationLock);
                     }
 
                     float x = FFXIVRepository.ConvertUInt16Coordinate(rawPacket.x);
@@ -52,8 +53,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
                     var h = FFXIVRepository.ConvertHeading(aeHeader.Get<ushort>("rotation"));
                     return string.Format(CultureInfo.InvariantCulture,
-                        "{0:X8}|{1:X4}|{2:X8}|{3}|{4:F3}|{5:F3}|{6:F3}|{7:F3}",
-                        ActorID, abilityId, globalEffectCounter, (int)LineSubType.DATA_PRESENT, x, y, z, h);
+                        "{0:X8}|{1:X4}|{2:X8}|{3}|{4:F3}|{5:F3}|{6:F3}|{7:F3}|{8:F3}",
+                        ActorID, abilityId, globalEffectCounter, (int)LineSubType.DATA_PRESENT, x, y, z, h, animationLock);
                 }
                 finally
                 {

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -66,7 +66,7 @@
         "ID": 264,
         "Name": "AbilityExtra",
         "Source": "OverlayPlugin",
-        "Version": 1,
+        "Version": 2,
         "Comment": "Extra info from ActionEffect packets"
     },
     {


### PR DESCRIPTION
Adds an animationLock field to line 264 (LineAbilityExtra).

Examples:

```
# Normal instant GCD or oGCD:
264|2024-06-17T15:08:10.9610000-07:00|1234ABCD|5EF9|00004CC8|0||||0.600||
# Hard cast:
264|2024-06-17T15:07:59.9930000-07:00|1234ABCD|5EF8|00004CC7|0||||0.100||
# Gap closer (Icarus):
264|2024-06-17T15:06:47.4520000-07:00|1234ABCD|5EE7|00004CC6|0||||0.700||
# Potion:
264|2024-06-17T15:06:24.5980000-07:00|1234ABCD|F9CBF|00004CC5|0||||1.100||
```

Also just to note it somewhere, a swifted GCD will have 0.6s lock like a natural instant GCD.