### PR TITLE
Fix deadlock during plugin init

### DIFF
--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -254,32 +254,36 @@ namespace RainbowMage.OverlayPlugin
                             // Wrap FFXIV plugin related initialization in try/catch to allow OP to work when FFXIV plugin isn't present
                             try
                             {
-                                // Initialize the parser in the second phase since it needs the FFXIV plugin.
-                                // If OverlayPlugin is placed above the FFXIV plugin, it won't be available in the first
-                                // phase but it'll be loaded by the time we enter the second phase.
-                                _container.Register(new FFXIVRepository(_container));
-                                _container.Register(new NetworkParser(_container));
-                                _container.Register(new TriggIntegration(_container));
-                                _container.Register(new FFXIVCustomLogLines(_container));
-                                _container.Register(new MemoryProcessors.FFXIVClientStructs.Data(_container));
+                                await Task.Run(() =>
+                                {
+                                    // Initialize the parser in the second phase since it needs the FFXIV plugin.
+                                    // If OverlayPlugin is placed above the FFXIV plugin, it won't be available in the first
+                                    // phase but it'll be loaded by the time we enter the second phase.
+                                    _container.Register(new FFXIVRepository(_container));
+                                    _container.Register(new NetworkParser(_container));
+                                    _container.Register(new TriggIntegration(_container));
+                                    _container.Register(new FFXIVCustomLogLines(_container));
+                                    _container.Register(new MemoryProcessors.FFXIVClientStructs.Data(_container));
 
-                                // Register FFXIV memory reading subcomponents.
-                                // Must be done before loading addons.
-                                _container.Register(new FFXIVMemory(_container));
+                                    // Register FFXIV memory reading subcomponents.
+                                    // Must be done before loading addons.
+                                    _container.Register(new FFXIVMemory(_container));
 
-                                // These are registered to be lazy-loaded. Use interface to force TinyIoC to use singleton pattern.
-                                _container.Register<ICombatantMemory, CombatantMemoryManager>();
-                                _container.Register<ITargetMemory, TargetMemoryManager>();
-                                _container.Register<IContentFinderSettingsMemory, ContentFinderSettingsMemoryManager>();
-                                _container.Register<IAggroMemory, AggroMemoryManager>();
-                                _container.Register<IEnmityMemory, EnmityMemoryManager>();
-                                _container.Register<IEnmityHudMemory, EnmityHudMemoryManager>();
-                                _container.Register<IInCombatMemory, InCombatMemoryManager>();
-                                _container.Register<IAtkStageMemory, AtkStageMemoryManager>();
-                                _container.Register<IPartyMemory, PartyMemoryManager>();
-                                _container.Register<IJobGaugeMemory, JobGaugeMemoryManager>();
+                                    // These are registered to be lazy-loaded. Use interface to force TinyIoC to use singleton pattern.
+                                    _container.Register<ICombatantMemory, CombatantMemoryManager>();
+                                    _container.Register<ITargetMemory, TargetMemoryManager>();
+                                    _container
+                                        .Register<IContentFinderSettingsMemory, ContentFinderSettingsMemoryManager>();
+                                    _container.Register<IAggroMemory, AggroMemoryManager>();
+                                    _container.Register<IEnmityMemory, EnmityMemoryManager>();
+                                    _container.Register<IEnmityHudMemory, EnmityHudMemoryManager>();
+                                    _container.Register<IInCombatMemory, InCombatMemoryManager>();
+                                    _container.Register<IAtkStageMemory, AtkStageMemoryManager>();
+                                    _container.Register<IPartyMemory, PartyMemoryManager>();
+                                    _container.Register<IJobGaugeMemory, JobGaugeMemoryManager>();
 
-                                _container.Register(new OverlayPluginLogLines(_container));
+                                    _container.Register(new OverlayPluginLogLines(_container));
+                                });
                             }
                             catch (Exception ex)
                             {

--- a/OverlayPlugin.Updater/HttpClientWrapper.cs
+++ b/OverlayPlugin.Updater/HttpClientWrapper.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading;
+using Advanced_Combat_Tracker;
 
 namespace RainbowMage.OverlayPlugin.Updater
 {
@@ -32,6 +33,9 @@ namespace RainbowMage.OverlayPlugin.Updater
         public static string Get(string url, Dictionary<string, string> headers, string downloadDest,
             ProgressInfoCallback infoCb, bool resume)
         {
+            if (!ActGlobals.oFormActMain.InvokeRequired)
+                throw new Exception("HttpClientWrapper called on UI thread, this can cause deadlocks");
+
             var completionLock = new object();
             string result = null;
             Exception error = null;

--- a/OverlayPlugin.Updater/HttpClientWrapper.cs
+++ b/OverlayPlugin.Updater/HttpClientWrapper.cs
@@ -34,7 +34,7 @@ namespace RainbowMage.OverlayPlugin.Updater
             ProgressInfoCallback infoCb, bool resume)
         {
             if (!ActGlobals.oFormActMain.InvokeRequired)
-                throw new Exception("HttpClientWrapper called on UI thread, this can cause deadlocks");
+                throw new HttpClientException(false, "HttpClientWrapper called on UI thread, this can cause deadlocks");
 
             var completionLock = new object();
             string result = null;


### PR DESCRIPTION
The debug build froze ACT several times for me. The reason is that I didn't have opcodes and `OverlayPluginLogLines` which tries to download them is created on the UI thread in init phase 2. I've tried to debug this but the only thing I could figure out is that `client.SendAsync` in `HttpClientWrapper.Get` never returns if `Get` is called on the UI thread.

I'm guessing that `HttpClientWrapper.Get` blocks the UI thread with `Monitor.Wait` which prevents .NET from executing the rest of the async `action`.

In any case, I've added a check to prevent this from happening again and moved most stuff in init phase 2 into a background thread which fixed the issue and is a good idea anyway since we don't want to block the UI thread during that init stuff or the opcode download.

The init overhaul will probably make this obsolete but this PR can serve as a workaround until we merge that.