### PR TITLE
7.1 Global Signature and Structure updates

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory71.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory71.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
+{
+    interface ICombatantMemory71 : ICombatantMemory { }
+
+    class CombatantMemory71 : CombatantMemory, ICombatantMemory71
+    {
+        private const string charmapSignature = "488B5720B8000000E0483BD00F84????????488D0D";
+
+        public CombatantMemory71(TinyIoCContainer container)
+            : base(container, charmapSignature, CombatantMemory.Size, EffectMemory.Size, 629)
+        {
+
+        }
+
+        public override Version GetVersion()
+        {
+            return new Version(7, 1);
+        }
+
+        // Returns a combatant if the combatant is a mob or a PC.
+        protected override unsafe Combatant GetMobFromByteArray(byte[] source, uint mycharID)
+        {
+            fixed (byte* p = source)
+            {
+                CombatantMemory mem = *(CombatantMemory*)&p[0];
+                ObjectType type = (ObjectType)mem.Type;
+                if (mem.ID == 0 || mem.ID == emptyID)
+                    return null;
+            }
+            return GetCombatantFromByteArray(source, mycharID, false);
+        }
+
+        // Will return any kind of combatant, even if not a mob.
+        // This function always returns a combatant object, even if empty.
+        protected override unsafe Combatant GetCombatantFromByteArray(byte[] source, uint mycharID, bool isPlayer, bool exceptEffects = false)
+        {
+            fixed (byte* p = source)
+            {
+                CombatantMemory mem = *(CombatantMemory*)&p[0];
+
+                if (isPlayer)
+                {
+                    mycharID = mem.ID;
+                }
+
+                Combatant combatant = new Combatant()
+                {
+                    Name = FFXIVMemory.GetStringFromBytes(mem.Name, CombatantMemory.NameBytes),
+                    Job = mem.Job,
+                    ID = mem.ID,
+                    OwnerID = mem.OwnerID == emptyID ? 0 : mem.OwnerID,
+                    Type = (ObjectType)mem.Type,
+                    MonsterType = 0,
+                    Status = (ObjectStatus)mem.Status,
+                    ModelStatus = (ModelStatus)mem.ModelStatus,
+                    // Normalize all possible aggression statuses into the basic 4 ones.
+                    AggressionStatus = 0,
+                    NPCTargetID = mem.NPCTargetID,
+                    RawEffectiveDistance = mem.EffectiveDistance,
+                    PosX = mem.PosX,
+                    // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
+                    PosY = mem.PosZ,
+                    PosZ = mem.PosY,
+                    Heading = mem.Heading,
+                    Radius = mem.Radius,
+                    // In-memory there are separate values for PC's current target and NPC's current target
+                    TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
+                    CurrentHP = mem.CurrentHP,
+                    MaxHP = mem.MaxHP,
+                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+
+                    BNpcID = mem.BNpcID,
+                    CurrentMP = mem.CurrentMP,
+                    MaxMP = mem.MaxMP,
+                    CurrentGP = mem.CurrentGP,
+                    MaxGP = mem.MaxGP,
+                    CurrentCP = mem.CurrentCP,
+                    MaxCP = mem.MaxCP,
+                    Level = mem.Level,
+                    PCTargetID = mem.PCTargetID,
+
+                    BNpcNameID = mem.BNpcNameID,
+
+                    WorldID = mem.WorldID,
+                    CurrentWorldID = mem.CurrentWorldID,
+
+                    IsCasting1 = mem.IsCasting1,
+                    IsCasting2 = mem.IsCasting2,
+                    CastBuffID = mem.CastBuffID,
+                    CastTargetID = mem.CastTargetID,
+                    // Y and Z are deliberately swapped to match FFXIV_ACT_Plugin's data model
+                    CastGroundTargetX = mem.CastGroundTargetX,
+                    CastGroundTargetY = mem.CastGroundTargetZ,
+                    CastGroundTargetZ = mem.CastGroundTargetY,
+                    CastDurationCurrent = mem.CastDurationCurrent,
+                    CastDurationMax = mem.CastDurationMax,
+
+                    TransformationId = mem.TransformationId,
+                    WeaponId = mem.WeaponId
+                };
+                combatant.IsTargetable =
+                    (combatant.ModelStatus == ModelStatus.Visible)
+                    && ((combatant.Status == ObjectStatus.NormalActorStatus) || (combatant.Status == ObjectStatus.NormalSubActorStatus));
+                if (combatant.Type != ObjectType.PC && combatant.Type != ObjectType.Monster)
+                {
+                    // Other types have garbage memory for hp.
+                    combatant.CurrentHP = 0;
+                    combatant.MaxHP = 0;
+                }
+                return combatant;
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private unsafe struct CombatantMemory
+        {
+            public static int Size => Marshal.SizeOf(typeof(CombatantMemory));
+
+            // 64 bytes per both FFXIV_ACT_Plugin and aers/FFXIVClientStructs
+            public const int NameBytes = 64;
+
+            public const int EffectCount = 60;
+            public const int EffectBytes = EffectMemory.Size * EffectCount;
+
+            [FieldOffset(0x30)]
+            public fixed byte Name[NameBytes];
+
+            [FieldOffset(0x74)]
+            public uint ID;
+
+            [FieldOffset(0x80)]
+            public uint BNpcID;
+
+            [FieldOffset(0x84)]
+            public uint OwnerID;
+
+            [FieldOffset(0x8C)]
+            public byte Type;
+
+            [FieldOffset(0x92)]
+            public byte EffectiveDistance;
+
+            [FieldOffset(0x94)]
+            public byte Status;
+
+            [FieldOffset(0xB0)]
+            public Single PosX;
+
+            [FieldOffset(0xB4)]
+            public Single PosY;
+
+            [FieldOffset(0xB8)]
+            public Single PosZ;
+
+            [FieldOffset(0xC0)]
+            public Single Heading;
+
+            [FieldOffset(0xD0)]
+            public Single Radius;
+
+            [FieldOffset(0x104)]
+            public int ModelStatus;
+
+            [FieldOffset(0x1AC)]
+            public int CurrentHP;
+
+            [FieldOffset(0x1B0)]
+            public int MaxHP;
+
+            [FieldOffset(0x1B4)]
+            public int CurrentMP;
+
+            [FieldOffset(0x1B8)]
+            public int MaxMP;
+
+            [FieldOffset(0x1BC)]
+            public ushort CurrentGP;
+
+            [FieldOffset(0x1BE)]
+            public ushort MaxGP;
+
+            [FieldOffset(0x1C0)]
+            public ushort CurrentCP;
+
+            [FieldOffset(0x1C2)]
+            public ushort MaxCP;
+
+            [FieldOffset(0x1C4)]
+            public short TransformationId;
+
+            [FieldOffset(0x1CA)]
+            public byte Job;
+
+            [FieldOffset(0x1CB)]
+            public byte Level;
+
+            [FieldOffset(0xC70)]
+            public byte WeaponId;
+
+            // TODO: Verify for 7.1. Could potentially be 0xD50, 0xF30, 0x1110
+            [FieldOffset(0xD50)]
+            public uint PCTargetID;
+
+            // TODO: Verify for 7.1. Could potentially be 0x19EC or 0x2288
+            [FieldOffset(0x2288)]
+            public uint NPCTargetID;
+
+            [FieldOffset(0x22B4)]
+            public uint BNpcNameID;
+
+            [FieldOffset(0x22D8)]
+            public ushort CurrentWorldID;
+
+            [FieldOffset(0x22DA)]
+            public ushort WorldID;
+
+            [FieldOffset(0x2338)]
+            public fixed byte Effects[EffectBytes];
+
+            [FieldOffset(0x2620)]
+            public byte IsCasting1;
+
+            [FieldOffset(0x2622)]
+            public byte IsCasting2;
+
+            [FieldOffset(0x2624)]
+            public uint CastBuffID;
+
+            [FieldOffset(0x2630)]
+            public uint CastTargetID;
+
+            [FieldOffset(0x2640)]
+            public float CastGroundTargetX;
+
+            [FieldOffset(0x2644)]
+            public float CastGroundTargetY;
+
+            [FieldOffset(0x2648)]
+            public float CastGroundTargetZ;
+
+            [FieldOffset(0x2654)]
+            public float CastDurationCurrent;
+
+            [FieldOffset(0x2658)]
+            public float CastDurationMax;
+
+            // Missing PartyType
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemoryManager.cs
@@ -23,6 +23,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             this.container = container;
             container.Register<ICombatantMemory65, CombatantMemory65>();
             container.Register<ICombatantMemory70, CombatantMemory70>();
+            container.Register<ICombatantMemory71, CombatantMemory71>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();
@@ -44,6 +45,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
             List<ICombatantMemory> candidates = new List<ICombatantMemory>();
             candidates.Add(container.Resolve<ICombatantMemory65>());
             candidates.Add(container.Resolve<ICombatantMemory70>());
+            candidates.Add(container.Resolve<ICombatantMemory71>());
             memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());
         }
 

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings71.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettings71.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
+{
+    interface IContentFinderSettingsMemory71 : IContentFinderSettingsMemory { }
+
+    class ContentFinderSettingsMemory71 : ContentFinderSettingsMemory, IContentFinderSettingsMemory71
+    {
+        // FUN_14184cea0:14184ceaa, DAT_142780dd0
+        private const string settingsSignature = "488D0D????????E8????????488BF84885C00F84????????488B4B??4889AC24";
+
+        // FUN_1400aa840:1400aa862
+        // IsLocalPlayerInParty:1400aa862 (after rename)
+        private const string inContentFinderSignature = "803D??????????74??E8????????488BC8";
+
+        public ContentFinderSettingsMemory71(TinyIoCContainer container)
+            : base(container, settingsSignature, inContentFinderSignature, -1)
+        { }
+
+        // For 7.0 and onwards, handle this properly.
+        // TODO: Once CN and KR are on 7.0, move this logic up to `ContentFinderSettings` for common use
+        public override void ScanPointers()
+        {
+            ResetPointers();
+            if (!memory.IsValid())
+                return;
+
+            List<string> fail = new List<string>();
+
+            List<IntPtr> list = memory.SigScan(settingsSignature, -29, true);
+            if (list != null && list.Count > 0)
+            {
+                settingsAddress = list[0] + 0xA8;
+            }
+            else
+            {
+                settingsAddress = IntPtr.Zero;
+                fail.Add(nameof(settingsAddress));
+            }
+
+            logger.Log(LogLevel.Debug, "settingsAddress: 0x{0:X}", settingsAddress.ToInt64());
+
+            list = memory.SigScan(inContentFinderSignature, -15, true, 1);
+            if (list != null && list.Count > 0)
+            {
+                inContentFinderAddress = list[0];
+            }
+            else
+            {
+                inContentFinderAddress = IntPtr.Zero;
+                fail.Add(nameof(inContentFinderAddress));
+            }
+
+            logger.Log(LogLevel.Debug, "inContentFinderAddress: 0x{0:X}", inContentFinderAddress.ToInt64());
+
+            if (fail.Count == 0)
+            {
+                logger.Log(LogLevel.Info, $"Found content finder settings memory via {GetType().Name}.");
+                return;
+            }
+
+            logger.Log(LogLevel.Error, $"Failed to find content finder settings memory via {GetType().Name}: {string.Join(", ", fail)}.");
+            return;
+        }
+
+        public override Version GetVersion()
+        {
+            return new Version(7, 1);
+        }
+    }
+}

--- a/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/ContentFinderSettings/ContentFinderSettingsMemoryManager.cs
@@ -34,6 +34,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
             this.container = container;
             container.Register<IContentFinderSettingsMemory651, ContentFinderSettingsMemory651>();
             container.Register<IContentFinderSettingsMemory70, ContentFinderSettingsMemory70>();
+            container.Register<IContentFinderSettingsMemory71, ContentFinderSettingsMemory71>();
             repository = container.Resolve<FFXIVRepository>();
 
             var memory = container.Resolve<FFXIVMemory>();
@@ -53,6 +54,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.ContentFinderSettings
         public void ScanPointers()
         {
             List<IContentFinderSettingsMemory> candidates = new List<IContentFinderSettingsMemory>();
+            candidates.Add(container.Resolve<IContentFinderSettingsMemory71>());
             candidates.Add(container.Resolve<IContentFinderSettingsMemory70>());
             candidates.Add(container.Resolve<IContentFinderSettingsMemory651>());
             memory = FFXIVMemory.FindCandidate(candidates, repository.GetMachinaRegion());

--- a/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineRSV.cs
@@ -6,36 +6,10 @@ using RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper;
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
 {
     class LineRSV : LineBaseCustom<
-            Server_MessageHeader_Global, LineRSV.RSV_v70,
+            Server_MessageHeader_Global, LineRSV.RSV_v62,
             Server_MessageHeader_CN, LineRSV.RSV_v62,
             Server_MessageHeader_KR, LineRSV.RSV_v62>
     {
-        [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
-        internal unsafe struct RSV_v70 : IPacketStruct
-        {
-            public const int structSize = 1080;
-            public const int keySize = 0x64;
-            public const int valueSize = 0x404;
-            [FieldOffset(0x0)]
-            public int valueByteCount;
-            [FieldOffset(0x4)]
-            public fixed byte key[keySize];
-            [FieldOffset(0x68)]
-            public fixed byte value[valueSize];
-
-            public string ToString(long epoch, uint ActorID)
-            {
-                fixed (byte* key = this.key) fixed (byte* value = this.value)
-                {
-                    return
-                        $"{ffxiv.GetLocaleString()}|" +
-                        $"{valueByteCount:X8}|" +
-                        $"{FFXIVMemory.GetStringFromBytes(key, keySize).Replace("\r", "\\r").Replace("\n", "\\n")}|" +
-                        $"{FFXIVMemory.GetStringFromBytes(value, Math.Min(valueByteCount, valueSize)).Replace("\r", "\\r").Replace("\n", "\\n")}";
-                }
-            }
-        }
-
         [StructLayout(LayoutKind.Explicit, Size = structSize, Pack = 1)]
         internal unsafe struct RSV_v62 : IPacketStruct
         {


### PR DESCRIPTION
- [x] Combatant list sigs (no change)
- [x] Combatant structs
- [x] InCombat sigs (no change)
- [x] InCombat offset (no change)
- [x] ContentFinder sigs (broken)
- [x] ContentFinder structs (unknown)
- [x] PartyMemory sigs (no change)
- [x] PartyMemory structs (unknown)
- [x] JobGauge sigs (no change)
- [x] JobGauge structs (unknown)
- [x] TargetMemory sigs (no change)
- [x] TargetMemory structs (unknown)
- [x] AggroMemory sigs (no change)
- [x] AggroMemory structs (unknown)
- [x] EnmityMemory sigs (no change)
- [x] EnmityMemory structs (unknown)
- [x] EnmityHUDMemory sigs (no change)
- [x] EnmityHUDMemory structs (unknown)
- [x] Packet struct changes are unknown for all packet types.
- [x] Only DoT/HoT AC category changed apparently? I manually verified everything except `DisplayPublicContentTextMessage`, which is a pain to actually check, and they were all the same for us AFAICT. ~~ActorControl categories have changed and will need to be verified.~~