### PR TITLE
HiDPI fixes for tab control

### DIFF
--- a/DEPS.json
+++ b/DEPS.json
@@ -1,11 +1,11 @@
 {
   "ACT": {
-    "url": "https://github.com/EQAditu/AdvancedCombatTracker/releases/download/3.4.9.271/ACTv3.zip",
+    "url": "https://github.com/EQAditu/AdvancedCombatTracker/releases/download/3.8.0.283/ACTv3.zip",
     "dest": "Thirdparty/ACT",
     "strip": 0,
     "hash": [
       "sha256",
-      "eb5dc7074c32a534d4e80e0248976c9499c377b61892be2ae85ad631e5af6589"
+      "663F1A276425B51DEC2AF5CB9CA63507B75FBF46188A0D8C9A6BC11A6C4FDC6D"
     ]
   },
   "FFXIV_ACT_Plugin": {

--- a/OverlayPlugin.Core/Controls/TabControlExt.cs
+++ b/OverlayPlugin.Core/Controls/TabControlExt.cs
@@ -1,16 +1,44 @@
 ﻿using System;
 using System.Drawing;
 using System.Windows.Forms;
+using Advanced_Combat_Tracker;
 
 namespace RainbowMage.OverlayPlugin
 {
     public class TabControlExt : TabControl
     {
+        float dpiScale = 0;
+        float DpiScale
+        {
+            get
+            {
+                if (dpiScale == 0)
+                {
+                    try { dpiScale = ActGlobals.oFormActMain.DpiScale; }
+                    catch { dpiScale = 1; }
+                }
+                return dpiScale;
+            }
+        }
+        int Dpi(float InputValue)
+        {
+            return (int)(InputValue * DpiScale);
+        }
+
+        bool itemSizeSet = false;
         protected override void OnPaint(PaintEventArgs e)
         {
-            base.OnPaint(e);
+            if (itemSizeSet == false)   // For some reason setting the size in the constructor is ineffective
+            {
+                itemSizeSet = true;
+                ItemSize = new Size(Dpi(46), Dpi(140));
+            }
+
+            //base.OnPaint(e);    // Seems unnecessary since the next line wipes everything?
             e.Graphics.Clear(SystemColors.ControlLightLight);
-            e.Graphics.FillRectangle(SystemBrushes.ControlLight, 4, 4, (ItemSize.Height * RowCount) - 4, Height - 8);
+            Rectangle tabsetRect = new Rectangle(Dpi(4), Dpi(4), (ItemSize.Height * RowCount) - Dpi(4), Height - Dpi(8));   // The entire tabset area
+            Rectangle tabmodelRect = new Rectangle(tabsetRect.X + Dpi(2), 0, tabsetRect.Width - Dpi(4), 20);    // A size model for a single tab
+            e.Graphics.FillRectangle(SystemBrushes.ControlLight, tabsetRect);
 
             int inc = 0;
 
@@ -18,11 +46,11 @@ namespace RainbowMage.OverlayPlugin
             {
                 Color fore = Color.Black;
                 Font fontF = Font;
-                Font fontFSmall = new Font(Font.FontFamily, (float)(Font.Size * 0.85));
-                Rectangle tabrect = GetTabRect(inc);
-                Rectangle rect = new Rectangle(tabrect.X + 4, tabrect.Y + 4, tabrect.Width - 8, tabrect.Height - 2);
-                Rectangle textrect1 = new Rectangle(tabrect.X + 4, tabrect.Y + 4, tabrect.Width - 8, tabrect.Height - 20);
-                Rectangle textrect2 = new Rectangle(tabrect.X + 4, tabrect.Y + 20, tabrect.Width - 8, tabrect.Height - 20);
+                Font fontFSmall = new Font(Font.FontFamily, (float)(Font.Size * 0.85));  // This is already DPI scaled by Windows because this.Font was
+                Rectangle tabclipRect = GetTabRect(inc);    // A clipping rectangle that encompasses this tab
+                Rectangle tabRect = new Rectangle(tabmodelRect.X, tabclipRect.Y + Dpi(5), tabmodelRect.Width, tabclipRect.Height - Dpi(2)); // A combination of our tab size model and the offset from the clipping rectangle
+                Rectangle textRect1 = new Rectangle(tabmodelRect.X, tabclipRect.Y + Dpi(6), tabmodelRect.Width, tabclipRect.Height - Dpi(20));
+                Rectangle textRect2 = new Rectangle(tabmodelRect.X, tabclipRect.Y + Dpi(22), tabmodelRect.Width, tabclipRect.Height - Dpi(20));
 
                 StringFormat sf = new StringFormat();
                 sf.LineAlignment = StringAlignment.Center;
@@ -30,24 +58,24 @@ namespace RainbowMage.OverlayPlugin
 
                 if (inc == SelectedIndex)
                 {
-                    e.Graphics.FillRectangle(new SolidBrush(SystemColors.Highlight), rect);
+                    e.Graphics.FillRectangle(new SolidBrush(SystemColors.Highlight), tabRect);
                     fore = SystemColors.HighlightText;
                     fontF = new Font(Font, FontStyle.Bold);
                 }
                 else
                 {
-                    e.Graphics.FillRectangle(Brushes.White, rect);
+                    e.Graphics.FillRectangle(Brushes.White, tabRect);
                 }
 
-                e.Graphics.DrawString(tp.Name, fontF, new SolidBrush(fore), textrect1, sf);
-                e.Graphics.DrawString(tp.Text, fontFSmall, new SolidBrush(fore), textrect2, sf);
+                e.Graphics.DrawString(tp.Name, fontF, new SolidBrush(fore), textRect1, sf);
+                e.Graphics.DrawString(tp.Text, fontFSmall, new SolidBrush(fore), textRect2, sf);
                 inc++;
             }
         }
 
-        protected override void OnTabIndexChanged(EventArgs e)
+        protected override void OnSelectedIndexChanged(EventArgs e)
         {
-            base.OnTabIndexChanged(e);
+            base.OnSelectedIndexChanged(e);
             Invalidate();
         }
 
@@ -63,7 +91,7 @@ namespace RainbowMage.OverlayPlugin
 
             DoubleBuffered = true;
 
-            ItemSize = new Size(46, 140);
+            //ItemSize = new Size(Dpi(46), Dpi(140));   // For some reason setting the size in the constructor is ineffective
             SizeMode = TabSizeMode.Fixed;
             BackColor = Color.Transparent;
         }


### PR DESCRIPTION
Fixes #352 

I can't think of anything else I need to do with the DPI changes part.  The only thing that bothers me is that at 100% DPI, the top border is one pixel different compared to the side borders.  150% & 200% scaling has the same borders all around, though.

Please understand that this relies on a newer version of ACT to detect DPI scaling in a reliable manner.  For this reason, please hold off on releasing the changes in this PR until you feel it is likely that everyone has updated ACT to one of the new releases of this year.  It may create a problem if a long-absent player comes back and updates OverlayPlugin and restarts while ignoring the ACT update also available.  The effect is that this tab control will fail to render unless ACT is updated.