### PR TITLE
Write out heading/rotation for ActionEffect1

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineAbilityExtra.cs
@@ -37,20 +37,20 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                     var abilityId = aeHeader.Get<uint>("actionId");
                     var globalEffectCounter = aeHeader.Get<uint>("globalEffectCounter");
 
+                    var h = FFXIVRepository.ConvertHeading(aeHeader.Get<ushort>("rotation"));
+
                     if (rawPacket.actionEffectCount == 1)
                     {
-                        // AE1 is not useful. It does not contain this data. But we still need to write something
-                        // to indicate that a proper line will not be happening.
+                        // AE1 only contains rotation.
                         return string.Format(CultureInfo.InvariantCulture,
-                            "{0:X8}|{1:X4}|{2:X8}|{3}||||",
-                            ActorID, abilityId, globalEffectCounter, (int)LineSubType.NO_DATA);
+                            "{0:X8}|{1:X4}|{2:X8}|{3}|||{4:F3}|",
+                            ActorID, abilityId, globalEffectCounter, (int)LineSubType.NO_DATA, h);
                     }
 
                     float x = FFXIVRepository.ConvertUInt16Coordinate(rawPacket.x);
                     float y = FFXIVRepository.ConvertUInt16Coordinate(rawPacket.y);
                     float z = FFXIVRepository.ConvertUInt16Coordinate(rawPacket.z);
 
-                    var h = FFXIVRepository.ConvertHeading(aeHeader.Get<ushort>("rotation"));
                     return string.Format(CultureInfo.InvariantCulture,
                         "{0:X8}|{1:X4}|{2:X8}|{3}|{4:F3}|{5:F3}|{6:F3}|{7:F3}",
                         ActorID, abilityId, globalEffectCounter, (int)LineSubType.DATA_PRESENT, x, y, z, h);

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -66,7 +66,7 @@
         "ID": 264,
         "Name": "AbilityExtra",
         "Source": "OverlayPlugin",
-        "Version": 1,
+        "Version": 2,
         "Comment": "Extra info from ActionEffect packets"
     },
     {


### PR DESCRIPTION
Contrary to my original logic, it is worth including the heading/rotation value for ActionEffect1. Not sure if this is a new optimization on SEs end or if I just missed it originally, but AoE skills can sometimes be sent from server to client as an AE1.

In light of this, I've updated the logic:
1. Rotation is always written
2. The "data present" flag now indicates whether or not a position might be present (same as before), but no longer implies anything about whether or not the rotation is present or not. 

Since the second item is technically a breakage of public API, let me know if you want a different approach. I bumpbed the "Version" of the line accordingly.