### PR TITLE
Don't create new renderers during shutdown to avoid crashing ACT

### DIFF
--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -20,6 +20,7 @@ namespace RainbowMage.HtmlRenderer
     public class Renderer : IDisposable
     {
         const string CRASH_SERVER = "https://sentry.gruenprint.de/api/12/minidump/?sentry_key=5742b37c4b71484e9ba590c6a6a0e137";
+        public static bool noMoreRenders = false;
 
         public event EventHandler<BrowserErrorEventArgs> BrowserError;
         public event EventHandler<BrowserLoadEventArgs> BrowserStartLoading;
@@ -57,6 +58,8 @@ namespace RainbowMage.HtmlRenderer
 
         public void InitBrowser()
         {
+            if (noMoreRenders) return;
+
             this._browser = new BrowserWrapper(lastUrl ?? "about:blank", automaticallyCreateBrowser: false, target: _target);
             _browser.RequestHandler = new CustomRequestHandler(this);
             _browser.MenuHandler = new ContextMenuHandler(_ctxMenuCallback);
@@ -76,14 +79,15 @@ namespace RainbowMage.HtmlRenderer
         public void SetApi(object api)
         {
             _api = api;
-            if (api != null)
+            if (api != null && _browser != null)
                 _browser.JavascriptObjectRepository.Register("OverlayPluginApi", api, isAsync: true);
         }
 
         public void SetContextMenuCallback(Func<int, int, bool> ctxMenuCallback)
         {
             _ctxMenuCallback = ctxMenuCallback;
-            _browser.MenuHandler = new ContextMenuHandler(ctxMenuCallback);
+            if (_browser != null)
+                _browser.MenuHandler = new ContextMenuHandler(ctxMenuCallback);
         }
 
         private void _browser_BrowserInitialized(object sender, EventArgs e)
@@ -191,6 +195,8 @@ namespace RainbowMage.HtmlRenderer
 
         public void BeginRender()
         {
+            if (noMoreRenders) return;
+
             EndRender();
             InitBrowser();
 

--- a/OverlayPlugin/PluginLoader.cs
+++ b/OverlayPlugin/PluginLoader.cs
@@ -91,6 +91,14 @@ namespace RainbowMage.OverlayPlugin
             await FinishInit(container);
         }
 
+        // Make sure that .NET only tries to load HtmlRenderer once this method is called and not
+        // when a calling method is called (assembly references are resolved before a method is called).
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SetNoMoreRenders(bool value)
+        {
+            Renderer.noMoreRenders = value;
+        }
+
         public async Task FinishInit(TinyIoCContainer container)
         {
             if (await CefInstaller.EnsureCef(GetCefPath()))
@@ -99,6 +107,9 @@ namespace RainbowMage.OverlayPlugin
                 // the CefInstaller is done.
                 if (SanityChecker.LoadSaneAssembly("HtmlRenderer"))
                 {
+                    // Make sure the killswitch isn't still enabled.
+                    SetNoMoreRenders(false);
+
                     // Since this is an async method, we could have switched threds. Make sure InitPlugin() runs on the ACT main thread.
                     ActGlobals.oFormActMain.Invoke((Action)(() =>
                     {
@@ -133,6 +144,16 @@ namespace RainbowMage.OverlayPlugin
 
         public void DeInitPlugin()
         {
+            try
+            {
+                // Due to some issues with WinForms, some event handlers might try to create new renderers which is
+                // pointless since we're shutting down anyway and can cause crashes because CEF just crashes the entire
+                // process if a window handle for a parent window disappears while it's constructing a new renderer.
+                // To work around that, we just enable our killswitch here which causes any attempt to create a new
+                // renderer to noop.
+                SetNoMoreRenders(true);
+            } catch(Exception e) {}
+
             if (pluginMain != null && !initFailed)
             {
                 pluginMain.DeInitPlugin();

--- a/OverlayPlugin/PluginLoader.cs
+++ b/OverlayPlugin/PluginLoader.cs
@@ -152,7 +152,8 @@ namespace RainbowMage.OverlayPlugin
                 // To work around that, we just enable our killswitch here which causes any attempt to create a new
                 // renderer to noop.
                 SetNoMoreRenders(true);
-            } catch(Exception e) {}
+            }
+            catch (Exception e) { }
 
             if (pluginMain != null && !initFailed)
             {


### PR DESCRIPTION
CEF causes ACT to crash if a window handle becomes invalid shortly after a new browser was created for that handle to work around this issue, we disable the browser init logic during shutdown.

The main issue is that Cactbot initialises its config browser control the first time its tab becomes visible. For whatever reason, this happens during shutdown (probably because the tabs above Cactbot's get destroyed making Cactbot's tab the first tab and by default the first tab is selected). Cactbot then creates a new `OverlayControl` (which in hindsight is a bad name for a browser control) which creates a new CEF browser instance. The control (and underlying window handle) are destroyed shortly afterwards which becomes an issue when CEF tries to use that window handle a few moments later. Since CEF's `CreateWindow` call fails with an "invalid parameter" error, it then crashes the process with a fatal error. Since this is very annoying and we can't guarantee that this won't happen in other circumstances, I think the easiest solution is just to entirely disable the browser creation during shutdown.