### PR TITLE
Fix EffectMemory size

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
@@ -199,7 +199,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         [StructLayout(LayoutKind.Explicit, Size = Size)]
         public struct EffectMemory
         {
-            public const int Size = 12;
+            public const int Size = 16;
 
             [FieldOffset(0)]
             public ushort BuffID;

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory.cs
@@ -150,11 +150,11 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
         // This function always returns a combatant object, even if empty.
         protected abstract unsafe Combatant GetCombatantFromByteArray(byte[] source, uint mycharID, bool isPlayer, bool exceptEffects = false);
 
-        protected unsafe List<EffectEntry> GetEffectEntries(byte* source, ObjectType type, uint mycharID)
+        protected unsafe List<EffectEntry> GetEffectEntries(Version version, byte* source, ObjectType type, uint mycharID)
         {
             var result = new List<EffectEntry>();
             int maxEffects = (type == ObjectType.PC) ? 30 : 60;
-            var size = EffectMemory.Size * maxEffects;
+            var size = (version.Minor == 2 ? EffectMemory.Size : 12) * maxEffects;
 
             var bytes = new byte[size];
             Marshal.Copy((IntPtr)source, bytes, 0, size);

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory70.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory70.cs
@@ -71,7 +71,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
-                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(GetVersion(), mem.Effects, (ObjectType)mem.Type, mycharID),
 
                     BNpcID = mem.BNpcID,
                     CurrentMP = mem.CurrentMP,

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory71.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory71.cs
@@ -71,7 +71,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
-                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(GetVersion(), mem.Effects, (ObjectType)mem.Type, mycharID),
 
                     BNpcID = mem.BNpcID,
                     CurrentMP = mem.CurrentMP,

--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory72.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/CombatantMemory72.cs
@@ -71,7 +71,7 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                     TargetID = (ObjectType)mem.Type == ObjectType.PC ? mem.PCTargetID : mem.NPCTargetID,
                     CurrentHP = mem.CurrentHP,
                     MaxHP = mem.MaxHP,
-                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(mem.Effects, (ObjectType)mem.Type, mycharID),
+                    Effects = exceptEffects ? new List<EffectEntry>() : GetEffectEntries(GetVersion(), mem.Effects, (ObjectType)mem.Type, mycharID),
 
                     BNpcID = mem.BNpcID,
                     CurrentMP = mem.CurrentMP,


### PR DESCRIPTION
Fixed wrong `Effects` data in `CombatantMemory`.
Add a `version` param to indicate game version for compatibility use.