### PR TITLE
Delay opcode fetching for packet helpers until receiving network data

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/PacketHelper/PacketHelper.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/PacketHelper/PacketHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
@@ -18,11 +19,11 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
         public readonly PacketHelper<HeaderStruct_CN, PacketStruct_CN> cn;
         public readonly PacketHelper<HeaderStruct_KR, PacketStruct_KR> kr;
 
-        public RegionalizedPacketHelper(ushort globalOpcode, ushort cnOpcode, ushort krOpcode)
+        private RegionalizedPacketHelper(Func<ushort> globalOpcodeFunc, Func<ushort> cnOpcodeFunc, Func<ushort> krOpcodeFunc)
         {
-            global = new PacketHelper<HeaderStruct_Global, PacketStruct_Global>(globalOpcode);
-            cn = new PacketHelper<HeaderStruct_CN, PacketStruct_CN>(cnOpcode);
-            kr = new PacketHelper<HeaderStruct_KR, PacketStruct_KR>(krOpcode);
+            global = new PacketHelper<HeaderStruct_Global, PacketStruct_Global>(globalOpcodeFunc);
+            cn = new PacketHelper<HeaderStruct_CN, PacketStruct_CN>(cnOpcodeFunc);
+            kr = new PacketHelper<HeaderStruct_KR, PacketStruct_KR>(krOpcodeFunc);
         }
 
         public IPacketHelper this[GameRegion gameRegion]
@@ -43,55 +44,85 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
         public static RegionalizedPacketHelper<HeaderStruct_Global, PacketStruct_Global, HeaderStruct_CN, PacketStruct_CN, HeaderStruct_KR, PacketStruct_KR>
             CreateFromMachina(string opcodeName)
         {
-            var opcodes = FFXIVRepository.GetMachinaOpcodes();
-            if (opcodes == null)
+            Func<ushort> globalOpcodeFunc = () =>
             {
-                return null;
-            }
+                var opcodes = FFXIVRepository.GetMachinaOpcodes();
+                if (opcodes == null)
+                {
+                    return 0;
+                }
+                if (!opcodes.TryGetValue(GameRegion.Global, out var globalOpcodes))
+                {
+                    return 0;
+                }
+                if (!globalOpcodes.TryGetValue(opcodeName, out var globalOpcode))
+                {
+                    return 0;
+                }
+                return globalOpcode;
+            };
 
-            if (!opcodes.TryGetValue(GameRegion.Global, out var globalOpcodes))
+            Func<ushort> cnOpcodeFunc = () =>
             {
-                return null;
-            }
-            if (!opcodes.TryGetValue(GameRegion.Chinese, out var cnOpcodes))
-            {
-                return null;
-            }
-            if (!opcodes.TryGetValue(GameRegion.Korean, out var krOpcodes))
-            {
-                return null;
-            }
+                var opcodes = FFXIVRepository.GetMachinaOpcodes();
+                if (opcodes == null)
+                {
+                    return 0;
+                }
+                if (!opcodes.TryGetValue(GameRegion.Chinese, out var cnOpcodes))
+                {
+                    return 0;
+                }
+                if (!cnOpcodes.TryGetValue(opcodeName, out var cnOpcode))
+                {
+                    return 0;
+                }
+                return cnOpcode;
+            };
 
-            if (!globalOpcodes.TryGetValue(opcodeName, out var globalOpcode))
+            Func<ushort> krOpcodeFunc = () =>
             {
-                globalOpcode = 0;
-            }
-            if (!cnOpcodes.TryGetValue(opcodeName, out var cnOpcode))
-            {
-                cnOpcode = 0;
-            }
-            if (!krOpcodes.TryGetValue(opcodeName, out var krOpcode))
-            {
-                krOpcode = 0;
-            }
+                var opcodes = FFXIVRepository.GetMachinaOpcodes();
+                if (opcodes == null)
+                {
+                    return 0;
+                }
+                if (!opcodes.TryGetValue(GameRegion.Korean, out var krOpcodes))
+                {
+                    return 0;
+                }
+                if (!krOpcodes.TryGetValue(opcodeName, out var krOpcode))
+                {
+                    return 0;
+                }
+                return krOpcode;
+            };
 
             return new RegionalizedPacketHelper<HeaderStruct_Global, PacketStruct_Global, HeaderStruct_CN, PacketStruct_CN, HeaderStruct_KR, PacketStruct_KR>
-                (globalOpcode, cnOpcode, krOpcode);
+                (globalOpcodeFunc, cnOpcodeFunc, krOpcodeFunc);
         }
 
         public static RegionalizedPacketHelper<HeaderStruct_Global, PacketStruct_Global, HeaderStruct_CN, PacketStruct_CN, HeaderStruct_KR, PacketStruct_KR>
             CreateFromOpcodeConfig(OverlayPluginLogLineConfig opcodeConfig, string opcodeName)
         {
-            var globalOpcodeConfigEntry = opcodeConfig[opcodeName, GameRegion.Global.ToString()];
-            var cnOpcodeConfigEntry = opcodeConfig[opcodeName, GameRegion.Chinese.ToString()];
-            var krOpcodeConfigEntry = opcodeConfig[opcodeName, GameRegion.Korean.ToString()];
-
-            ushort globalOpcode = (ushort)(globalOpcodeConfigEntry?.opcode ?? 0);
-            ushort cnOpcode = (ushort)(cnOpcodeConfigEntry?.opcode ?? 0);
-            ushort krOpcode = (ushort)(krOpcodeConfigEntry?.opcode ?? 0);
+            Func<ushort> globalOpcodeFunc = () =>
+            {
+                var globalOpcodeConfigEntry = opcodeConfig[opcodeName, GameRegion.Global.ToString()];
+                return (ushort)(globalOpcodeConfigEntry?.opcode ?? 0);
+            };
+            Func<ushort> cnOpcodeFunc = () =>
+            {
+                var cnOpcodeConfigEntry = opcodeConfig[opcodeName, GameRegion.Chinese.ToString()];
+                return (ushort)(cnOpcodeConfigEntry?.opcode ?? 0);
+            };
+            Func<ushort> krOpcodeFunc = () =>
+            {
+                var krOpcodeConfigEntry = opcodeConfig[opcodeName, GameRegion.Korean.ToString()];
+                return (ushort)(krOpcodeConfigEntry?.opcode ?? 0);
+            };
 
             return new RegionalizedPacketHelper<HeaderStruct_Global, PacketStruct_Global, HeaderStruct_CN, PacketStruct_CN, HeaderStruct_KR, PacketStruct_KR>
-                (globalOpcode, cnOpcode, krOpcode);
+                (globalOpcodeFunc, cnOpcodeFunc, krOpcodeFunc);
         }
     }
 
@@ -104,15 +135,27 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
         where HeaderStruct : struct, IHeaderStruct
         where PacketStruct : struct, IPacketStruct
     {
-        public readonly ushort Opcode;
+        public ushort Opcode { get; private set; }
         public readonly int headerSize;
         public readonly int packetSize;
+        private readonly Func<ushort> getOpcodeFunc;
 
-        public PacketHelper(ushort opcode)
+        public PacketHelper(Func<ushort> getOpcodeFunc)
         {
-            Opcode = opcode;
+            this.getOpcodeFunc = getOpcodeFunc;
             headerSize = Marshal.SizeOf(typeof(HeaderStruct));
             packetSize = Marshal.SizeOf(typeof(PacketStruct));
+        }
+
+
+        // Tell the compiler to inline this whenever possible for performance reasons
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void InitOpcode()
+        {
+            if (Opcode == 0)
+            {
+                Opcode = getOpcodeFunc();
+            }
         }
 
         /// <summary>
@@ -123,6 +166,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
         /// <returns>null for invalid packet, otherwise a constructed packet</returns>
         public string ToString(long epoch, byte[] message)
         {
+            InitOpcode();
             if (ToStructs(message, out var header, out var packet) == false)
             {
                 return null;
@@ -139,11 +183,13 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
         /// <returns>null for invalid packet, otherwise a constructed packet</returns>
         public string ToString(long epoch, HeaderStruct header, PacketStruct packet)
         {
+            InitOpcode();
             return packet.ToString(epoch, header.ActorID);
         }
 
         public unsafe bool ToStructs(byte[] message, out HeaderStruct header, out PacketStruct packet)
         {
+            InitOpcode();
             // Message is too short to contain this packet
             if (message.Length < headerSize + packetSize)
             {


### PR DESCRIPTION
@ngld I think this solves the issues with opcodes loading before being ready, as we were discussing in Discord.

Needs more testing, I basically only managed to test `ActorCastExtra` before Windows decided that 3 weeks of uptime was enough and started dying on me.

Basically this intrinsically ties the loading of opcodes to when a packet is received, so `FFXIV_ACT_Plugin` is always in a good/ready state when loading.

It doesn't solve users having ACT running before a game update, and then still having the same instance running after the update, but then opcodes would have changed and require an update/ACT restart anyways in that case.