### PR TITLE
fix: Duplicated add combatant lines from concurrent state checks

### DIFF
--- a/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
+++ b/OverlayPlugin.Core/MemoryProcessors/Combatant/LineCombatant.cs
@@ -261,22 +261,27 @@ namespace RainbowMage.OverlayPlugin.MemoryProcessors.Combatant
                 }
 
                 // If this is a new combatant, always write a line for it
-                if (!combatantStateMap.ContainsKey(combatant.ID))
+                if (!combatantStateMap.TryGetValue(combatant.ID, out var oldState))
                 {
-                    combatantStateMap[combatant.ID] = new CombatantStateInfo()
+                    var state = new CombatantStateInfo()
                     {
                         lastUpdated = now,
                         combatant = combatant,
                     };
-                    WriteLine(
-                        CombatantMemoryChangeType.Add,
-                        combatant.ID,
-                        string.Join("", CombatantChangeCriteria.AllFields.Select((fi) => FormatFieldChange(fi, combatant, true))));
+
+                    // It's possible that another thread has already added this combatant since we checked
+                    if (combatantStateMap.TryAdd(combatant.ID, state))
+                    {
+                        WriteLine(
+                            CombatantMemoryChangeType.Add,
+                            combatant.ID,
+                            string.Join("", CombatantChangeCriteria.AllFields.Select((fi) => FormatFieldChange(fi, combatant, true))));
+                    }
                     continue;
                 }
 
-                var oldCombatant = combatantStateMap[combatant.ID].combatant;
-                var lastUpdatedDiff = (now - combatantStateMap[combatant.ID].lastUpdated).TotalMilliseconds;
+                var oldCombatant = oldState.combatant;
+                var lastUpdatedDiff = (now - oldState.lastUpdated).TotalMilliseconds;
                 var changed = new HashSet<FieldInfo>();
 
                 // Check position/heading first since it has a custom delay timing with threshold


### PR DESCRIPTION
In extremely rare cases, `LineCombatant` can emit duplicate `Add` lines for the same combatant within a short time window. In my logs, this occurred in less than 0.1% of single-mechanic captures (e.g. the Loop towers in TOP P1), but it can still break triggers that wait for data from the first _n_ `EventObject` entries before continuing.

Example log:

```log
[00:34:50.229] 261 105:Add:4000A2AE:BNpcID:1EB83D:...:PosX:112.0000:PosY:97.0000:...
[00:34:50.229] 261 105:Add:4000A2B0:BNpcID:1EB83D:...:PosX:88.0000:PosY:103.0000:...
[00:34:50.332] 261 105:Add:4000A2AE:BNpcID:1EB83D:...:PosX:112.0000:PosY:97.0000:...
[00:34:50.332] 261 105:Add:4000A2B0:BNpcID:1EB83D:...:PosX:88.0000:PosY:103.0000:...
```

This appears to be caused by a race condition where multiple checks can observe the same combatant as missing before one of them adds it to the state map. This change makes the add path use `TryAdd`. 

Since the issue is extremely rare, I cannot confirm that it is actually fixed, but it addresses the race condition I was able to identify.