### PR TITLE
Update opcodes for global 7.0

### DIFF
--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -44,42 +44,42 @@
         }
     },
     "Global": {
-        "2024.04.23.0000.0000": {
-            // Version: 6.58 Hotfix 2
+        "2024.06.18.0000.0000": {
+            // Version: 7.0
             "MapEffect": {
-                "opcode": 764,
+                "opcode": 255,
                 "size": 11
             },
             "CEDirector": {
-                "opcode": 213,
+                "opcode": 210,
                 "size": 16
             },
             "RSVData": {
-                "opcode": 101,
+                "opcode": 954,
                 "size": 1080
             },
             "NpcYell": {
-                "opcode": 474,
+                "opcode": 995,
                 "size": 32
             },
             "BattleTalk2": {
-                "opcode": 768,
+                "opcode": 855,
                 "size": 40
             },
             "Countdown": {
-                "opcode": 886,
+                "opcode": 687,
                 "size": 48
             },
             "CountdownCancel": {
-                "opcode": 695,
+                "opcode": 673,
                 "size": 40
             },
             "ActorMove": {
-                "opcode": 284,
+                "opcode": 838,
                 "size": 16
             },
             "ActorSetPos": {
-                "opcode": 669,
+                "opcode": 811,
                 "size": 24
             }
         }


### PR DESCRIPTION
Packet structures look fine at a glance, but someone should double check.