### PR TITLE
Fix two shutdown crashes

### DIFF
--- a/HtmlRenderer/OverlayControl.cs
+++ b/HtmlRenderer/OverlayControl.cs
@@ -56,13 +56,19 @@ namespace RainbowMage.HtmlRenderer
 
         public void Init(string url, int maxFrameRate = 30, object api = null)
         {
+            // Work around a bug where Cactbot calls this method during shutdown
+            if (!Visible)
+            {
+                return;
+            }
+
             this.DoubleBuffered = true;
             this.SetStyle(ControlStyles.Selectable | ControlStyles.UserMouse, true);
             this.SetStyle(ControlStyles.StandardClick | ControlStyles.StandardDoubleClick, false);
 
             lock (surfaceLock)
             {
-                if (surfaceBuffer == null)
+                if (surfaceBuffer == null && Width > 1 && Height > 1)
                 {
                     // Make sure we have a valid buffer to avoid the "No buffer!" warning in OnPaint().
                     surfaceBuffer = new Bitmap(Width, Height);

--- a/HtmlRenderer/OverlayForm.cs
+++ b/HtmlRenderer/OverlayForm.cs
@@ -316,7 +316,7 @@ namespace RainbowMage.HtmlRenderer
 
         private void OverlayForm_FormClosed(object sender, FormClosedEventArgs e)
         {
-            this.Renderer.EndRender();
+            this.Renderer?.EndRender();
             terminated = true;
         }
 
@@ -326,20 +326,18 @@ namespace RainbowMage.HtmlRenderer
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (this.surfaceBuffer != null)
+            terminated = true;
+
+            if (disposing)
             {
-                this.surfaceBuffer.Dispose();
+                surfaceBuffer?.Dispose();
+                surfaceBuffer = null;
+                Renderer?.Dispose();
+                Renderer = null;
+                components?.Dispose();
+                components = null;
             }
 
-            if (this.Renderer != null)
-            {
-                this.Renderer.Dispose();
-            }
-
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
             base.Dispose(disposing);
         }
 

--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -192,6 +192,7 @@ namespace RainbowMage.HtmlRenderer
         public void BeginRender()
         {
             EndRender();
+            InitBrowser();
 
             var cefWindowInfo = CreateWindowInfo();
             _isWindowless = cefWindowInfo.WindowlessRenderingEnabled;
@@ -211,8 +212,7 @@ namespace RainbowMage.HtmlRenderer
                 _browser.GetBrowser().CloseBrowser(true);
                 _browser.GetBrowserHost().CloseBrowser(true);
                 _browser.Dispose();
-
-                InitBrowser();
+                _browser = null;
             }
         }
 

--- a/OverlayPlugin.Core/JSApi/MinimalApi.cs
+++ b/OverlayPlugin.Core/JSApi/MinimalApi.cs
@@ -35,7 +35,8 @@ namespace RainbowMage.OverlayPlugin
 
         public static void AttachTo(Renderer r, TinyIoCContainer container)
         {
-            r.SetApi(new MinimalApi(r, container));
+            if (r != null)
+                r.SetApi(new MinimalApi(r, container));
         }
 
         [Obsolete("Please pass your IoC container to AttachTo().")]


### PR DESCRIPTION
`Renderer.EndRender` is called when an overlay window closes which can happen during shutdown. Calling `InitBrowser` at that point is problematic since CEF can crash if we shut it down while it's still creating browsers or a window it uses for the browser disappears. Besides that, creating a new browser during shutdown is pointless.

The change in `OverlayControl.Init` is to work around a bug in Cactbot which sometimes calls `Init` during shutdown since the `VisibleChanged` listener doesn't check whether the tab becomes visible or hidden (which happens during shutdown because the tab is destroyed). I'll submit a separate PR for Cactbot to fix that issue as well. I just thought the additional safety checks wouldn't hurt.

The second crash sometimes causes ACT to complain like this and has been reported by several people:
![](https://i.imgur.com/dtZ3vRi.png)

The first fix was an attempt to fix the crash yosio (on Discord) encountered but apparently that didn't work, it did fix the crash Aditu encountered, though.