### PR TITLE
Preliminary support for bundled MapEffect packets

### DIFF
--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -459,7 +459,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 // Two blank fields at the end used to be $"{unknown1:X2}|{unknown2:X4}", turned out to be padding
                 // @TODO: Remove these fields at some point, this is a breaking change.
                 // @TODO: Since we'll be breaking things anyways, maybe separate flags out into two fields?
-                logWriter($"{strInstanceContentID}|{flag1:X4}{flag2:X4}|{index:X2}||", serverTime);
+                logWriter($"{strInstanceContentID}|{flag2:X4}{flag1:X4}|{index:X2}||", serverTime);
             }
         }
     }

--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -339,7 +339,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             Server_MessageHeader_CN, LineMapEffect.MapEffect8_v72,
             Server_MessageHeader_KR, LineMapEffect.MapEffect8_v72> packetHelper_8;
 
-        private  RegionalizedPacketHelper<
+        private RegionalizedPacketHelper<
             Server_MessageHeader_Global, LineMapEffect.MapEffect16_v72,
             Server_MessageHeader_CN, LineMapEffect.MapEffect16_v72,
             Server_MessageHeader_KR, LineMapEffect.MapEffect16_v72> packetHelper_16;
@@ -353,6 +353,12 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         protected override void MessageReceived(string id, long epoch, byte[] message)
         {
             if (MessageReceivedSubHandler(packetHelper, epoch, message))
+                return;
+            if (MessageReceivedSubHandler(packetHelper_4, epoch, message))
+                return;
+            if (MessageReceivedSubHandler(packetHelper_8, epoch, message))
+                return;
+            if (MessageReceivedSubHandler(packetHelper_16, epoch, message))
                 return;
         }
 
@@ -445,7 +451,8 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
                 // Two blank fields at the end used to be $"{unknown1:X2}|{unknown2:X4}", turned out to be padding
                 // @TODO: Remove these fields at some point, this is a breaking change.
-                logWriter($"{strInstanceContentID}|{flag1:X4}|{flag2:X4}|{index:X2}||", serverTime);
+                // @TODO: Since we'll be breaking things anyways, maybe separate flags out into two fields?
+                logWriter($"{strInstanceContentID}|{flag1:X4}{flag2:X4}|{index:X2}||", serverTime);
             }
         }
     }

--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -234,9 +234,9 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal unsafe struct MapEffect16_v72 : IPacketStruct, IMapEffectPacket
+        internal unsafe struct MapEffect12_v72 : IPacketStruct, IMapEffectPacket
         {
-            private const int MaxCount = 16;
+            private const int MaxCount = 12;
             public ushort count;
             public fixed ushort flags1[MaxCount];
             public fixed ushort flags2[MaxCount];
@@ -340,9 +340,9 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             Server_MessageHeader_KR, LineMapEffect.MapEffect8_v72> packetHelper_8;
 
         private RegionalizedPacketHelper<
-            Server_MessageHeader_Global, LineMapEffect.MapEffect16_v72,
-            Server_MessageHeader_CN, LineMapEffect.MapEffect16_v72,
-            Server_MessageHeader_KR, LineMapEffect.MapEffect16_v72> packetHelper_16;
+            Server_MessageHeader_Global, LineMapEffect.MapEffect12_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect12_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect12_v72> packetHelper_12;
 
         public LineMapEffect(TinyIoCContainer container)
             : base(container, LogFileLineID, logLineName, MachinaPacketName)
@@ -361,10 +361,10 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             Server_MessageHeader_CN, LineMapEffect.MapEffect8_v72,
             Server_MessageHeader_KR, LineMapEffect.MapEffect8_v72>.CreateFromOpcodeConfig(opcodeConfig, $"{MachinaPacketName}8");
 
-            packetHelper_16 = RegionalizedPacketHelper<
-            Server_MessageHeader_Global, LineMapEffect.MapEffect16_v72,
-            Server_MessageHeader_CN, LineMapEffect.MapEffect16_v72,
-            Server_MessageHeader_KR, LineMapEffect.MapEffect16_v72>.CreateFromOpcodeConfig(opcodeConfig, $"{MachinaPacketName}16");
+            packetHelper_12 = RegionalizedPacketHelper<
+            Server_MessageHeader_Global, LineMapEffect.MapEffect12_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect12_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect12_v72>.CreateFromOpcodeConfig(opcodeConfig, $"{MachinaPacketName}12");
         }
 
         protected override void MessageReceived(string id, long epoch, byte[] message)
@@ -375,7 +375,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 return;
             if (MessageReceivedSubHandler(packetHelper_8, epoch, message))
                 return;
-            if (MessageReceivedSubHandler(packetHelper_16, epoch, message))
+            if (MessageReceivedSubHandler(packetHelper_12, epoch, message))
                 return;
         }
 

--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -79,7 +79,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
             uint IMapEffectPacket.instanceContentID => 0;
 
-            ushort IMapEffectPacket.count => 1;
+            ushort IMapEffectPacket.count => count;
 
             List<ushort> IMapEffectPacket.flags1
             {
@@ -162,7 +162,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
             uint IMapEffectPacket.instanceContentID => 0;
 
-            ushort IMapEffectPacket.count => 1;
+            ushort IMapEffectPacket.count => count;
 
             List<ushort> IMapEffectPacket.flags1
             {
@@ -245,7 +245,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
 
             uint IMapEffectPacket.instanceContentID => 0;
 
-            ushort IMapEffectPacket.count => 1;
+            ushort IMapEffectPacket.count => count;
 
             List<ushort> IMapEffectPacket.flags1
             {
@@ -348,6 +348,23 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             : base(container, LogFileLineID, logLineName, MachinaPacketName)
         {
             logger = container.Resolve<ILogger>();
+
+            var opcodeConfig = container.Resolve<OverlayPluginLogLineConfig>();
+
+            packetHelper_4 = RegionalizedPacketHelper<
+            Server_MessageHeader_Global, LineMapEffect.MapEffect4_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect4_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect4_v72>.CreateFromOpcodeConfig(opcodeConfig, $"{MachinaPacketName}4");
+
+            packetHelper_8 = RegionalizedPacketHelper<
+            Server_MessageHeader_Global, LineMapEffect.MapEffect8_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect8_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect8_v72>.CreateFromOpcodeConfig(opcodeConfig, $"{MachinaPacketName}8");
+
+            packetHelper_16 = RegionalizedPacketHelper<
+            Server_MessageHeader_Global, LineMapEffect.MapEffect16_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect16_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect16_v72>.CreateFromOpcodeConfig(opcodeConfig, $"{MachinaPacketName}16");
         }
 
         protected override void MessageReceived(string id, long epoch, byte[] message)
@@ -403,16 +420,6 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
                 default:
                     return false;
             }
-
-            var line = packetHelper[currentRegion.Value].ToString(epoch, message);
-
-            if (line != null)
-            {
-                DateTime serverTime = ffxiv.EpochToDateTime(epoch);
-                logWriter(line, serverTime);
-                return true;
-            }
-            return false;
         }
 
         private void WriteLinesFor(long epoch, uint instanceContentID, ushort count, List<ushort> flags1, List<ushort> flags2, List<byte> indexes)

--- a/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/LineMapEffect.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper;
 
 namespace RainbowMage.OverlayPlugin.NetworkProcessors
@@ -9,26 +11,442 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors
             Server_MessageHeader_KR, LineMapEffect.MapEffect_v62>
     {
         [StructLayout(LayoutKind.Sequential, Pack = 1)]
-        internal struct MapEffect_v62 : IPacketStruct
+        internal struct MapEffect_v62 : IPacketStruct, IMapEffectPacket
         {
             public uint instanceContentID;
-            public uint flags;
+            public ushort flags1;
+            public ushort flags2;
             public byte index;
             public byte unknown1;
             public ushort unknown2;
             public uint padding;
 
+            uint IMapEffectPacket.instanceContentID => instanceContentID;
+
+            ushort IMapEffectPacket.count => 1;
+
+            List<ushort> IMapEffectPacket.flags1
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    flags.Add(flags1);
+
+                    return flags;
+                }
+            }
+
+            List<ushort> IMapEffectPacket.flags2
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    flags.Add(flags2);
+
+                    return flags;
+                }
+            }
+
+            List<byte> IMapEffectPacket.indexes
+            {
+                get
+                {
+                    List<byte> indexes = new List<byte>();
+
+                    indexes.Add(index);
+
+                    return indexes;
+                }
+            }
+
             public string ToString(long epoch, uint ActorID)
             {
-                return $"{instanceContentID:X8}|{flags:X8}|{index:X2}|{unknown1:X2}|{unknown2:X4}";
+                return $"";
             }
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        internal unsafe struct MapEffect4_v72 : IPacketStruct, IMapEffectPacket
+        {
+            private const int MaxCount = 4;
+            public ushort count;
+            public fixed ushort flags1[MaxCount];
+            public fixed ushort flags2[MaxCount];
+            public fixed byte indexes[MaxCount];
+            public ushort padding;
+
+            uint IMapEffectPacket.instanceContentID => 0;
+
+            ushort IMapEffectPacket.count => 1;
+
+            List<ushort> IMapEffectPacket.flags1
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    unsafe
+                    {
+                        fixed (ushort* ptr = flags1)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                flags.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return flags;
+                }
+            }
+
+            List<ushort> IMapEffectPacket.flags2
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    unsafe
+                    {
+                        fixed (ushort* ptr = flags2)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                flags.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return flags;
+                }
+            }
+
+            List<byte> IMapEffectPacket.indexes
+            {
+                get
+                {
+                    List<byte> indexes = new List<byte>();
+
+                    unsafe
+                    {
+                        fixed (byte* ptr = this.indexes)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                indexes.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return indexes;
+                }
+            }
+
+            public string ToString(long epoch, uint ActorID)
+            {
+                return $"";
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        internal unsafe struct MapEffect8_v72 : IPacketStruct, IMapEffectPacket
+        {
+            private const int MaxCount = 8;
+            public ushort count;
+            public fixed ushort flags1[MaxCount];
+            public fixed ushort flags2[MaxCount];
+            public fixed byte indexes[MaxCount];
+            public ushort padding;
+
+            uint IMapEffectPacket.instanceContentID => 0;
+
+            ushort IMapEffectPacket.count => 1;
+
+            List<ushort> IMapEffectPacket.flags1
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    unsafe
+                    {
+                        fixed (ushort* ptr = flags1)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                flags.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return flags;
+                }
+            }
+
+            List<ushort> IMapEffectPacket.flags2
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    unsafe
+                    {
+                        fixed (ushort* ptr = flags2)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                flags.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return flags;
+                }
+            }
+
+            List<byte> IMapEffectPacket.indexes
+            {
+                get
+                {
+                    List<byte> indexes = new List<byte>();
+
+                    unsafe
+                    {
+                        fixed (byte* ptr = this.indexes)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                indexes.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return indexes;
+                }
+            }
+
+            public string ToString(long epoch, uint ActorID)
+            {
+                return $"";
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        internal unsafe struct MapEffect16_v72 : IPacketStruct, IMapEffectPacket
+        {
+            private const int MaxCount = 16;
+            public ushort count;
+            public fixed ushort flags1[MaxCount];
+            public fixed ushort flags2[MaxCount];
+            public fixed byte indexes[MaxCount];
+            public ushort padding;
+
+            uint IMapEffectPacket.instanceContentID => 0;
+
+            ushort IMapEffectPacket.count => 1;
+
+            List<ushort> IMapEffectPacket.flags1
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    unsafe
+                    {
+                        fixed (ushort* ptr = flags1)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                flags.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return flags;
+                }
+            }
+
+            List<ushort> IMapEffectPacket.flags2
+            {
+                get
+                {
+                    List<ushort> flags = new List<ushort>();
+
+                    unsafe
+                    {
+                        fixed (ushort* ptr = flags2)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                flags.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return flags;
+                }
+            }
+
+            List<byte> IMapEffectPacket.indexes
+            {
+                get
+                {
+                    List<byte> indexes = new List<byte>();
+
+                    unsafe
+                    {
+                        fixed (byte* ptr = this.indexes)
+                        {
+                            for (var i = 0; i < count && i < MaxCount; ++i)
+                            {
+                                indexes.Add(ptr[i]);
+                            }
+                        }
+                    }
+
+                    return indexes;
+                }
+            }
+
+            public string ToString(long epoch, uint ActorID)
+            {
+                return $"";
+            }
+        }
+
+        internal interface IMapEffectPacket
+        {
+            uint instanceContentID { get; }
+            ushort count { get; }
+            List<ushort> flags1 { get; }
+            List<ushort> flags2 { get; }
+            List<byte> indexes { get; }
         }
 
         public const uint LogFileLineID = 257;
         public const string logLineName = "MapEffect";
         public const string MachinaPacketName = "MapEffect";
+        private readonly ILogger logger;
+        private RegionalizedPacketHelper<
+            Server_MessageHeader_Global, LineMapEffect.MapEffect4_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect4_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect4_v72> packetHelper_4;
+
+        private RegionalizedPacketHelper<
+            Server_MessageHeader_Global, LineMapEffect.MapEffect8_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect8_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect8_v72> packetHelper_8;
+
+        private  RegionalizedPacketHelper<
+            Server_MessageHeader_Global, LineMapEffect.MapEffect16_v72,
+            Server_MessageHeader_CN, LineMapEffect.MapEffect16_v72,
+            Server_MessageHeader_KR, LineMapEffect.MapEffect16_v72> packetHelper_16;
 
         public LineMapEffect(TinyIoCContainer container)
-            : base(container, LogFileLineID, logLineName, MachinaPacketName) { }
+            : base(container, LogFileLineID, logLineName, MachinaPacketName)
+        {
+            logger = container.Resolve<ILogger>();
+        }
+
+        protected override void MessageReceived(string id, long epoch, byte[] message)
+        {
+            if (MessageReceivedSubHandler(packetHelper, epoch, message))
+                return;
+        }
+
+        protected bool MessageReceivedSubHandler<T>(RegionalizedPacketHelper<
+            Server_MessageHeader_Global, T,
+            Server_MessageHeader_CN, T,
+            Server_MessageHeader_KR, T> helper, long epoch, byte[] message) where T : unmanaged, IMapEffectPacket, IPacketStruct
+        {
+            if (packetHelper == null)
+                return true;
+
+            if (currentRegion == null)
+                currentRegion = ffxiv.GetMachinaRegion();
+
+            if (currentRegion == null)
+                return true;
+
+            switch (currentRegion)
+            {
+                case GameRegion.Global:
+                    {
+                        if (!helper.global.ToStructs(message, out var header, out var packet))
+                            return false;
+                        WriteLinesFor(epoch, packet.instanceContentID, packet.count, packet.flags1, packet.flags2, packet.indexes);
+                        return true;
+                    }
+                case GameRegion.Chinese:
+                    {
+                        if (!helper.cn.ToStructs(message, out var header, out var packet))
+                            return false;
+                        WriteLinesFor(epoch, packet.instanceContentID, packet.count, packet.flags1, packet.flags2, packet.indexes);
+                        return true;
+                    }
+                case GameRegion.Korean:
+                    {
+                        if (!helper.kr.ToStructs(message, out var header, out var packet))
+                            return false;
+                        WriteLinesFor(epoch, packet.instanceContentID, packet.count, packet.flags1, packet.flags2, packet.indexes);
+                        return true;
+                    }
+
+                default:
+                    return false;
+            }
+
+            var line = packetHelper[currentRegion.Value].ToString(epoch, message);
+
+            if (line != null)
+            {
+                DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+                logWriter(line, serverTime);
+                return true;
+            }
+            return false;
+        }
+
+        private void WriteLinesFor(long epoch, uint instanceContentID, ushort count, List<ushort> flags1, List<ushort> flags2, List<byte> indexes)
+        {
+            if (count == 0)
+            {
+                logger.Log(LogLevel.Error, $"Got MapEffect packet with 0 entries");
+                return;
+            }
+
+            if (flags1.Count != count)
+            {
+                logger.Log(LogLevel.Error, $"Mismatch in flags1 count for MapEffect packet, expected {count}, got {flags1.Count}");
+                return;
+            }
+            if (flags2.Count != count)
+            {
+                logger.Log(LogLevel.Error, $"Mismatch in flags2 count for MapEffect packet, expected {count}, got {flags2.Count}");
+                return;
+            }
+            if (indexes.Count != count)
+            {
+                logger.Log(LogLevel.Error, $"Mismatch in indexes count for MapEffect packet, expected {count}, got {indexes.Count}");
+                return;
+            }
+
+            DateTime serverTime = ffxiv.EpochToDateTime(epoch);
+
+            var strInstanceContentID = instanceContentID == 0 ? "" : $"{instanceContentID:X8}";
+
+            for (var i = 0; i < count; ++i)
+            {
+                var flag1 = flags1[i];
+                var flag2 = flags2[i];
+                var index = indexes[i];
+
+                // Two blank fields at the end used to be $"{unknown1:X2}|{unknown2:X4}", turned out to be padding
+                // @TODO: Remove these fields at some point, this is a breaking change.
+                logWriter($"{strInstanceContentID}|{flag1:X4}|{flag2:X4}|{index:X2}||", serverTime);
+            }
+        }
     }
 }

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -58,7 +58,7 @@
                 "opcode": 605,
                 "size": 0
             },
-            "MapEffect16": {
+            "MapEffect12": {
                 "opcode": 247,
                 "size": 0
             },

--- a/OverlayPlugin.Core/resources/opcodes.jsonc
+++ b/OverlayPlugin.Core/resources/opcodes.jsonc
@@ -50,6 +50,18 @@
                 "opcode": 242,
                 "size": 11
             },
+            "MapEffect4": {
+                "opcode": 790,
+                "size": 0
+            },
+            "MapEffect8": {
+                "opcode": 605,
+                "size": 0
+            },
+            "MapEffect16": {
+                "opcode": 247,
+                "size": 0
+            },
             "CEDirector": {
                 "opcode": 182,
                 "size": 16

--- a/OverlayPlugin.Core/resources/reserved_log_lines.json
+++ b/OverlayPlugin.Core/resources/reserved_log_lines.json
@@ -17,7 +17,7 @@
         "ID": 257,
         "Name":  "MapEffect",
         "Source": "OverlayPlugin",
-        "Version": 1,
+        "Version": 2,
         "Comment": "MapEffect data"
     },
     {


### PR DESCRIPTION
Completely untested support for the new bundled MapEffect packets in use in 7.2.

TODO:

- [x] Bump version number of line
- [x] Make sure old MapEffect packets still work
- [x] Test new packets (seen in new Extreme)