### PR TITLE
feat: Add missing enum values and adjust data logic for combatants

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory70.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory70.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -68,48 +68,41 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     Heading = mem.Heading,
                     Radius = mem.Radius,
                     // In-memory there are separate values for PC's current target and NPC's current target
-                    TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
-                    CurrentHP = mem.CurrentHP,
-                    MaxHP = mem.MaxHP,
-                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
-
-                    BNpcID = mem.BNpcID,
-                    CurrentMP = mem.CurrentMP,
-                    MaxMP = mem.MaxMP,
-                    CurrentGP = mem.CurrentGP,
-                    MaxGP = mem.MaxGP,
-                    CurrentCP = mem.CurrentCP,
-                    MaxCP = mem.MaxCP,
-                    Level = mem.Level,
+                    TargetID = ((ObjectType)mem.Type == ObjectType.PC || (ObjectType)mem.Type == ObjectType.Retainer) ? mem.PCTargetID : mem.NPCTargetID,
+                    BNpcID = mem.BNpcID,   
                     PCTargetID = mem.PCTargetID,
-
                     BNpcNameID = mem.BNpcNameID,
-
                     WorldID = mem.WorldID,
                     CurrentWorldID = mem.CurrentWorldID,
-
-                    IsCasting1 = mem.IsCasting1,
-                    IsCasting2 = mem.IsCasting2,
-                    CastBuffID = mem.CastBuffID,
-                    CastTargetID = mem.CastTargetID,
-                    // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
-                    CastGroundTargetX = mem.CastGroundTargetX,
-                    CastGroundTargetY = mem.CastGroundTargetZ,
-                    CastGroundTargetZ = mem.CastGroundTargetY,
-                    CastDurationCurrent = mem.CastDurationCurrent,
-                    CastDurationMax = mem.CastDurationMax,
-
-                    TransformationId = mem.TransformationId,
-                    WeaponId = mem.WeaponId
                 };
                 combatant.IsTargetable =
                     (combatant.ModelStatus == ModelStatus.Visible)
                     && ((combatant.Status == ObjectStatus.NormalActorStatus) || (combatant.Status == ObjectStatus.NormalSubActorStatus));
-                if (combatant.Type != ObjectType.PC && combatant.Type != ObjectType.Monster)
+                if (combatant.Type == ObjectType.PC || combatant.Type == ObjectType.Monster || combatant.Type == ObjectType.NPC || combatant.Type == ObjectType.Retainer)
                 {
-                    // Other types have garbage memory for hp.
-                    combatant.CurrentHP = 0;
-                    combatant.MaxHP = 0;
+                    // Other types have garbage memory for at least the data below:
+                    combatant.Level = mem.Level;
+                    combatant.CurrentHP = mem.CurrentHP;
+                    combatant.MaxHP = mem.MaxHP;
+                    combatant.CurrentMP = mem.CurrentMP;
+                    combatant.MaxMP = mem.MaxMP;
+                    combatant.CurrentCP = mem.CurrentCP;
+                    combatant.MaxCP = mem.MaxCP;
+                    combatant.CurrentGP = mem.CurrentGP;
+                    combatant.MaxGP = mem.MaxGP;
+                    combatant.Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID);
+                    combatant.IsCasting1 = mem.IsCasting1;
+                    combatant.IsCasting2 = mem.IsCasting2;
+                    combatant.CastBuffID = mem.CastBuffID;
+                    combatant.CastTargetID = mem.CastTargetID;
+                    // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
+                    combatant.CastGroundTargetX = mem.CastGroundTargetX;
+                    combatant.CastGroundTargetY = mem.CastGroundTargetZ;
+                    combatant.CastGroundTargetZ = mem.CastGroundTargetY;
+                    combatant.CastDurationCurrent = mem.CastDurationCurrent;
+                    combatant.CastDurationMax = mem.CastDurationMax;
+                    combatant.TransformationId = mem.TransformationId;
+                    combatant.WeaponId = mem.WeaponId;
                 }
                 return combatant;
             }

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/Common.cs
@@ -1,17 +1,28 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
 {
+    // PC, Monster, NPC, Treasure, Gathering, EventObj, Retainer, AreaObject, HousingEventObject could be retrieved by GetCombatantList()
     public enum ObjectType : byte
     {
-        Unknown = 0x00,
-        PC = 0x01,
-        Monster = 0x02,
-        NPC = 0x03,
-        Aetheryte = 0x05,
-        Gathering = 0x06,
-        Minion = 0x09
+        Unknown = 0,
+        PC = 1,
+        Monster = 2,        // FFCS: BattleNpc
+        NPC = 3,            // FFCS: EventNpc 
+        Treasure = 4, 
+        Aetheryte = 5,
+        Gathering = 6,      // FFCS: GatheringPoint
+        EventObj = 7,
+        Mount = 8,
+        Minion = 9,         // FFCS: Companion
+        Retainer = 10,
+        AreaObject = 11,
+        HousingEventObject = 12,
+        Cutscene = 13,
+        MjiObject = 14,
+        Ornament = 15,
+        CardStand = 16
     }
 
     /// <summary>A byte offset by 0x1980 from the combatant's address that further describes the combatant if their ObjectType is a Monster.</summary>


### PR DESCRIPTION
[feat: Add enum values that are available but not included in the ObjectType enum](https://github.com/OverlayPlugin/OverlayPlugin/commit/530ea0677f066e562a65aba4d18db8a49dbd809c) 

from FFCS  
The types that could be retreived by GetCombatantList() and not included before:  
```
        Treasure = 4, 
        EventObj = 7,
        Retainer = 10,
        AreaObject = 11,
        HousingEventObject = 12,
```

[feat: Adjust logic for populating data for specific entity types](https://github.com/OverlayPlugin/OverlayPlugin/commit/b60b1b23b21655edfa2b59f52cb1f323f665f079) 

Retainer is similar to a real PC player;  
EventNPC does not contain junk data (except `PCTargetID`);  
For the other types, more data fields with junk data are ignored.  

This could also help reducing non-default garbage values in certain log lines.  