### PR TITLE
Revert animation lock

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -43,7 +43,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                         // AE1 is not useful. It does not contain this data. But we still need to write something
                         // to indicate that a proper line will not be happening.
                         return string.Format(CultureInfo.InvariantCulture,
-                            "{0:X8}|{1:X4}|{2:X8}|{3}|||||{4:F3}",
+                            "{0:X8}|{1:X4}|{2:X8}|{3}||||{4:F3}|",
                             ActorID, abilityId, globalEffectCounter, (int)LineSubType.NO_DATA, animationLock);
                     }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -36,15 +36,14 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     // exception if we try to prematurely cast it to UInt16
                     var abilityId = aeHeader.Get<uint>("actionId");
                     var globalEffectCounter = aeHeader.Get<uint>("globalEffectCounter");
-                    var animationLock = aeHeader.Get<float>("animationLockTime");
 
                     if (rawPacket.actionEffectCount == 1)
                     {
                         // AE1 is not useful. It does not contain this data. But we still need to write something
                         // to indicate that a proper line will not be happening.
                         return string.Format(CultureInfo.InvariantCulture,
-                            "{0:X8}|{1:X4}|{2:X8}|{3}||||{4:F3}|",
-                            ActorID, abilityId, globalEffectCounter, (int)LineSubType.NO_DATA, animationLock);
+                            "{0:X8}|{1:X4}|{2:X8}|{3}||||",
+                            ActorID, abilityId, globalEffectCounter, (int)LineSubType.NO_DATA);
                     }
 
                     float x = FFXIVRepository.ConvertUInt16Coordinate(rawPacket.x);
@@ -53,8 +52,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
                     var h = FFXIVRepository.ConvertHeading(aeHeader.Get<ushort>("rotation"));
                     return string.Format(CultureInfo.InvariantCulture,
-                        "{0:X8}|{1:X4}|{2:X8}|{3}|{4:F3}|{5:F3}|{6:F3}|{7:F3}|{8:F3}",
-                        ActorID, abilityId, globalEffectCounter, (int)LineSubType.DATA_PRESENT, x, y, z, h, animationLock);
+                        "{0:X8}|{1:X4}|{2:X8}|{3}|{4:F3}|{5:F3}|{6:F3}|{7:F3}",
+                        ActorID, abilityId, globalEffectCounter, (int)LineSubType.DATA_PRESENT, x, y, z, h);
                 }
                 finally
                 {

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -66,7 +66,7 @@
         "ID": 264,
         "Name": "AbilityExtra",
         "Source": "OverlayPlugin",
-        "Version": 2,
+        "Version": 1,
         "Comment": "Extra info from ActionEffect packets"
     },
     {


### PR DESCRIPTION
Reverts animation lock PR in its entirety, as this is now part of the base plugin.