### PR TITLE
Use Global structs for TC packets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,8 +5,8 @@
         <Copyright>Copyright © RainbowMage 2015, Kuriyama hibiya 2016, ngld 2019, OverlayPlugin Team 2022</Copyright>
         <RunCodeAnalysis>false</RunCodeAnalysis>
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <AssemblyVersion>0.19.94</AssemblyVersion>
-        <FileVersion>0.19.94</FileVersion>
+        <AssemblyVersion>0.19.94.1</AssemblyVersion>
+        <FileVersion>0.19.94.1</FileVersion>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/OverlayPlugin.Core/NetworkProcessors/PacketHelper/MachinaPacketHelper.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/PacketHelper/MachinaPacketHelper.cs
@@ -154,12 +154,10 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
             {
                 return false;
             }
-            if (!MachinaMap.GetPacketType(GameRegion.TraditionalChinese, packetTypeName, out var tcPacketType))
-            {
-                // @TODO: Once FFXIV_ACT_Plugin has TC opcodes for global release, remove this default
-                tcPacketType = globalPacketType;
-                // return false;
-            }
+
+            // TC packet structs are identical to Global (same fields, different opcodes only),
+            // so always use the Global struct to avoid type mismatches in TC-specific definitions.
+            var tcPacketType = globalPacketType;
 
             if (!globalOpcodes.TryGetValue(packetOpcodeName, out var globalOpcode))
             {

--- a/OverlayPlugin.Core/NetworkProcessors/PacketHelper/MachinaPacketHelper.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/PacketHelper/MachinaPacketHelper.cs
@@ -154,9 +154,11 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
             {
                 return false;
             }
-
-            // TC packet structs are identical to Global (same fields, different opcodes only),
-            // so always use the Global struct to avoid type mismatches in TC-specific definitions.
+            // FFXIV_ACT_Plugin currently defines dedicated TraditionalChinese packet handlers and structures,
+            // but does not use them at runtime. It handles TC packets through Global packet handlers instead.
+            // Use Global packet structures with TC opcodes to match runtime behavior.
+            // @TODO: If FFXIV_ACT_Plugin switches runtime TC handling to its dedicated TC packet handlers
+            // and packet structures, restore the TC packet type lookup via MachinaMap.GetPacketType(...).
             var tcPacketType = globalPacketType;
 
             if (!globalOpcodes.TryGetValue(packetOpcodeName, out var globalOpcode))

--- a/OverlayPlugin.Core/NetworkProcessors/PacketHelper/MachinaPacketHelper.cs
+++ b/OverlayPlugin.Core/NetworkProcessors/PacketHelper/MachinaPacketHelper.cs
@@ -159,6 +159,7 @@ namespace RainbowMage.OverlayPlugin.NetworkProcessors.PacketHelper
             // Use Global packet structures with TC opcodes to match runtime behavior.
             // @TODO: If FFXIV_ACT_Plugin switches runtime TC handling to its dedicated TC packet handlers
             // and packet structures, restore the TC packet type lookup via MachinaMap.GetPacketType(...).
+            // ref git commit 252cc49b3ad6767dbc6a33e1682a411ed0abb52e
             var tcPacketType = globalPacketType;
 
             if (!globalOpcodes.TryGetValue(packetOpcodeName, out var globalOpcode))


### PR DESCRIPTION
## Summary

Fix Traditional Chinese packet parsing by using Global packet structures with TC opcodes.

`FFXIV_ACT_Plugin` currently handles Traditional Chinese packets through Global packet handlers at runtime. As a result, the effective runtime model is:

- Global packet handlers
- Global packet structures
- TraditionalChinese opcodes

Previously, `MachinaPacketHelper.cs` attempted to resolve a dedicated TC packet type first:

```csharp
MachinaMap.GetPacketType(GameRegion.TraditionalChinese, packetTypeName, out var tcPacketType)
```

When a TC-specific Machina structure exists, this can cause the helper to use the TC structure instead of the Global one. Since this does not match the packet structures used by `FFXIV_ACT_Plugin` at runtime, it can lead to parsing mismatches.

## Change

Use the Global packet type for TC packet structure resolution:

```csharp
var tcPacketType = globalPacketType;
```

The TC opcode values are still used as before.

## Testing

Tested this change on the Traditional Chinese client. Several logs that previously failed to display now work correctly.

For example,`107` logs are displayed correctly after this change.

## Notes

This change is intended to match the current runtime behavior of `FFXIV_ACT_Plugin`.

If `FFXIV_ACT_Plugin` later switches TC runtime handling to dedicated TC packet handlers and packet structures, this logic can be restored to use:

```csharp
MachinaMap.GetPacketType(GameRegion.TraditionalChinese, ...)
```
