### PR TITLE
Make error message for when _PartyList is not found

### DIFF
--- a/OverlayPlugin.Core/EventSources/FFXIVClientStructsEventSource.cs
+++ b/OverlayPlugin.Core/EventSources/FFXIVClientStructsEventSource.cs
@@ -72,6 +72,12 @@ namespace RainbowMage.OverlayPlugin.EventSources
 
             dynamic addonPartyList = atkStageMemory.GetAddon("_PartyList");
 
+            if (addonPartyList == null)
+            {
+                logger.Log(LogLevel.Error, "addonPartyList not found");
+                return null;
+            }
+
             partyList.ChocoboCount = addonPartyList.ChocoboCount;
             partyList.MemberCount = addonPartyList.MemberCount;
             partyList.PartyType = addonPartyList.PartyTypeTextNode.NodeText;


### PR DESCRIPTION
I haven't had time to look into why this is coming back as null, but this gives a better failure message than before, where you would just get `Cannot perform runtime binding on a null reference`.