### PR TITLE
Version bump to 0.19.38

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
         <Copyright>Copyright © RainbowMage 2015, Kuriyama hibiya 2016, ngld 2019, OverlayPlugin Team 2022</Copyright>
         <RunCodeAnalysis>false</RunCodeAnalysis>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <AssemblyVersion>0.19.37</AssemblyVersion>
-        <FileVersion>0.19.37</FileVersion>
+        <AssemblyVersion>0.19.38</AssemblyVersion>
+        <FileVersion>0.19.38</FileVersion>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>


### PR DESCRIPTION
CN Dawntrail bump per discussion on #399.  @MnFeN @ShadyWhite @Ra-Workspace please version bump when needed for CN or KR, most of us don't have any visibility to what's going on with the non-international release schedule.