### PR TITLE
Version bump to 0.19.33

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
         <Copyright>Copyright © RainbowMage 2015, Kuriyama hibiya 2016, ngld 2019, OverlayPlugin Team 2022</Copyright>
         <RunCodeAnalysis>false</RunCodeAnalysis>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <AssemblyVersion>0.19.32</AssemblyVersion>
-        <FileVersion>0.19.32</FileVersion>
+        <AssemblyVersion>0.19.33</AssemblyVersion>
+        <FileVersion>0.19.33</FileVersion>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>


### PR DESCRIPTION
Since the version check is still broken due to a race condition, we should publish an update to make sure everyone has the latest opcodes.

I'd like to merge #377 before this PR as well to fix the crashes during shutdown.