### PR TITLE
fix: Guard invalid CefSharp frames in load callbacks

### DIFF
--- a/HtmlRenderer/Renderer.cs
+++ b/HtmlRenderer/Renderer.cs
@@ -98,7 +98,7 @@ namespace RainbowMage.HtmlRenderer
 
         private void Browser_FrameLoadStart(object sender, FrameLoadStartEventArgs e)
         {
-            if (!e.Frame.IsMain)
+            if (e.Frame?.IsValid != true || !e.Frame.IsMain)
                 return;
 
             lastUrl = e.Url;
@@ -152,7 +152,7 @@ namespace RainbowMage.HtmlRenderer
 
         private void Browser_FrameLoadEnd(object sender, FrameLoadEndEventArgs e)
         {
-            if (!e.Frame.IsMain)
+            if (e.Frame?.IsValid != true || !e.Frame.IsMain)
                 return;
 
             if (urlToLoad != null)


### PR DESCRIPTION
A user reported an exception from `HtmlRenderer`:

<img width="505" height="204" alt="image" src="https://github.com/user-attachments/assets/24661c96-e800-434d-8f99-a1a95bf6a5f1" />

On that user's PC, the error appears to occur after the ACT main form has loaded, and only when the game is running.

This PR guards `FrameLoadStart` and `FrameLoadEnd` against invalid frames, but the exact reason that causes the invalid frame is still unclear.