### PR TITLE
Version bump to 0.19.32

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
         <Copyright>Copyright © RainbowMage 2015, Kuriyama hibiya 2016, ngld 2019, OverlayPlugin Team 2022</Copyright>
         <RunCodeAnalysis>false</RunCodeAnalysis>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <AssemblyVersion>0.19.31</AssemblyVersion>
-        <FileVersion>0.19.31</FileVersion>
+        <AssemblyVersion>0.19.32</AssemblyVersion>
+        <FileVersion>0.19.32</FileVersion>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>


### PR DESCRIPTION
Please don't merge this until #369 and #371 are done.

We need to publish a new version to make sure everyone has the recent opcodes since the version detection that should trigger an automatic fetch is broken.