### PR TITLE
add game language to tech support output

### DIFF
--- a/OverlayPlugin.Core/ClipboardTechSupport.cs
+++ b/OverlayPlugin.Core/ClipboardTechSupport.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -10,6 +11,7 @@ using System.Threading;
 using System.Windows.Forms;
 using Advanced_Combat_Tracker;
 using Newtonsoft.Json.Linq;
+using RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework;
 
 // TODO: print warning on cactbot plugin / url / user dir mismatch
 // TODO: include first N lines of OverlayPlugin log
@@ -36,6 +38,7 @@ namespace RainbowMage.OverlayPlugin
         private static WindowsIdentity actWi = null;
         private static WindowsIdentity ffxivWi = null;
         private static Process[] actProcesses = null;
+        private static string gameLanguage = null;
         private static string actIsAdmin = null;
         private static string ffxivIsAdmin = null;
         private static string screenMode = null;
@@ -137,6 +140,8 @@ namespace RainbowMage.OverlayPlugin
             }
 
             settings = new List<string> { "Various Settings" + " - Value" };
+            gameLanguage = GetGameLanguage(container);
+            settings.Add("Game Language" + " - " + gameLanguage);
             var repository = container.Resolve<FFXIVRepository>();
             if (repository.IsFFXIVPluginPresent())
             {
@@ -269,6 +274,22 @@ namespace RainbowMage.OverlayPlugin
             {
                 return null;
             }
+        }
+
+        private static string GetGameLanguage(TinyIoCContainer container)
+        {
+            var clientFrameworkMemory = container.Resolve<IClientFrameworkMemory>();
+            if (!clientFrameworkMemory.IsValid())
+            {
+                return "(unknown)";
+            }
+
+            var clientFramework = clientFrameworkMemory.GetClientFramework();
+            if (!clientFramework.foundLanguage)
+            {
+                return "(unknown)";
+            }
+            return clientFramework.clientLanguage.ToString();
         }
 
         private void GetFFXIVScreenMode(Process process)

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFramework.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFramework.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
+{
+    public enum ClientLang
+    {
+        Japanese = 0,
+        English = 1,
+        German = 2,
+        French = 3,
+        // The global client only supports the above options, but presumably
+        // other clients have different byte values for their languages.
+        // We don't know what these are yet, so make all other possible
+        // values 'Unknown', and we can map if/once they are known.
+        Unknown4 = 4,
+        Unknown5 = 5,
+        Unknown6 = 6,
+        Unknown7 = 7,
+        Unknown8 = 8,
+        Unknown9 = 9,
+        Unknown10 = 10,
+        Unknown11 = 11,
+        Unknown12 = 12,
+        Unknown13 = 13,
+        Unknown14 = 14,
+        Unknown15 = 15
+    }
+
+    public class ClientFramework
+    {
+        public bool foundLanguage = false;
+        public ClientLang clientLanguage;
+    }
+
+    public abstract class ClientFrameworkMemory
+    {
+        protected FFXIVMemory memory;
+        protected ILogger logger;
+
+        protected IntPtr clientFrameworkInstanceAddress = IntPtr.Zero;
+        protected IntPtr clientFrameworkAddress = IntPtr.Zero;
+
+        private readonly string clientFrameworkSignature;
+        private readonly int clientFrameworkSignatureOffset;
+
+        public ClientFrameworkMemory(TinyIoCContainer container, string clientFrameworkSignature, int clientFrameworkSignatureOffset)
+        {
+            this.clientFrameworkSignature = clientFrameworkSignature;
+            this.clientFrameworkSignatureOffset = clientFrameworkSignatureOffset;
+            logger = container.Resolve<ILogger>();
+            memory = container.Resolve<FFXIVMemory>();
+        }
+
+        private void ResetPointers()
+        {
+            clientFrameworkInstanceAddress = IntPtr.Zero;
+            clientFrameworkAddress = IntPtr.Zero;
+        }
+
+        private bool HasValidPointers()
+        {
+            if (clientFrameworkInstanceAddress == IntPtr.Zero)
+                return false;
+            if (clientFrameworkAddress == IntPtr.Zero)
+                return false;
+            return true;
+        }
+
+        public bool IsValid()
+        {
+            if (!memory.IsValid())
+                return false;
+
+            if (!HasValidPointers())
+                return false;
+            return true;
+        }
+
+        public virtual void ScanPointers()
+        {
+            ResetPointers();
+            if (!memory.IsValid())
+                return;
+
+            List<string> fail = new List<string>();
+
+            List<IntPtr> list = memory.SigScan(clientFrameworkSignature, clientFrameworkSignatureOffset, true);
+
+            if (list != null && list.Count == 1)
+            {
+                clientFrameworkInstanceAddress = list[0];
+            }
+            else
+            {
+                clientFrameworkInstanceAddress = IntPtr.Zero;
+                fail.Add(nameof(clientFrameworkInstanceAddress));
+            }
+            logger.Log(LogLevel.Debug, "clientFrameworkInstanceAddress: 0x{0:X}", clientFrameworkInstanceAddress.ToInt64());
+
+            if (clientFrameworkInstanceAddress != IntPtr.Zero)
+            {
+                clientFrameworkAddress = memory.ReadIntPtr(clientFrameworkInstanceAddress);
+            }
+            else
+            {
+                clientFrameworkAddress = IntPtr.Zero;
+                fail.Add(nameof(clientFrameworkAddress));
+            }
+
+            if (fail.Count == 0)
+            {
+                logger.Log(LogLevel.Info, $"Found client framework memory via {GetType().Name}.");
+                return;
+            }
+
+            logger.Log(LogLevel.Error, $"Failed to find client framework memory via {GetType().Name}: {string.Join(", ", fail)}.");
+            return;
+        }
+
+        public abstract Version GetVersion();
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFramework.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFramework.cs
@@ -108,6 +108,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
                 clientFrameworkAddress = IntPtr.Zero;
                 fail.Add(nameof(clientFrameworkAddress));
             }
+            logger.Log(LogLevel.Debug, "clientFrameworkAddress: 0x{0:X}", clientFrameworkAddress.ToInt64());
 
             if (fail.Count == 0)
             {

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFramework.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFramework.cs
@@ -6,15 +6,14 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
 {
     public enum ClientLang
     {
+        // global client
         Japanese = 0,
         English = 1,
         German = 2,
         French = 3,
-        // The global client only supports the above options, but presumably
-        // other clients have different byte values for their languages.
-        // We don't know what these are yet, so make all other possible
-        // values 'Unknown', and we can map if/once they are known.
-        Unknown4 = 4,
+        // cn client
+        Chinese = 4,
+        // We don't know what these are yet; treat as unknown for now.
         Unknown5 = 5,
         Unknown6 = 6,
         Unknown7 = 7,

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
+{
+    interface IClientFrameworkMemory655 : IClientFrameworkMemory { }
+
+    // Note: The struct size/offsets and `clientFrameworkSignature` are based on
+    // older versions of FFXIVClientStructs. These can't be validated against
+    // the current global client, but they also appear to have been stable for
+    // multiple releases prior to 7.0.  Including them here so there is at least
+    // some support for ko/cn clients until they are on 7.0.
+    public class ClientFrameworkMemory655 : ClientFrameworkMemory, IClientFrameworkMemory655
+    {
+        // FFXIVClientStructs.FFXIV.Client.System.Framework.Framework
+        [StructLayout(LayoutKind.Explicit, Size = 0x35C8)]
+        public unsafe partial struct ClientFrameworkStruct
+        {
+            [FieldOffset(0x0580)]
+            public byte ClientLanguage;
+        }
+
+        private const string clientFrameworkSignature = "440FB6C0488B0D????????";
+        private const int clientFrameworkSignatureOffset = -4;
+
+        public ClientFrameworkMemory655(TinyIoCContainer container) : base(container, clientFrameworkSignature, clientFrameworkSignatureOffset) { }
+
+        public override Version GetVersion()
+        {
+            return new Version(6, 5, 5);
+        }
+
+        public unsafe ClientFramework GetClientFramework()
+        {
+            var ret = new ClientFramework();
+            if (!IsValid())
+            {
+                return ret;
+            }
+
+            if (clientFrameworkAddress == IntPtr.Zero)
+            {
+                return ret;
+            }
+
+            try
+            {
+                var clientFramework = ManagedType<ClientFrameworkStruct>.GetManagedTypeFromIntPtr(clientFrameworkAddress, memory).ToType();
+                ret.clientLanguage = (ClientLang)clientFramework.ClientLanguage;
+                ret.foundLanguage = true;
+            }
+            catch (Exception ex)
+            {
+                logger.Log(LogLevel.Error, "Failed to read client language: {0}", ex);
+            }
+            return ret;
+        }
+
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655.cs
@@ -11,16 +11,8 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
     // the current global client, but they also appear to have been stable for
     // multiple releases prior to 7.0.  Including them here so there is at least
     // some support for ko/cn clients until they are on 7.0.
-    public class ClientFrameworkMemory655 : ClientFrameworkMemory, IClientFrameworkMemory655
+    partial class ClientFrameworkMemory655 : ClientFrameworkMemory, IClientFrameworkMemory655
     {
-        // FFXIVClientStructs.FFXIV.Client.System.Framework.Framework
-        [StructLayout(LayoutKind.Explicit, Size = 0x35C8)]
-        public unsafe partial struct ClientFrameworkStruct
-        {
-            [FieldOffset(0x0580)]
-            public byte ClientLanguage;
-        }
-
         private const string clientFrameworkSignature = "440FB6C0488B0D????????";
         private const int clientFrameworkSignatureOffset = -4;
 
@@ -46,7 +38,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
 
             try
             {
-                var clientFramework = ManagedType<ClientFrameworkStruct>.GetManagedTypeFromIntPtr(clientFrameworkAddress, memory).ToType();
+                var clientFramework = ManagedType<Framework>.GetManagedTypeFromIntPtr(clientFrameworkAddress, memory).ToType();
                 ret.clientLanguage = (ClientLang)clientFramework.ClientLanguage;
                 ret.foundLanguage = true;
             }

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655ClientStructs.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655ClientStructs.cs
@@ -4,8 +4,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
 {
     partial class ClientFrameworkMemory655 : ClientFrameworkMemory, IClientFrameworkMemory655
     {
-        // Due to lack of multi-version support in FFXIVClientStructs, we need to duplicate these structures here per-version
-        // We use FFXIVClientStructs versions of the structs because they have more required details than FFXIV_ACT_Plugin's struct definitions
         // Many offsets are commented because they are typed and we don't need to bother with them.
         #region FFXIVClientStructs structs
         [StructLayout(LayoutKind.Explicit, Size = 0x35C8)]

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655ClientStructs.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory655ClientStructs.cs
@@ -1,0 +1,87 @@
+﻿using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
+{
+    partial class ClientFrameworkMemory655 : ClientFrameworkMemory, IClientFrameworkMemory655
+    {
+        // Due to lack of multi-version support in FFXIVClientStructs, we need to duplicate these structures here per-version
+        // We use FFXIVClientStructs versions of the structs because they have more required details than FFXIV_ACT_Plugin's struct definitions
+        // Many offsets are commented because they are typed and we don't need to bother with them.
+        #region FFXIVClientStructs structs
+        [StructLayout(LayoutKind.Explicit, Size = 0x35C8)]
+        public unsafe partial struct Framework
+        {
+            // [FieldOffset(0x0010)] public SystemConfig SystemConfig;
+            // [FieldOffset(0x0460)] public DevConfig DevConfig;
+            // [FieldOffset(0x0570)] public SavedAppearanceManager* SavedAppearanceData;
+            [FieldOffset(0x0580)] public byte ClientLanguage;
+            [FieldOffset(0x0581)] public byte Region;
+            // [FieldOffset(0x0588)] public Cursor* Cursor;
+            // [FieldOffset(0x0590)] public nint CallerWindow;
+            // [FieldOffset(0x0598)] public FileAccessPath ConfigPath;
+            // [FieldOffset(0x07A8)] public GameWindow* GameWindow;
+
+            [FieldOffset(0x09F8)] public int CursorPosX;
+            [FieldOffset(0x09FC)] public int CursorPosY;
+
+            [FieldOffset(0x1104)] public int CursorPosX2;
+            [FieldOffset(0x1108)] public int CursorPosY2;
+
+            // [FieldOffset(0x1670)] public NetworkModuleProxy* NetworkModuleProxy;
+            [FieldOffset(0x1678)] public bool IsNetworkModuleInitialized;
+            [FieldOffset(0x1679)] public bool EnableNetworking;
+            // [FieldOffset(0x1680)] public TimePoint UtcTime;
+            [FieldOffset(0x1698)] public uint TimerResolutionMillis;
+            [FieldOffset(0x16A0)] public long PerformanceCounterFrequency;
+            [FieldOffset(0x16A8)] public long PerformanceCounterValue;
+            [FieldOffset(0x16B8)] public float FrameDeltaTime;
+            [FieldOffset(0x16BC)] public float RealFrameDeltaTime;
+            [FieldOffset(0x16C0)] public float FrameDeltaTimeOverride;
+            [FieldOffset(0x16C4)] public float FrameDeltaFactor;
+            [FieldOffset(0x16C8)] public uint FrameCounter;
+            [FieldOffset(0x16D0)] public long FrameDeltaTimeMSInt;
+            [FieldOffset(0x16D8)] public float FrameDeltaTimeMSRem;
+            [FieldOffset(0x16E0)] public long FrameDeltaTimeUSInt;
+            [FieldOffset(0x16E8)] public float FrameDeltaTimeUSRem;
+            // [FieldOffset(0x16F8)] public TaskManager TaskManager;
+            // [FieldOffset(0x1768)] public ClientTime ClientTime;
+            [FieldOffset(0x17B0)] public float GameSpeedMultiplier;
+            [FieldOffset(0x17C4)] public float FrameRate;
+            [FieldOffset(0x17C8)] public bool DiscardFrame;
+            [FieldOffset(0x17CC)] public float NextFrameDeltaTimeOverride;
+            [FieldOffset(0x17D0)] public bool WindowInactive;
+
+            [FieldOffset(0x17E0)] public int DataPathType;
+
+            // [FieldOffset(0x19EC), FixedSizeArray(isString: true)] internal FixedSizeArray260<char> _gamePath;
+            // [FieldOffset(0x1DFC), FixedSizeArray(isString: true)] internal FixedSizeArray260<char> _sqPackPath;
+            // [FieldOffset(0x220C), FixedSizeArray(isString: true)] internal FixedSizeArray260<char> _userPath;
+
+            // [FieldOffset(0x2B30)] public ExcelModuleInterface* ExcelModuleInterface;
+            // [FieldOffset(0x2B38)] public ExdModule* ExdModule;
+            // [FieldOffset(0x2B50)] public BGCollisionModule* BGCollisionModule;
+            // [FieldOffset(0x2B60)] public UIModule* UIModule;
+            // [FieldOffset(0x2B68)] public UIClipboard* UIClipboard;
+            // [FieldOffset(0x2B78)] public EnvironmentManager* EnvironmentManager;
+            // [FieldOffset(0x2B80)] public SoundManager* SoundManager;
+            // [FieldOffset(0x2BC8)] public LuaState LuaState;
+
+            // [FieldOffset(0x2BF0), FixedSizeArray(isString: true)] internal FixedSizeArray256<byte> _gameVersion;
+            // [FieldOffset(0x2CF0 + 0 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex1Version; // Heavensward
+            // [FieldOffset(0x2CF0 + 1 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex2Version; // Stormblood
+            // [FieldOffset(0x2CF0 + 2 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex3Version; // Shadowbringers
+            // [FieldOffset(0x2CF0 + 3 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex4Version; // Endwalker
+            // [FieldOffset(0x2CF0 + 4 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex5Version; // Dawntrail
+
+            [FieldOffset(0x3500)] public bool UseWatchDogThread;
+
+            [FieldOffset(0x3510)] public int FramesUntilDebugCheck;
+            [FieldOffset(0x35B4)] public bool IsSteamGame;
+
+            // [FieldOffset(0x35B8)] public SteamApi* SteamApi;
+
+            // [FieldOffset(0x35C0)] public nint SteamApiLibraryHandle;
+        }
+        #endregion
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70.cs
@@ -6,20 +6,14 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
 {
     interface IClientFrameworkMemory70 : IClientFrameworkMemory { }
 
-    public class ClientFrameworkMemory70 : ClientFrameworkMemory, IClientFrameworkMemory70
+    partial class ClientFrameworkMemory70 : ClientFrameworkMemory, IClientFrameworkMemory70
     {
-        // FFXIVClientStructs.FFXIV.Client.System.Framework.Framework
-        [StructLayout(LayoutKind.Explicit, Size = 0x35D0)]
-        public unsafe partial struct ClientFrameworkStruct
-        {
-            [FieldOffset(0x0580)]
-            public byte ClientLanguage;
-        }
-
         private const string clientFrameworkSignature = "498BDC48891D????????";
         private const int clientFrameworkSignatureOffset = -4;
 
-        public ClientFrameworkMemory70(TinyIoCContainer container) : base(container, clientFrameworkSignature, clientFrameworkSignatureOffset) { }
+        public ClientFrameworkMemory70(TinyIoCContainer container)
+            : base(container, clientFrameworkSignature, clientFrameworkSignatureOffset)
+        { }
 
         public override Version GetVersion()
         {
@@ -41,7 +35,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
 
             try
             {
-                var clientFramework = ManagedType<ClientFrameworkStruct>.GetManagedTypeFromIntPtr(clientFrameworkAddress, memory).ToType();
+                var clientFramework = ManagedType<Framework>.GetManagedTypeFromIntPtr(clientFrameworkAddress, memory).ToType();
                 ret.clientLanguage = (ClientLang)clientFramework.ClientLanguage;
                 ret.foundLanguage = true;
             }

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using RainbowMage.OverlayPlugin.MemoryProcessors.FFXIVClientStructs;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
+{
+    interface IClientFrameworkMemory70 : IClientFrameworkMemory { }
+
+    public class ClientFrameworkMemory70 : ClientFrameworkMemory, IClientFrameworkMemory70
+    {
+        // FFXIVClientStructs.FFXIV.Client.System.Framework.Framework
+        [StructLayout(LayoutKind.Explicit, Size = 0x35D0)]
+        public unsafe partial struct ClientFrameworkStruct
+        {
+            [FieldOffset(0x0580)]
+            public byte ClientLanguage;
+        }
+
+        private const string clientFrameworkSignature = "498BDC48891D????????";
+        private const int clientFrameworkSignatureOffset = -4;
+
+        public ClientFrameworkMemory70(TinyIoCContainer container) : base(container, clientFrameworkSignature, clientFrameworkSignatureOffset) { }
+
+        public override Version GetVersion()
+        {
+            return new Version(7, 0);
+        }
+
+        public unsafe ClientFramework GetClientFramework()
+        {
+            var ret = new ClientFramework();
+            if (!IsValid())
+            {
+                return ret;
+            }
+
+            if (clientFrameworkAddress == IntPtr.Zero)
+            {
+                return ret;
+            }
+
+            try
+            {
+                var clientFramework = ManagedType<ClientFrameworkStruct>.GetManagedTypeFromIntPtr(clientFrameworkAddress, memory).ToType();
+                ret.clientLanguage = (ClientLang)clientFramework.ClientLanguage;
+                ret.foundLanguage = true;
+            }
+            catch (Exception ex)
+            {
+                logger.Log(LogLevel.Error, "Failed to read client language: {0}", ex);
+            }
+            return ret;
+        }
+
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70ClientStructs.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70ClientStructs.cs
@@ -1,0 +1,87 @@
+﻿using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
+{
+    partial class ClientFrameworkMemory70 : ClientFrameworkMemory, IClientFrameworkMemory70
+    {
+        // Due to lack of multi-version support in FFXIVClientStructs, we need to duplicate these structures here per-version
+        // We use FFXIVClientStructs versions of the structs because they have more required details than FFXIV_ACT_Plugin's struct definitions
+        // Many offsets are commented because they are typed and we don't need to bother with them.
+        #region FFXIVClientStructs structs
+        [StructLayout(LayoutKind.Explicit, Size = 0x35D0)]
+        public unsafe partial struct Framework
+        {
+            // [FieldOffset(0x0010)] public SystemConfig SystemConfig;
+            // [FieldOffset(0x0460)] public DevConfig DevConfig;
+            // [FieldOffset(0x0570)] public SavedAppearanceManager* SavedAppearanceData;
+            [FieldOffset(0x0580)] public byte ClientLanguage;
+            [FieldOffset(0x0581)] public byte Region;
+            // [FieldOffset(0x0588)] public Cursor* Cursor;
+            // [FieldOffset(0x0590)] public nint CallerWindow;
+            // [FieldOffset(0x0598)] public FileAccessPath ConfigPath;
+            // [FieldOffset(0x07A8)] public GameWindow* GameWindow;
+
+            [FieldOffset(0x09FC)] public int CursorPosX;
+            [FieldOffset(0x0A00)] public int CursorPosY;
+
+            [FieldOffset(0x110C)] public int CursorPosX2;
+            [FieldOffset(0x1110)] public int CursorPosY2;
+
+            // [FieldOffset(0x1678)] public NetworkModuleProxy* NetworkModuleProxy;
+            [FieldOffset(0x1680)] public bool IsNetworkModuleInitialized;
+            [FieldOffset(0x1681)] public bool EnableNetworking;
+            // [FieldOffset(0x1688)] public TimePoint UtcTime;
+            [FieldOffset(0x16A0)] public uint TimerResolutionMillis;
+            [FieldOffset(0x16A8)] public long PerformanceCounterFrequency;
+            [FieldOffset(0x16B0)] public long PerformanceCounterValue;
+            [FieldOffset(0x16C0)] public float FrameDeltaTime;
+            [FieldOffset(0x16C4)] public float RealFrameDeltaTime;
+            [FieldOffset(0x16C8)] public float FrameDeltaTimeOverride;
+            [FieldOffset(0x16CC)] public float FrameDeltaFactor;
+            [FieldOffset(0x16D0)] public uint FrameCounter;
+            [FieldOffset(0x16D8)] public long FrameDeltaTimeMSInt;
+            [FieldOffset(0x16E0)] public float FrameDeltaTimeMSRem;
+            [FieldOffset(0x16E8)] public long FrameDeltaTimeUSInt;
+            [FieldOffset(0x16F0)] public float FrameDeltaTimeUSRem;
+            // [FieldOffset(0x1700)] public TaskManager TaskManager;
+            // [FieldOffset(0x1770)] public ClientTime ClientTime;
+            [FieldOffset(0x17B8)] public float GameSpeedMultiplier;
+            [FieldOffset(0x17CC)] public float FrameRate;
+            [FieldOffset(0x17D0)] public bool DiscardFrame;
+            [FieldOffset(0x17D4)] public float NextFrameDeltaTimeOverride;
+            [FieldOffset(0x17D8)] public bool WindowInactive;
+
+            [FieldOffset(0x17E8)] public int DataPathType;
+
+            // [FieldOffset(0x19F4), FixedSizeArray(isString: true)] internal FixedSizeArray260<char> _gamePath;
+            // [FieldOffset(0x1E04), FixedSizeArray(isString: true)] internal FixedSizeArray260<char> _sqPackPath;
+            // [FieldOffset(0x2214), FixedSizeArray(isString: true)] internal FixedSizeArray260<char> _userPath;
+
+            // [FieldOffset(0x2B38)] public ExcelModuleInterface* ExcelModuleInterface;
+            // [FieldOffset(0x2B40)] public ExdModule* ExdModule;
+            // [FieldOffset(0x2B58)] public BGCollisionModule* BGCollisionModule;
+            // [FieldOffset(0x2B68)] public UIModule* UIModule;
+            // [FieldOffset(0x2B70)] public UIClipboard* UIClipboard;
+            // [FieldOffset(0x2B80)] public EnvironmentManager* EnvironmentManager;
+            // [FieldOffset(0x2B88)] public SoundManager* SoundManager;
+            // [FieldOffset(0x2BD0)] public LuaState LuaState;
+
+            // [FieldOffset(0x2BF8), FixedSizeArray(isString: true)] internal FixedSizeArray256<byte> _gameVersion;
+            // [FieldOffset(0x2CF8 + 0 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex1Version; // Heavensward
+            // [FieldOffset(0x2CF8 + 1 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex2Version; // Stormblood
+            // [FieldOffset(0x2CF8 + 2 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex3Version; // Shadowbringers
+            // [FieldOffset(0x2CF8 + 3 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex4Version; // Endwalker
+            // [FieldOffset(0x2CF8 + 4 * 0x20), FixedSizeArray(isString: true)] internal FixedSizeArray32<byte> _ex5Version; // Dawntrail
+
+            [FieldOffset(0x3508)] public bool UseWatchDogThread;
+
+            [FieldOffset(0x3518)] public int FramesUntilDebugCheck;
+            [FieldOffset(0x35BC)] public bool IsSteamGame;
+
+            // [FieldOffset(0x35C0)] public SteamApi* SteamApi;
+
+            // [FieldOffset(0x35C8)] public nint SteamApiLibraryHandle;
+        }
+        #endregion
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70ClientStructs.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemory70ClientStructs.cs
@@ -4,8 +4,6 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
 {
     partial class ClientFrameworkMemory70 : ClientFrameworkMemory, IClientFrameworkMemory70
     {
-        // Due to lack of multi-version support in FFXIVClientStructs, we need to duplicate these structures here per-version
-        // We use FFXIVClientStructs versions of the structs because they have more required details than FFXIV_ACT_Plugin's struct definitions
         // Many offsets are commented because they are typed and we don't need to bother with them.
         #region FFXIVClientStructs structs
         [StructLayout(LayoutKind.Explicit, Size = 0x35D0)]

--- a/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ClientFramework/ClientFrameworkMemoryManager.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework
+{
+    public interface IClientFrameworkMemory : IVersionedMemory
+    {
+        ClientFramework GetClientFramework();
+    }
+
+    class ClientFrameworkMemoryManager : IClientFrameworkMemory
+    {
+        private readonly TinyIoCContainer container;
+        private readonly FFXIVRepository repository;
+        private IClientFrameworkMemory memory = null;
+
+        public ClientFrameworkMemoryManager(TinyIoCContainer container)
+        {
+            this.container = container;
+            container.Register<IClientFrameworkMemory70, ClientFrameworkMemory70>();
+            container.Register<IClientFrameworkMemory655, ClientFrameworkMemory655>();
+            repository = container.Resolve<FFXIVRepository>();
+
+            var ffxivMemory = container.Resolve<FFXIVMemory>();
+            ffxivMemory.RegisterOnProcessChangeHandler(FindMemory);
+        }
+
+        private void FindMemory(object sender, Process p)
+        {
+            memory = null;
+            if (p == null)
+            {
+                return;
+            }
+            ScanPointers();
+        }
+
+        public void ScanPointers()
+        {
+            List<IClientFrameworkMemory> candidates = new List<IClientFrameworkMemory>();
+            candidates.Add(container.Resolve<IClientFrameworkMemory70>());
+            candidates.Add(container.Resolve<IClientFrameworkMemory655>());
+            memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
+        }
+
+        public bool IsValid()
+        {
+            if (memory == null || !memory.IsValid())
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public Version GetVersion()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetVersion();
+        }
+
+        public ClientFramework GetClientFramework()
+        {
+            if (!IsValid())
+                return null;
+            return memory.GetClientFramework();
+        }
+    }
+}

--- a/OverlayPlugin.Core/PluginMain.cs
+++ b/OverlayPlugin.Core/PluginMain.cs
@@ -14,6 +14,7 @@ using RainbowMage.OverlayPlugin.EventSources;
 using RainbowMage.OverlayPlugin.MemoryProcessors;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Aggro;
 using RainbowMage.OverlayPlugin.MemoryProcessors.AtkStage;
+using RainbowMage.OverlayPlugin.MemoryProcessors.ClientFramework;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Combatant;
 using RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings;
 using RainbowMage.OverlayPlugin.MemoryProcessors.Enmity;
@@ -272,6 +273,7 @@ namespace RainbowMage.OverlayPlugin
                                     // These are registered to be lazy-loaded. Use interface to force TinyIoC to use singleton pattern.
                                     _container.Register<ICombatantMemory, CombatantMemoryManager>();
                                     _container.Register<ITargetMemory, TargetMemoryManager>();
+                                    _container.Register<IClientFrameworkMemory, ClientFrameworkMemoryManager>();
                                     _container
                                         .Register<IContentFinderSettingsMemory, ContentFinderSettingsMemoryManager>();
                                     _container.Register<IAggroMemory, AggroMemoryManager>();


### PR DESCRIPTION
This adds the current game client language to the tech support clipboard output.  Tested & working with the current global client, but I can't validate that that the pre-7.0 signatures work with current `cn`/`ko` clients (nor can I determine what their language byte is), so would appreciate if anyone on those clients is able to test and provide that info.  But this will at least return values for unknown languages in the meantime, and it can always be supplemented later.

I haven't mucked around much with this part of the code before, so apologies in advance for any dumb stuff.